### PR TITLE
Add dynamic property for contextable mixin to get rid of typescript error

### DIFF
--- a/packages/ui/src/components/context-test/context-provide/ContextPlugin.ts
+++ b/packages/ui/src/components/context-test/context-provide/ContextPlugin.ts
@@ -1,9 +1,7 @@
-//  @ts-nocheck
-
 import flow from 'lodash/flow'
 import camelCase from 'lodash/camelCase'
 import upperFirst from 'lodash/upperFirst'
-import Vue from 'vue'
+import { Component, Mixins, Vue, Inject } from 'vue-property-decorator';
 import { hasOwnProperty } from '../../../services/utils'
 
 const pascalCase = flow(camelCase, upperFirst)
@@ -21,7 +19,7 @@ export const ContextProviderKey = 'va-context-provider'
  * Plugin provide global config to Vue component through prototype
  */
 export const ContextPlugin = {
-  install (Vue, options = {}) {
+  install (vue: Vue, options = {}) {
     Vue.prototype.$vaContextConfig = Vue.observable(options)
   },
 }
@@ -30,13 +28,9 @@ export const ContextPlugin = {
  * Mixin provide local configs to Vue component through injecting
  * All list of local configs contain in this._$configs
  */
-export const ContextPluginMixin = {
-  inject: {
-    _$configs: {
-      from: [ContextProviderKey],
-      default: () => [],
-    },
-  },
+@Component
+export class ContextPluginMixin extends Vue {
+  @Inject({ from: ContextProviderKey, default: () => []}) readonly _$configs!: string[]
 }
 
 /**
@@ -49,7 +43,7 @@ export const ContextPluginMixin = {
  *
  * @returns {any} config object if found undefined means not found.
  */
-function getLocalConfigWithComponentProp (configs, componentName, propName) {
+function getLocalConfigWithComponentProp (configs: any[], componentName: string, propName: any) {
   // Find prop value in config chain.
   return configs.reverse().find(config => {
     const componentConfig = config[componentName]
@@ -68,7 +62,16 @@ function getLocalConfigWithComponentProp (configs, componentName, propName) {
  * @returns {any} Returns property value.
  * @deprecated
  */
-export const getContextPropValue = (context, prop, defaultValue) => {
+export const getContextPropValue = (
+  context: {
+    [x: string]: any;
+    $options?: any;
+    _$configs?: any;
+    $vaContextConfig?: any;
+  },
+  prop: string,
+  defaultValue: () => any
+) => {
   // We have to pass context here as this method will be mainly used in prop default,
   // and methods are not accessible there.
 
@@ -99,7 +102,10 @@ export const getContextPropValue = (context, prop, defaultValue) => {
 }
 
 // Allows to completely overwrite global context config.
-export function overrideContextConfig (context, options) {
+export function overrideContextConfig (
+  context: { $vaContextConfig: object; },
+  options: { [x: string]: any; }
+) {
   for (const key in { ...options, ...context.$vaContextConfig }) {
     if (!(key in options)) {
       Vue.delete(context.$vaContextConfig, key)
@@ -116,7 +122,10 @@ export function overrideContextConfig (context, options) {
  * @param context - [object] this of the vue component.
  * @returns {any} Returns property value.
  */
-export function getOriginalPropValue (key, context) {
+export function getOriginalPropValue (
+  key: string,
+  context: { $options: { propsData: { [x: string]: any; }; }; }
+) {
   if (!(key in context.$options.propsData)) {
     return undefined
   }
@@ -125,15 +134,29 @@ export function getOriginalPropValue (key, context) {
 }
 
 // Just 2 levels deep merge. B has priority.
-export function mergeConfigs (configA, configB) {
+export function mergeConfigs (
+  configA: {
+    [x: string]: any;
+    A?: { A: string; };
+    AB?: { A: string; AB: string; };
+  },
+  configB: {
+    [x: string]: any;
+    AB?: { AB: string; B: string; };
+    B?: { B: string; };
+  }
+) {
   const result = {}
   // A or A + B
   for (const key in configA) {
+    // @ts-ignore
     result[key] = { ...configA[key], ...configB[key] }
   }
   // B
   for (const key in configB) {
+    // @ts-ignore
     if (!result[key]) {
+      // @ts-ignore
       result[key] = { ...configB[key] }
     }
   }
@@ -157,26 +180,33 @@ export function mergeConfigs (configA, configB) {
  * @param prefix - that prefix goes to contexted prop (that's intended for userland usage)
  * @returns object - vue mixin with props and computed
  */
-export const makeContextablePropsMixin = (componentProps, prefix = 'c_'): ComponentOptions => {
+export const makeContextablePropsMixin = (componentProps: any, prefix = 'c_') => {
   const computed = {}
 
   Object.entries(componentProps).forEach(([name, definition]) => {
+    // @ts-ignore
     computed[`${prefix}${name}`] = function () {
       // We want to fallback to context in 2 cases:
       // * prop value is undefined (allows user to dynamically enter/exit context).
       // * prop value is not defined
+      // @ts-ignore
       if (!(name in this.$options.propsData) || this.$options.propsData[name] === undefined) {
+        // @ts-ignore
         return getContextPropValue(this, name, definition.default)
       }
       // In other cases we return the prop itself.
+      // @ts-ignore
       return this[name]
     }
   })
 
-  return {
-    // We attach mixin here for convenience
-    mixins: [ContextPluginMixin],
+  @Component({
     props: componentProps,
     computed,
+  })
+  class ContextableMixin extends Mixins(ContextPluginMixin) {
+    [x: string]: any
   }
+
+  return ContextableMixin
 }

--- a/packages/ui/src/components/context-test/context-provide/ContextPlugin.ts
+++ b/packages/ui/src/components/context-test/context-provide/ContextPlugin.ts
@@ -63,8 +63,7 @@ function getLocalConfigWithComponentProp (configs: any[], componentName: string,
  * @deprecated
  */
 export const getContextPropValue = (
-  context: {
-    [x: string]: any;
+  context: Record<string, any> & {
     $options?: any;
     _$configs?: any;
     $vaContextConfig?: any;
@@ -124,7 +123,11 @@ export function overrideContextConfig (
  */
 export function getOriginalPropValue (
   key: string,
-  context: { $options: { propsData: { [x: string]: any; }; }; }
+  context: {
+    $options: {
+      propsData: Record<string, any>;
+    };
+  }
 ) {
   if (!(key in context.$options.propsData)) {
     return undefined
@@ -133,30 +136,21 @@ export function getOriginalPropValue (
   return context.$options.propsData[key]
 }
 
+export type ContextConfig = Record<string, Record<string, any>>
+
 // Just 2 levels deep merge. B has priority.
 export function mergeConfigs (
-  configA: {
-    [x: string]: any;
-    A?: { A: string; };
-    AB?: { A: string; AB: string; };
-  },
-  configB: {
-    [x: string]: any;
-    AB?: { AB: string; B: string; };
-    B?: { B: string; };
-  }
+  configA: ContextConfig,
+  configB: ContextConfig
 ) {
-  const result = {}
+  const result: Record<string, any> = {}
   // A or A + B
   for (const key in configA) {
-    // @ts-ignore
     result[key] = { ...configA[key], ...configB[key] }
   }
   // B
   for (const key in configB) {
-    // @ts-ignore
     if (!result[key]) {
-      // @ts-ignore
       result[key] = { ...configB[key] }
     }
   }

--- a/packages/ui/src/components/context-test/context-provide/ContextPlugin.ts
+++ b/packages/ui/src/components/context-test/context-provide/ContextPlugin.ts
@@ -1,8 +1,14 @@
 import flow from 'lodash/flow'
 import camelCase from 'lodash/camelCase'
 import upperFirst from 'lodash/upperFirst'
-import { Component, Mixins, Vue, Inject } from 'vue-property-decorator';
+import { Component, Mixins, Vue, Inject } from 'vue-property-decorator'
 import { hasOwnProperty } from '../../../services/utils'
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    $vaContextConfig?: ContextConfig;
+  }
+}
 
 const pascalCase = flow(camelCase, upperFirst)
 /**
@@ -30,7 +36,10 @@ export const ContextPlugin = {
  */
 @Component
 export class ContextPluginMixin extends Vue {
-  @Inject({ from: ContextProviderKey, default: () => []}) readonly _$configs!: ContextConfig[]
+  @Inject({
+    from: ContextProviderKey,
+    default: () => [],
+  }) readonly _$configs!: ContextConfig[]
 }
 
 /**
@@ -63,13 +72,9 @@ export const getLocalConfigWithComponentProp = (configs: any[], componentName: s
  * @deprecated
  */
 export const getContextPropValue = (
-  context: Record<string, any> & {
-    $options?: any;
-    _$configs?: any;
-    $vaContextConfig?: any;
-  },
+  context: Record<string, any> & ContextPluginMixin,
   prop: string,
-  defaultValue: () => any
+  defaultValue: () => any,
 ) => {
   // We have to pass context here as this method will be mainly used in prop default,
   // and methods are not accessible there.
@@ -103,7 +108,7 @@ export const getContextPropValue = (
 // Allows to completely overwrite global context config.
 export const overrideContextConfig = (
   context: { $vaContextConfig: object; },
-  options: { [x: string]: any; }
+  options: { [x: string]: any; },
 ) => {
   for (const key in { ...options, ...context.$vaContextConfig }) {
     if (!(key in options)) {
@@ -127,7 +132,7 @@ export function getOriginalPropValue (
     $options: {
       propsData: Record<string, any>;
     };
-  }
+  },
 ) {
   if (!(key in context.$options.propsData)) {
     return undefined
@@ -141,7 +146,7 @@ export type ContextConfig = Record<string, Record<string, any>>
 // Just 2 levels deep merge. B has priority.
 export const mergeConfigs = (
   configA: ContextConfig,
-  configB: ContextConfig
+  configB: ContextConfig,
 ) => {
   const result: Record<string, any> = {}
   // A or A + B

--- a/packages/ui/src/components/context-test/context-provide/ContextPlugin.ts
+++ b/packages/ui/src/components/context-test/context-provide/ContextPlugin.ts
@@ -19,7 +19,7 @@ export const ContextProviderKey = 'va-context-provider'
  * Plugin provide global config to Vue component through prototype
  */
 export const ContextPlugin = {
-  install (vue: Vue, options = {}) {
+  install (vue: Vue, options: ContextConfig = {}) {
     Vue.prototype.$vaContextConfig = Vue.observable(options)
   },
 }
@@ -30,7 +30,7 @@ export const ContextPlugin = {
  */
 @Component
 export class ContextPluginMixin extends Vue {
-  @Inject({ from: ContextProviderKey, default: () => []}) readonly _$configs!: string[]
+  @Inject({ from: ContextProviderKey, default: () => []}) readonly _$configs!: ContextConfig[]
 }
 
 /**
@@ -43,7 +43,7 @@ export class ContextPluginMixin extends Vue {
  *
  * @returns {any} config object if found undefined means not found.
  */
-function getLocalConfigWithComponentProp (configs: any[], componentName: string, propName: any) {
+export const getLocalConfigWithComponentProp = (configs: any[], componentName: string, propName: any) => {
   // Find prop value in config chain.
   return configs.reverse().find(config => {
     const componentConfig = config[componentName]
@@ -101,10 +101,10 @@ export const getContextPropValue = (
 }
 
 // Allows to completely overwrite global context config.
-export function overrideContextConfig (
+export const overrideContextConfig = (
   context: { $vaContextConfig: object; },
   options: { [x: string]: any; }
-) {
+) => {
   for (const key in { ...options, ...context.$vaContextConfig }) {
     if (!(key in options)) {
       Vue.delete(context.$vaContextConfig, key)
@@ -139,10 +139,10 @@ export function getOriginalPropValue (
 export type ContextConfig = Record<string, Record<string, any>>
 
 // Just 2 levels deep merge. B has priority.
-export function mergeConfigs (
+export const mergeConfigs = (
   configA: ContextConfig,
   configB: ContextConfig
-) {
+) => {
   const result: Record<string, any> = {}
   // A or A + B
   for (const key in configA) {


### PR DESCRIPTION
## Description
This should fix typescript errors with dynamic properties provided by ContextableMixin

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
