### PR TITLE
fix: cap ProgressCircle thickness between 0 and 50

### DIFF
--- a/docs/components/VaProgressBar.md
+++ b/docs/components/VaProgressBar.md
@@ -35,6 +35,6 @@
 * `indeterminate` - Boolean.
 * `color` - String  (default: `success`).
 * `size` - String|Number (default: 40) - bar size (diameter) in pixels or size in css units (rem|em|ex|pt|pc|mm|cm|px)
-* `thickness` - Number (default: 0.06) - circle border size between 0 and 1 (value translated to percentage, divided in half, since final maximum value should be 50%)
+* `thickness` - Number (default: 0.06) - circle border size between 0 and 1
 
 [Find DEMOs here!](http://vuestic.epicmax.co/#/admin/statistics/progress-bars)

--- a/docs/components/VaProgressBar.md
+++ b/docs/components/VaProgressBar.md
@@ -35,6 +35,6 @@
 * `indeterminate` - Boolean.
 * `color` - String  (default: `success`).
 * `size` - String|Number (default: 40) - bar size (diameter) in pixels or size in css units (rem|em|ex|pt|pc|mm|cm|px)
-* `thickness` - Number - circle border size in percent of component size
+* `thickness` - Number (default: 0.06) - circle border size between 0 and 1 (value translated to percentage, divided in half, since final maximum value should be 50%)
 
 [Find DEMOs here!](http://vuestic.epicmax.co/#/admin/statistics/progress-bars)

--- a/src/components/vuestic-components/va-progress-bar/progress-types/VaProgressCircle.demo.vue
+++ b/src/components/vuestic-components/va-progress-bar/progress-types/VaProgressCircle.demo.vue
@@ -65,23 +65,23 @@
 
     <VbCard title="Thickness">
       <div>
-        Thickness 1:
+        Thickness 0.01:
         <VaProgressCircle
-          :thickness="1"
+          :thickness="0.01"
           :value="value"
         />
       </div>
       <div>
-        Thickness 30:
+        Thickness 0.6:
         <VaProgressCircle
-          :thickness="30"
+          :thickness="0.6"
           :value="value"
         />
       </div>
       <div>
-        Thickness 30 + intermediate
+        Thickness 0.6 + intermediate
         <VaProgressCircle
-          :thickness="30"
+          :thickness="0.6"
           indeterminate
         />
       </div>
@@ -108,7 +108,7 @@
       </div>
       <div>
         thickness:
-        <VaContext :config="{VaProgressCircle: {thickness: 10}}">
+        <VaContext :config="{VaProgressCircle: {thickness: 0.20}}">
           <VaProgressCircle :value="value" />
         </VaContext>
       </div>

--- a/src/components/vuestic-components/va-progress-bar/progress-types/VaProgressCircle.vue
+++ b/src/components/vuestic-components/va-progress-bar/progress-types/VaProgressCircle.vue
@@ -57,7 +57,7 @@ export default {
   ],
   computed: {
     radius () {
-      return 20 - (20 * this.c_thickness / 100)
+      return 20 - (20 * this.cappedThickness / 100)
     },
     dasharray () {
       return 2 * Math.PI * this.radius
@@ -66,7 +66,7 @@ export default {
       return this.dasharray * (1 - this.normalizedValue / 100)
     },
     computedThickness () {
-      return `${this.c_thickness}%`
+      return `${this.cappedThickness}%`
     },
     computedStyle () {
       return { width: this.sizeComputed, height: this.sizeComputed }
@@ -79,6 +79,15 @@ export default {
     computedStyles () {
       return {
         color: this.computeInvertedColor(this.c_color),
+      }
+    },
+    cappedThickness () {
+      if (this.c_thickness < 0) {
+        return 0
+      } else if (this.c_thickness > 30) {
+        return 30
+      } else {
+        return this.c_thickness
       }
     },
   },

--- a/src/components/vuestic-components/va-progress-bar/progress-types/VaProgressCircle.vue
+++ b/src/components/vuestic-components/va-progress-bar/progress-types/VaProgressCircle.vue
@@ -39,7 +39,7 @@ import { SizeMixin } from '../../../../mixins/SizeMixin'
 const ProgressCircleContextMixin = makeContextablePropsMixin({
   thickness: {
     type: Number,
-    default: 3,
+    default: 0.06,
   },
   color: {
     type: String,
@@ -82,12 +82,12 @@ export default {
       }
     },
     cappedThickness () {
-      if (this.c_thickness < 0) {
+      if (this.c_thickness <= 0) {
         return 0
-      } else if (this.c_thickness > 50) {
+      } else if (this.c_thickness >= 1) {
         return 50
       } else {
-        return this.c_thickness
+        return this.c_thickness / 2 * 100
       }
     },
   },

--- a/src/components/vuestic-components/va-progress-bar/progress-types/VaProgressCircle.vue
+++ b/src/components/vuestic-components/va-progress-bar/progress-types/VaProgressCircle.vue
@@ -84,8 +84,8 @@ export default {
     cappedThickness () {
       if (this.c_thickness < 0) {
         return 0
-      } else if (this.c_thickness > 30) {
-        return 30
+      } else if (this.c_thickness > 50) {
+        return 50
       } else {
         return this.c_thickness
       }

--- a/src/components/vuestic-components/va-progress-bar/progress-types/VaProgressCircle.vue
+++ b/src/components/vuestic-components/va-progress-bar/progress-types/VaProgressCircle.vue
@@ -82,6 +82,7 @@ export default {
       }
     },
     cappedThickness () {
+      // value translated to percentage, divided in half, since final maximum value should be 50%
       if (this.c_thickness <= 0) {
         return 0
       } else if (this.c_thickness >= 1) {


### PR DESCRIPTION
closes #144

## Description
Cap ProgressCircle `thickness` prop between 0 and 30 values.


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
