### PR TITLE
fix: restore mechanism for themes

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "vue-chartjs": "^3.4.0",
     "vue-clipboard2": "^0.3.0",
     "vue-color": "^2.7.0",
-    "vue-epic-bus": "^0.1.2",
+    "vue-epic-bus": "^0.1.3",
     "vue-flatpickr-component": "^8.0.0",
     "vue-router": "^3.0.3",
     "vue-toasted": "^1.1.25",


### PR DESCRIPTION
Added theme restore mechanism for ColorThemePlugin.
Updated vue-epic-bus version to prevent issues with transpileDependencies. 

Connected with this [PR](https://github.com/epicmaxco/vuestic-admin/pull/665)