### PR TITLE
fix #502 now the first tab does not become active by default

### DIFF
--- a/packages/ui/src/components/vuestic-components/va-tabs/VaTab/VaTab.vue
+++ b/packages/ui/src/components/vuestic-components/va-tabs/VaTab/VaTab.vue
@@ -122,7 +122,7 @@ export default class VaTab extends mixins(
     this.$emit('focus')
   }
 
-  mounted () {
+  beforeMount () {
     // const idx = this.tabsHanler.tabs.push(this)
     // this.id = (this as any).$props.name || idx
     // eslint-disable-next-line no-unused-expressions

--- a/packages/ui/src/components/vuestic-components/va-tabs/VaTabs.vdemo.vue
+++ b/packages/ui/src/components/vuestic-components/va-tabs/VaTabs.vdemo.vue
@@ -360,7 +360,7 @@
           </va-tab>
           <va-tab
             name="Link 2"
-            to="/demo/vuestic-components/va-tabs/VaTabs.demo.vue"
+            to="/demo/vuestic-components/va-tabs/VaTabs.vdemo.vue"
           >
             Active link
           </va-tab>

--- a/packages/ui/src/components/vuestic-components/va-tabs/VaTabs.vue
+++ b/packages/ui/src/components/vuestic-components/va-tabs/VaTabs.vue
@@ -221,7 +221,7 @@ export default class VaTabs extends mixins(
   }
 
   get disablePaginationRight () {
-    return this.context.tabsService?.tabs[this.context.tabsService.tabs.length - 1].rightSidePosition <= this.tabsContentOffset + this.containerRef.clientWidth
+    return this.context.tabsService?.tabs[this.context.tabsService.tabs.length - 1]?.rightSidePosition <= this.tabsContentOffset + this.containerRef.clientWidth
   }
 
   // TODO: check if this even works


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
closes #502 

## Markup:

Also removed unnecessary function. Becouse we have same functionality in setup function.
```js
  // TODO: check if this even works
  parseItems () {
    const content = (this as any).$slots.default || 0
```

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
