### PR TITLE
fix#467. Now global config use default config on initialization. setG…

### DIFF
--- a/packages/ui/src/vue-book/book-main.ts
+++ b/packages/ui/src/vue-book/book-main.ts
@@ -1,8 +1,6 @@
 import { createApp } from 'vue'
 import App from './BookApp.vue'
 import GlobalConfigPlugin from '../services/GlobalConfigPlugin'
-import { DEFAULT_THEME } from '../services/Theme'
-import { getDefaultConfig } from '../components/vuestic-components/va-config/config-default'
 import DropdownPopperSubplugin from '../components/vuestic-components/va-dropdown/dropdown-popover-subplugin'
 // import ColorHelpersPlugin from '../components/vuestic-utilities/color-helpers-plugin'
 import ToastInstall from '../components/vuestic-components/va-toast/install'
@@ -39,8 +37,21 @@ app.use(router)
 
 if (!process.env.VUE_APP_DEMO_NO_THEME_PLUGIN) {
   app.use(GlobalConfigPlugin, {
-    ...getDefaultConfig(),
-    theme: DEFAULT_THEME,
+    // Provide custom style here, for example:
+
+    // theme: {
+    //   primary: '#0000ff',
+    //   dark: '#ff0000',
+    // },
+    // VaIcon: {
+    //   iconsConfig: {
+    //     icons: {
+    //       home: {
+    //         code: 'error',
+    //       },
+    //     },
+    //   },
+    // },
   })
 } else {
   app.use(GlobalConfigPlugin)


### PR DESCRIPTION
fix#467. Now global config use default config on initialization. setGlobalConfig now use deep merge instead spread operator.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Fix subtask of https://github.com/epicmaxco/vuestic-ui/issues/467 — Default icons config for components

Before fix Global Config Plugin required an object with all configuration

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
