### PR TITLE
fix: render va-breadcrumbs-items using v-for directive (#517)

### DIFF
--- a/packages/ui/src/components/vuestic-components/va-breadcrumbs/VaBreadcrumbs.vdemo.vue
+++ b/packages/ui/src/components/vuestic-components/va-breadcrumbs/VaBreadcrumbs.vdemo.vue
@@ -8,6 +8,16 @@
       </va-breadcrumbs>
     </VbCard>
 
+    <VbCard title="default (v-for)">
+      <va-breadcrumbs>
+        <va-breadcrumbs-item
+          v-for="(item, index) in items"
+          :key="index"
+          :label="item"
+        />
+      </va-breadcrumbs>
+    </VbCard>
+
     <VbCard title="routes">
       <va-breadcrumbs>
         <va-breadcrumbs-item
@@ -160,6 +170,12 @@
 import VaBreadcrumbs, { VaBreadcrumbsItem } from './index'
 
 export default {
+  data () {
+    return {
+      items: ['One', 'Two', 'Three'],
+    }
+  },
+
   components: {
     VaBreadcrumbs,
     VaBreadcrumbsItem,

--- a/packages/ui/src/components/vuestic-components/va-breadcrumbs/VaBreadcrumbs.vue
+++ b/packages/ui/src/components/vuestic-components/va-breadcrumbs/VaBreadcrumbs.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { VNode, h } from 'vue'
+import { VNode, h, Fragment } from 'vue'
 import { Options, prop, Vue, mixins } from 'vue-class-component'
 
 import { hasOwnProperty } from '../../../services/utils'
@@ -37,9 +37,16 @@ export default class VaBreadcrumbs extends mixins(
 
   render () {
     // TODO: use provide/inject for this not to stick to component's name
-    const childNodeFilter = (node?: VNode) => !!(node?.type as any)?.name?.match(/VaBreadcrumbsItem$/)
+    const childNodeFilter = (result: Array<VNode>, node?: VNode) => {
+      const nodes = node && node.type === Fragment && node.children ? node.children as Array<VNode> : [node]
 
-    const childNodes = (this.$slots as any)?.default()?.filter(childNodeFilter) || []
+      return [
+        ...result,
+        ...nodes.filter((node?: VNode) => !!(node?.type as any)?.name?.match(/VaBreadcrumbsItem$/)),
+      ]
+    }
+
+    const childNodes = (this.$slots as any)?.default()?.reduce(childNodeFilter, []) || []
 
     const childNodesLength = childNodes.length
     const isLastIndexChildNodes = (index: number) => index === childNodesLength - 1

--- a/packages/ui/src/components/vuestic-components/va-breadcrumbs/VaBreadcrumbs.vue
+++ b/packages/ui/src/components/vuestic-components/va-breadcrumbs/VaBreadcrumbs.vue
@@ -37,8 +37,8 @@ export default class VaBreadcrumbs extends mixins(
 
   render () {
     // TODO: use provide/inject for this not to stick to component's name
-    const childNodeFilter = (result: Array<VNode>, node?: VNode) => {
-      const nodes = node && node.type === Fragment && node.children ? node.children as Array<VNode> : [node]
+    const childNodeFilter = (result: VNode[], node?: VNode) => {
+      const nodes = node && node.type === Fragment && node.children ? node.children as VNode[] : [node]
 
       return [
         ...result,


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail -->

closes #517 
the type of `v-for` items is `Symbol(Fragment)`, we need to check this

## Markup:
<!-- Paste your markup here. -->
<details>

```vue
// Your code
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
