### PR TITLE
fix: remove unnecessary z-index from va-card

### DIFF
--- a/src/components/vuestic-components/va-card/VaCard.vue
+++ b/src/components/vuestic-components/va-card/VaCard.vue
@@ -116,6 +116,7 @@ export default {
           background: getGradientBackground(this.$themes[this.color]),
         }
       }
+      return ''
     },
   },
 }
@@ -231,7 +232,6 @@ export default {
     left: 0;
     width: 100%;
     height: 0.5rem;
-    z-index: 1;
   }
 }
 </style>


### PR DESCRIPTION
Fix for the issue (#656)[https://github.com/epicmaxco/vuestic-admin/issues/656].

Removed z-index property for the card stripe.