### PR TITLE
fix: sidebar mobile height

### DIFF
--- a/src/components/vuestic-components/va-sidebar/VaSidebar.vue
+++ b/src/components/vuestic-components/va-sidebar/VaSidebar.vue
@@ -60,6 +60,8 @@ export default {
 
   @include media-breakpoint-down(sm) {
     top: $sidebar-mobile-top;
+    min-height: $sidebar-mobile-min-height;
+    height: $sidebar-mobile-height;
   }
 
   @include media-breakpoint-down(xs) {

--- a/src/components/vuestic-sass/resources/_variables.scss
+++ b/src/components/vuestic-sass/resources/_variables.scss
@@ -80,6 +80,8 @@ $sidebar-viewport-height: calc(100% - #{$top-nav-height});
 $sidebar-box-shadow: 0 2px 3px 0 rgba(52, 56, 85, 0.25);
 $sidebar-minimized-width: 3.5rem;
 $sidebar-mobile-top: $top-mobile-nav-height;
+$sidebar-mobile-min-height: calc(100vh - #{$top-mobile-nav-height});
+$sidebar-mobile-height: calc(100% - #{$top-mobile-nav-height});
 
 
 //Mobile Layout


### PR DESCRIPTION
forgot to override sidebar height when the media query changed navbar to top: $sidebar-mobile-top