### PR TITLE
feat: select keyboard navigation (#583)

### DIFF
--- a/src/components/vuestic-components/va-checkbox/KeyboardOnlyFocusMixin.js
+++ b/src/components/vuestic-components/va-checkbox/KeyboardOnlyFocusMixin.js
@@ -7,8 +7,9 @@ export const KeyboardOnlyFocusMixin = {
   },
   methods: {
     onFocus (e, index) {
-      if (this.hasMouseDown) return
-      this.isKeyboardFocused = index || true
+      if (!this.hasMouseDown) {
+        this.isKeyboardFocused = index || true
+      }
     },
   },
 }

--- a/src/components/vuestic-components/va-dropdown/VaDropdown.vue
+++ b/src/components/vuestic-components/va-dropdown/VaDropdown.vue
@@ -227,7 +227,7 @@ export default {
       }
 
       if (this.boundaryBody) {
-        options.modifiers.preventOverflow.boundariesElement = document.body
+        options.modifiers.preventOverflow.boundariesElement = window
       }
 
       if (this.offset) {
@@ -282,6 +282,7 @@ export default {
       if (this.trigger === 'none') {
         return this.value
       }
+      throw new Error('Never')
     },
     scrollWidth () {
       const div = document.createElement('div')

--- a/src/components/vuestic-components/va-select/VaSelect.demo.vue
+++ b/src/components/vuestic-components/va-select/VaSelect.demo.vue
@@ -166,7 +166,7 @@
         max-height="320px"
       />
     </VbCard>
-    <VbCard title="custom width (30%)" :style="{'width': '100%'}" style="width: 400px;">
+    <VbCard title="custom width (30%)" style="width: 400px;">
       <va-select
         v-model="defaultSelect.value"
         :options="CountriesList"

--- a/src/components/vuestic-components/va-select/VaSelect.vue
+++ b/src/components/vuestic-components/va-select/VaSelect.vue
@@ -517,10 +517,6 @@ export default {
     bottom: 0;
     right: 2rem;
     margin: auto;
-
-    &--keyboard-focused {
-      background-color: #eee;
-    }
   }
 
   &__open-icon {

--- a/src/components/vuestic-components/va-select/VaSelect.vue
+++ b/src/components/vuestic-components/va-select/VaSelect.vue
@@ -115,7 +115,7 @@
       />
       <va-icon
         class="va-select__open-icon"
-        :class="{'va-select__open-icon--keyboard-focused': isKeyboardFocused}"
+        :class="{'va-select__open-icon--keyboard-focused': !disabled && isKeyboardFocused}"
         :name="visible ? 'fa fa-angle-up' : 'fa fa-angle-down'"
       />
     </div>
@@ -381,7 +381,9 @@ export default {
       this.search = ''
     },
     updateHoverState (hoverState) {
-      this.hoverState = hoverState
+      if (!this.disabled) {
+        this.hoverState = hoverState
+      }
     },
     updateHoveredOption (option) {
       if (option) {
@@ -391,7 +393,9 @@ export default {
       }
     },
     openDropdown (e) {
-      this.$refs.dropdown.isClicked = true
+      if (!this.disabled) {
+        this.$refs.dropdown.isClicked = true
+      }
     },
     closeDropdown (e) {
       this.$refs.dropdown.hide()
@@ -501,6 +505,7 @@ export default {
     text-overflow: ellipsis;
     overflow: hidden;
     margin: 0 .5rem;
+
     &:focus {
       outline: none;
     }
@@ -540,7 +545,7 @@ export default {
     right: .5rem;
 
     &--keyboard-focused {
-      background-color: rgba(0, 0, 0, 0.065);
+      background-color: rgba(100, 100, 100, 0.1);
     }
   }
 


### PR DESCRIPTION
Implement support for VaSelect keyboard navigation.

Use arrow keys to switch between options, tab/shift+tab to switch between different selects and/or search-field/options, backspace to clear selection.