### PR TITLE
fix #515 move v-on listeners from router-link to child div

### DIFF
--- a/packages/ui/src/components/vuestic-components/va-button/VaButton.vue
+++ b/packages/ui/src/components/vuestic-components/va-button/VaButton.vue
@@ -14,13 +14,13 @@
     :active-class="activeClass"
     :exact="exact"
     :exact-active-class="exactActiveClass"
-    v-on="inputListeners"
     @focus="updateFocusState(true)"
     @blur="updateFocusState(false)"
     :tabindex="loading ? -1 : 0"
   >
     <div
       class="va-button__content"
+      v-on="inputListeners"
       @mouseenter="updateHoverState(true)"
       @mouseleave="updateHoverState(false)"
     >

--- a/packages/ui/src/components/vuestic-components/va-card/VaCard.vue
+++ b/packages/ui/src/components/vuestic-components/va-card/VaCard.vue
@@ -11,14 +11,18 @@
     :exact="exact"
     :active-class="activeClass"
     :exact-active-class="exactActiveClass"
-    @click="$emit('click', $event)"
   >
     <div
       v-if="stripe"
       class="va-card__stripe"
       :style="stripeStyles"
     />
-    <slot />
+    <div
+      class="va-card__inner"
+      @click="$emit('click', $event)"
+    >
+      <slot />
+    </div>
   </component>
 </template>
 

--- a/packages/ui/src/components/vuestic-components/va-chip/VaChip.vue
+++ b/packages/ui/src/components/vuestic-components/va-chip/VaChip.vue
@@ -1,25 +1,25 @@
 <template>
-  <div
-    class="va-chip__wrapper"
-    @mouseenter="updateHoverState(true)"
-    @mouseleave="updateHoverState(false)"
-    @focus="updateFocusState(true)"
-    @blur="updateFocusState(false)"
+  <component
+    v-if="valueComputed"
+    class="va-chip"
+    :is="tagComputed"
+    :href="hrefComputed"
+    :target="target"
+    :to="to"
+    :replace="replace"
+    :exact="exact"
+    :active-class="activeClass"
+    :exact-active-class="exactActiveClass"
+    :class="computedClass"
+    :style="computedStyle"
+    :tabindex="indexComputed"
   >
-    <component
-      v-if="valueComputed"
-      class="va-chip"
-      :is="tagComputed"
-      :href="hrefComputed"
-      :target="target"
-      :to="to"
-      :replace="replace"
-      :exact="exact"
-      :active-class="activeClass"
-      :exact-active-class="exactActiveClass"
-      :class="computedClass"
-      :style="computedStyle"
-      :tabindex="indexComputed"
+    <div
+      class="va-chip__inner"
+      @mouseenter="updateHoverState(true)"
+      @mouseleave="updateHoverState(false)"
+      @focus="updateFocusState(true)"
+      @blur="updateFocusState(false)"
     >
       <va-icon
         v-if="icon"
@@ -37,8 +37,8 @@
         :size="iconSize"
         @click.stop="close()"
       />
-    </component>
-  </div>
+    </div>
+  </component>
 </template>
 
 <script lang="ts">
@@ -200,13 +200,15 @@ $tag-font-size-lg: 1.25rem !default;
   height: auto;
   min-width: initial;
   min-height: initial;
-
-  /* margin: 0 0.1rem; */
   padding: 0 0.3rem;
   color: $white;
   cursor: default;
-  align-items: center;
   font-size: $tag-font-size-nrm;
+
+  &__inner {
+    display: flex;
+    align-items: center;
+  }
 
   &:hover {
     opacity: 0.85;

--- a/packages/ui/src/components/vuestic-components/va-chip/VaChip.vue
+++ b/packages/ui/src/components/vuestic-components/va-chip/VaChip.vue
@@ -1,40 +1,44 @@
 <template>
-  <component
-    :is="tagComputed"
-    v-if="valueComputed"
-    :href="hrefComputed"
-    :target="target"
-    :to="to"
-    :replace="replace"
-    :exact="exact"
-    :active-class="activeClass"
-    :exact-active-class="exactActiveClass"
-    class="va-chip"
-    :class="computedClass"
-    :style="computedStyle"
-    :tabindex="indexComputed"
+  <div
+    class="va-chip__wrapper"
     @mouseenter="updateHoverState(true)"
     @mouseleave="updateHoverState(false)"
     @focus="updateFocusState(true)"
     @blur="updateFocusState(false)"
   >
-    <va-icon
-      v-if="icon"
-      class="va-chip__icon"
-      :name="icon"
-      :size="iconSize"
-    />
-    <span class="va-chip__content">
-      <slot></slot>
-    </span>
-    <va-icon
-      v-if="closeable"
-      class="va-chip__close-icon"
-      name="close"
-      :size="iconSize"
-      @click.stop="close()"
-    />
-  </component>
+    <component
+      v-if="valueComputed"
+      class="va-chip"
+      :is="tagComputed"
+      :href="hrefComputed"
+      :target="target"
+      :to="to"
+      :replace="replace"
+      :exact="exact"
+      :active-class="activeClass"
+      :exact-active-class="exactActiveClass"
+      :class="computedClass"
+      :style="computedStyle"
+      :tabindex="indexComputed"
+    >
+      <va-icon
+        v-if="icon"
+        class="va-chip__icon"
+        :name="icon"
+        :size="iconSize"
+      />
+      <span class="va-chip__content">
+        <slot></slot>
+      </span>
+      <va-icon
+        v-if="closeable"
+        class="va-chip__close-icon"
+        name="close"
+        :size="iconSize"
+        @click.stop="close()"
+      />
+    </component>
+  </div>
 </template>
 
 <script lang="ts">

--- a/packages/ui/src/components/vuestic-components/va-list/VaListItem.vue
+++ b/packages/ui/src/components/vuestic-components/va-list/VaListItem.vue
@@ -11,13 +11,17 @@
     class="va-list-item"
     :class="computedClass"
     :tabindex="indexComputed"
-    @mousedown="hasMouseDown = true"
-    @mouseup="hasMouseDown = false"
-    @focus="onFocus"
-    @blur="isKeyboardFocused = false"
-    @click="$emit('click')"
   >
-    <slot />
+    <div
+      class="va-list-item__inner"
+      @mousedown="hasMouseDown = true"
+      @mouseup="hasMouseDown = false"
+      @focus="onFocus"
+      @blur="isKeyboardFocused = false"
+      @click="$emit('click')"
+    >
+      <slot />
+    </div>
   </component>
 </template>
 
@@ -65,8 +69,12 @@ export default class VaListItem extends mixins(
 @import "../../vuestic-sass/resources/resources";
 
 .va-list-item {
-  display: flex;
-  align-items: center;
-  padding: $grid-gutter-default;
+  &__inner {
+    display: flex;
+    align-items: center;
+    padding: $grid-gutter-default;
+    width: 100%;
+    height: 100%;
+  }
 }
 </style>

--- a/packages/ui/src/components/vuestic-components/va-tabs/VaTab/VaTab.vue
+++ b/packages/ui/src/components/vuestic-components/va-tabs/VaTab/VaTab.vue
@@ -1,5 +1,6 @@
 <template>
   <component
+    class="va-tab"
     :is="tagComputed"
     :href="hrefComputed"
     :target="target"
@@ -8,17 +9,18 @@
     :exact="exact"
     :active-class="activeClass"
     :exact-active-class="exactActiveClass"
-    class="va-tab"
     :class="classComputed"
-    @click="onTabClick()"
-    @keydown.enter="onTabKeydown"
-    @mousedown="hasMouseDown = true"
-    @mouseup="hasMouseDown = false"
     :tabindex="tabIndexComputed"
-    @focus="onFocus"
-    @blur="isKeyboardFocused = false"
   >
-    <div class="va-tab__content">
+    <div
+      class="va-tab__content"
+      @focus="onFocus"
+      @blur="isKeyboardFocused = false"
+      @click="onTabClick()"
+      @keydown.enter="onTabKeydown"
+      @mousedown="hasMouseDown = true"
+      @mouseup="hasMouseDown = false"
+    >
       <slot>
         <va-icon
           v-if="icon"
@@ -152,8 +154,6 @@ export default class VaTab extends mixins(
   max-width: 264px;
   text-align: center;
   vertical-align: middle;
-  padding: 0.4375rem 0.75rem;
-  cursor: pointer;
   color: inherit;
 
   &:not(.va-tab--active) {
@@ -172,6 +172,8 @@ export default class VaTab extends mixins(
     transition: $transition-primary;
     user-select: none;
     white-space: nowrap;
+    padding: 0.4375rem 0.75rem;
+    cursor: pointer;
   }
 
   &__icon {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
closes #515 

`v-on="inputListeners"` was bind to route-link (`<component  tag="router-link" />`).

Route-link does not support `v-on`, therefore we need to use `.native` modifier (for vue2)  or move all listeners to a div wrapper. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
