### PR TITLE
Half done experimentation with composition api

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.12.0",
     "@popperjs/core": "^2.1.1",
+    "@vue/composition-api": "^0.5.0",
     "approximate-number": "^2.0.0",
     "asva-executors": "^0.1.22",
     "chart.js": "^2.6.0",

--- a/src/components/vuestic-components/va-checkbox/VaCheckbox.demo.vue
+++ b/src/components/vuestic-components/va-checkbox/VaCheckbox.demo.vue
@@ -1,12 +1,23 @@
 <template>
   <VbDemo>
     <VbCard title="Default">
+      <va-checkbox
+        v-model="value"
+        label="Selected"
+      />
+    </VbCard>
+    <VbCard title="vue-book checkbox (conflict check)">
       <VbCheckbox
         v-model="value"
         label="Selected"
       />
+    </VbCard>
+    <VbCard
+      focus
+      title="vue-book checkbox (conflict check)"
+    >
       <va-checkbox
-        v-model="value"
+        stateful
         label="Selected"
       />
     </VbCard>

--- a/src/vue-book/book-main.js
+++ b/src/vue-book/book-main.js
@@ -11,12 +11,14 @@ import { registerVuesticObject } from '../components/resize-events'
 import { DropdownPopperPlugin } from '../components/vuestic-components/va-dropdown/dropdown-popover-subplugin'
 import { installPlatform } from '../components/vuestic-components/va-popup/install'
 import ColorHelpersPlugin from '../components/vuestic-utilities/color-helpers-plugin'
+import VueCompositionApi from '@vue/composition-api'
 
 // eslint-disable-next-line
 console.log(`Version: ${VERSION}, ${TIMESTAMP}, commit: ${COMMIT}`)
 
 installPlatform()
 
+Vue.use(VueCompositionApi)
 Vue.use(Router)
 Vue.use(VueBookComponents)
 if (!process.env.VUE_APP_DEMO_NO_THEME_PLUGIN) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1653,6 +1653,13 @@
     source-map "~0.6.1"
     vue-template-es2015-compiler "^1.9.0"
 
+"@vue/composition-api@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-0.5.0.tgz#2dbaa02a5d1f5d0d407d53d5529fe444aa8362f3"
+  integrity sha512-9QDFWq7q839G1CTTaxeruPOTrrVOPSaVipJ2TxxK9QAruePNTHOGbOOFRpc8WLl4YPsu1/c29yBhMVmrXz8BZw==
+  dependencies:
+    tslib "^1.9.3"
+
 "@vue/eslint-config-standard@^5.1.2":
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@vue/eslint-config-standard/-/eslint-config-standard-5.1.2.tgz#c5d55af894a3ae23b65b1af4a425777ac0170b42"


### PR DESCRIPTION
It seems right now is not the best timing to do a switch.

We can work with composition API in 2 ways:
* We can use it on components that do not use mixins, but that doesn't make too much sense as main value comes from feature reuse.
* We can use composition API on components that use mixins. But in that case - all components, that use said mixin, should be remade to use composition API as well, as `setup` triggers before everything else, so it won't see any classical mixins. That's a big change, and not something we want to commit before stable release at least.

So, current solution is to shape code similarly to what we'll have with composition API, i.e. use mixins for separate features.