### PR TITLE
Fix #513 VaSelect error messages is null

### DIFF
--- a/packages/ui/src/components/vuestic-components/va-form/VaForm.vue
+++ b/packages/ui/src/components/vuestic-components/va-form/VaForm.vue
@@ -8,17 +8,10 @@
 </template>
 
 <script lang="ts">
-import { InjectionKey, inject, provide } from 'vue'
+import { inject, provide } from 'vue'
 import { Options, mixins, prop, Vue, setup } from 'vue-class-component'
-
 import { FormComponentMixin } from '../../vuestic-mixins/FormComponent/FormComponentMixin'
-
-export type FormProvider = {
-  onChildMounted: (child: FormComponentMixin) => void;
-  onChildUnmounted: (child: FormComponentMixin) => void;
-}
-
-export const FormServiceKey: InjectionKey<FormProvider> = Symbol('FormService')
+import { FormProvider, FormServiceKey } from './consts'
 
 class FormProps {
   autofocus = prop<boolean>({ type: Boolean, default: false })

--- a/packages/ui/src/components/vuestic-components/va-form/consts.ts
+++ b/packages/ui/src/components/vuestic-components/va-form/consts.ts
@@ -1,0 +1,9 @@
+import { InjectionKey } from 'vue'
+import { FormComponentMixin } from '../../vuestic-mixins/FormComponent/FormComponentMixin'
+
+export type FormProvider = {
+  onChildMounted: (child: FormComponentMixin) => void;
+  onChildUnmounted: (child: FormComponentMixin) => void;
+}
+
+export const FormServiceKey: InjectionKey<FormProvider> = Symbol('FormService')

--- a/packages/ui/src/components/vuestic-mixins/FormComponent/FormComponentMixin.ts
+++ b/packages/ui/src/components/vuestic-mixins/FormComponent/FormComponentMixin.ts
@@ -4,9 +4,9 @@ import flatten from 'lodash/flatten'
 import { inject } from 'vue'
 import { mixins, Options, prop, Vue, setup } from 'vue-class-component'
 
-import { FormProvider, FormServiceKey } from '../../vuestic-components/va-form/VaForm.vue'
+import { FormProvider, FormServiceKey } from '../../vuestic-components/va-form/consts'
 
-const prepareValidations = (messages: any = [], callArguments = null) => {
+const prepareValidations = (messages: string | any[] = [], callArguments = null) => {
   if (isString(messages)) {
     messages = [messages]
   }
@@ -48,7 +48,7 @@ export class FormComponentMixin extends mixins(
 ) {
   hadFocus = false
   isFocused = false
-  internalErrorMessages = null
+  internalErrorMessages: any[] = []
   internalError = false
   isFormComponent = true
 
@@ -98,14 +98,12 @@ export class FormComponentMixin extends mixins(
   /** @public */
   validate (): any {
     this.computedError = false
-    // @ts-ignore
     this.computedErrorMessages = []
 
     if (this.rules && this.rules.length > 0) {
       prepareValidations(flatten(this.rules), this.modelValue as any)
         .forEach((validateResult: any) => {
           if (isString(validateResult)) {
-            // @ts-ignore
             this.computedErrorMessages.push(validateResult)
             this.computedError = true
           } else if (validateResult === false) {
@@ -128,7 +126,6 @@ export class FormComponentMixin extends mixins(
   }
 
   resetValidation (): void {
-    // @ts-ignore
     this.computedErrorMessages = []
     this.computedError = false
   }
@@ -137,6 +134,7 @@ export class FormComponentMixin extends mixins(
     return this.computedError
   }
 
+  // eslint-disable-next-line camelcase
   ValidateMixin_onBlur (): void {
     this.isFocused = false
     this.computedError = false


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
closes #513

## Markup:
<!-- Paste your markup here. -->
<details>
Changes:

- Removed useless `// @ts-ignore`  

- Moved `FormProvider, FormServiceKey` from component exports to separated file `consts.ts` for better ts typing.

- Changed internalErrorMessages from null to []
```ts
  internalErrorMessages: any[] = []
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
