### PR TITLE
(fix) language selector

### DIFF
--- a/packages/docs/components/header/components/LanguageDropdown.vue
+++ b/packages/docs/components/header/components/LanguageDropdown.vue
@@ -56,8 +56,8 @@ import VaButton from 'vuestic-ui/src/components/vuestic-components/va-button/VaB
 })
 export default class LanguageDropdown extends Vue {
   setLanguage (locale) {
-    localStorage.setItem('currentLanguage', locale)
-    this.$root.$i18n.setLocale(locale)
+    localStorage.setItem('currentLanguage', locale === 'gb' ? 'en' : locale)
+    this.$root.$i18n.setLocale(locale === 'gb' ? 'en' : locale)
   }
 
   get currentLanguage () {

--- a/packages/docs/components/header/components/LanguageDropdown.vue
+++ b/packages/docs/components/header/components/LanguageDropdown.vue
@@ -35,7 +35,7 @@ import VaButton from 'vuestic-ui/src/components/vuestic-components/va-button/VaB
       type: Array,
       default: () => [
         {
-          code: 'gb',
+          code: 'en',
           name: 'english',
         },
         {
@@ -56,16 +56,16 @@ import VaButton from 'vuestic-ui/src/components/vuestic-components/va-button/VaB
 })
 export default class LanguageDropdown extends Vue {
   setLanguage (locale) {
-    localStorage.setItem('currentLanguage', locale === 'gb' ? 'en' : locale)
-    this.$root.$i18n.setLocale(locale === 'gb' ? 'en' : locale)
+    localStorage.setItem('currentLanguage', locale)
+    this.$root.$i18n.setLocale(locale)
   }
 
   get currentLanguage () {
-    return this.$root.$i18n.locale === 'en' ? 'gb' : this.$root.$i18n.locale
+    return this.$root.$i18n.locale
   }
 
   flagIconClass (code) {
-    return `flag-icon-${code}`
+    return `flag-icon-${code === 'en' ? 'gb' : code}`
   }
 }
 </script>


### PR DESCRIPTION
closes #338

## Description
We passed 'gb' value instead of 'en' to the vue router and router didn't recognise this value in locales folder. Fix replaces 'gb' with 'en'


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
