### PR TITLE
fix #503 use default white text color for dark card title and content

### DIFF
--- a/packages/ui/src/components/vuestic-components/va-card/VaCard.vdemo.vue
+++ b/packages/ui/src/components/vuestic-components/va-card/VaCard.vdemo.vue
@@ -16,6 +16,17 @@
         <va-card-content>{{ lorem }}</va-card-content>
       </va-card>
     </VbCard>
+
+    <VbCard title="Dark (Colored)">
+      <va-card
+        style="width: 400px;"
+        dark
+      >
+        <va-card-title textColor="primary">Title</va-card-title>
+        <va-card-content textColor="info">{{ lorem }}</va-card-content>
+      </va-card>
+    </VbCard>
+
     <VbCard title="Square">
       <va-card
         style="width: 400px;"

--- a/packages/ui/src/components/vuestic-components/va-card/VaCard.vdemo.vue
+++ b/packages/ui/src/components/vuestic-components/va-card/VaCard.vdemo.vue
@@ -17,13 +17,24 @@
       </va-card>
     </VbCard>
 
-    <VbCard title="Dark (Colored)">
+    <VbCard title="Dark (Colored text)">
       <va-card
         style="width: 400px;"
         dark
       >
         <va-card-title textColor="primary">Title</va-card-title>
         <va-card-content textColor="info">{{ lorem }}</va-card-content>
+      </va-card>
+    </VbCard>
+
+    <VbCard title="Dark (Colored background)">
+      <va-card
+        style="width: 400px;"
+        color="secondary"
+        dark
+      >
+        <va-card-title>Title</va-card-title>
+        <va-card-content>{{ lorem }}</va-card-content>
       </va-card>
     </VbCard>
 

--- a/packages/ui/src/components/vuestic-components/va-card/VaCard.vue
+++ b/packages/ui/src/components/vuestic-components/va-card/VaCard.vue
@@ -66,7 +66,7 @@ export default class VaCard extends mixins(
   }
 
   get cardStyles () {
-    const color = this.dark ? this.computeColor(this.color) : this.theme.getColor(this.color, '#ffffff')
+    const color = this.dark ? this.computeColor(this.color || 'dark') : this.theme.getColor(this.color, '#ffffff')
 
     if (this.gradient && this.color) {
       return {

--- a/packages/ui/src/components/vuestic-components/va-card/VaCardContent.vue
+++ b/packages/ui/src/components/vuestic-components/va-card/VaCardContent.vue
@@ -27,7 +27,7 @@ export default class VaCardContent extends mixins(
 ) {
   get contentStyles () {
     return {
-      color: this.theme.getColor(this.textColor),
+      color: this.textColor ? this.theme.getColor(this.textColor): '',
     }
   }
 }

--- a/packages/ui/src/components/vuestic-components/va-card/VaCardTitle.vue
+++ b/packages/ui/src/components/vuestic-components/va-card/VaCardTitle.vue
@@ -27,7 +27,7 @@ export default class VaCardTitle extends mixins(
 ) {
   get titleStyles () {
     return {
-      color: this.theme.getColor(this.textColor),
+      color: this.textColor ? this.theme.getColor(this.textColor): '',
     }
   }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
closes #503

#### Before fix
![изображение](https://user-images.githubusercontent.com/23530004/107224026-9322e480-6a1f-11eb-9a05-459568b1e8a2.png)
![изображение](https://user-images.githubusercontent.com/23530004/107224056-9d44e300-6a1f-11eb-90cc-097589f5083f.png)
#### After fix
![изображение](https://user-images.githubusercontent.com/23530004/107224120-b2ba0d00-6a1f-11eb-8422-e3d70b869a4d.png)
Added one more demo "Dark (Colored)"
![изображение](https://user-images.githubusercontent.com/23530004/107224171-c1a0bf80-6a1f-11eb-9a63-3c204bed63e3.png)



## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
