### PR TITLE
Fix#508/strange stateful mixin logic

### DIFF
--- a/packages/ui/src/components/vuestic-components/va-chip/VaChip.vue
+++ b/packages/ui/src/components/vuestic-components/va-chip/VaChip.vue
@@ -1,7 +1,7 @@
 <template>
   <component
     :is="tagComputed"
-    v-if="valueComputed"
+    v-if="doShowChip"
     :href="hrefComputed"
     :target="target"
     :to="to"
@@ -85,14 +85,18 @@ export default class VaChip extends mixins(
   focusState = false
 
   created () {
-    if (this.$props.stateful) {
-      this.valueComputed = true
-    }
-
     watch(() => this.hoverState, (value) => {
       this.updateFocusState(value)
       this.updateHoverState(value)
     })
+  }
+
+  get doShowChip () {
+    return this.valueComputed
+  }
+
+  set doShowChip (val) {
+    this.valueComputed = val
   }
 
   get iconSize () {
@@ -174,7 +178,7 @@ export default class VaChip extends mixins(
 
   close () {
     if (!this.disabled) {
-      this.valueComputed = false
+      this.doShowChip = false
     }
   }
 }

--- a/packages/ui/src/components/vuestic-components/va-chip/VaChip.vue
+++ b/packages/ui/src/components/vuestic-components/va-chip/VaChip.vue
@@ -1,7 +1,8 @@
 <template>
   <component
+    v-if="valueComputed"
+    class="va-chip"
     :is="tagComputed"
-    v-if="doShowChip"
     :href="hrefComputed"
     :target="target"
     :to="to"
@@ -9,7 +10,6 @@
     :exact="exact"
     :active-class="activeClass"
     :exact-active-class="exactActiveClass"
-    class="va-chip"
     :class="computedClass"
     :style="computedStyle"
     :tabindex="indexComputed"
@@ -91,14 +91,6 @@ export default class VaChip extends mixins(
     })
   }
 
-  get doShowChip () {
-    return this.valueComputed
-  }
-
-  set doShowChip (val) {
-    this.valueComputed = val
-  }
-
   get iconSize () {
     const size: any = {
       small: '0.875rem',
@@ -178,7 +170,7 @@ export default class VaChip extends mixins(
 
   close () {
     if (!this.disabled) {
-      this.doShowChip = false
+      this.valueComputed = false
     }
   }
 }

--- a/packages/ui/src/components/vuestic-components/va-modal/VaModal.vue
+++ b/packages/ui/src/components/vuestic-components/va-modal/VaModal.vue
@@ -231,24 +231,16 @@ export default class VaModal extends mixins(
     return this.$slots.footer
   }
 
-  setStateOrEmit (value: boolean) {
-    if (this.$props.stateful) {
-      this.valueComputed = value
-    } else {
-      this.$emit('update:modelValue', value)
-    }
-  }
-
   show () {
-    this.setStateOrEmit(true)
+    this.valueComputed = true
   }
 
   hide () {
-    this.setStateOrEmit(false)
+    this.valueComputed = false
   }
 
   toggle () {
-    this.setStateOrEmit(!this.valueComputed)
+    this.valueComputed = !this.valueComputed
   }
 
   cancel () {

--- a/packages/ui/src/components/vuestic-mixins/StatefulMixin/README.md
+++ b/packages/ui/src/components/vuestic-mixins/StatefulMixin/README.md
@@ -3,11 +3,11 @@ In many cases stateful components require less code for simplest cases, which mi
 
 Here's how component should operate for `stateful === true`:
 
-Component shouldn't require `value` or `@input` handling from parent to be able to function. But it still updates it internal state on `:value` change if it's provided. `:value` allows to set default value for stateful component, and `@input` just informs parent of the change.
+Component shouldn't require `modelValue` or `@update:modelValue` handling from parent to be able to function. But it still updates it internal state on `:modelValue` change if it's provided. `:modelValue` allows to set default value for stateful component, and `@update:modelValue` just informs parent of the change.
 
 Here's how component should operate for `stateful === false`:
 
-Internal interactions should not modify state, only emit (i.e. you won't be able to open stateless modal by clicking on anchor if @input is not handled in parent).
+Internal interactions should not modify state, only emit (i.e. you won't be able to open stateless modal by clicking on anchor if @update:modelValue is not handled in parent).
 
 ## Note
-* Speaking of statelessness, we're referring primarily to `value`. While cursor position in select, focus, scroll etc. could technically be considered state, external control could be implemented via refs or waived off.
+* Speaking of statelessness, we're referring primarily to `modelValue`. While cursor position in select, focus, scroll etc. could technically be considered state, external control could be implemented via refs or waived off.

--- a/packages/ui/src/components/vuestic-mixins/StatefulMixin/StatefulMixin.ts
+++ b/packages/ui/src/components/vuestic-mixins/StatefulMixin/StatefulMixin.ts
@@ -25,7 +25,7 @@ const PropsMixin = Vue.with(Props)
 })
 export class StatefulMixin extends mixins(PropsMixin) {
   valueState: ValueState = {
-    modelValue: undefined,
+    modelValue: this.$props.modelValue,
   }
 
   hasStatefulMixin!: boolean


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
closes #508 

Replaced undefiend to prop modelValue value:
```ts
export class StatefulMixin extends mixins(PropsMixin) {
  valueState: ValueState = {
    modelValue: this.$props.modelValue,
  }
// ...
}
```

From Readme
> `:value` allows to set default value for stateful component, and `@input` just informs parent of the change.

Also Readme was updated for vue3
>  `:modelValue` allows to set default value for stateful component, and `@update:modelValue` just informs parent of the change.

This changes allow us to set default value for `:modelValue` for stateful components using following code:

```ts
modelValue = prop<boolean>({ type: Boolean, default: true }) 
// Then
this.valueComputed === true // true

// Or

modelValue = prop<boolean>({ type: Boolean, default: false}) 
// Then
this.valueComputed === false // true
```

Tested for components: `VaChip`, `VaModal`

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
