### PR TITLE
Fix#520. Added default padding for buttons.

### DIFF
--- a/packages/ui/src/components/vuestic-sass/global/reset.scss
+++ b/packages/ui/src/components/vuestic-sass/global/reset.scss
@@ -148,3 +148,7 @@ table {
 :focus {
   outline: none;
 }
+
+button {
+  padding: 0;
+}

--- a/packages/ui/src/components/vuestic-sass/resources/_mixins.scss
+++ b/packages/ui/src/components/vuestic-sass/resources/_mixins.scss
@@ -86,7 +86,6 @@
   font-size: $font-size;
   line-height: $line-height;
   border-radius: $border-radius;
-  padding: $padding-y $padding-x;
 }
 
 @mixin va-code-snippet {

--- a/packages/ui/src/components/vuestic-sass/resources/_mixins.scss
+++ b/packages/ui/src/components/vuestic-sass/resources/_mixins.scss
@@ -86,6 +86,7 @@
   font-size: $font-size;
   line-height: $line-height;
   border-radius: $border-radius;
+  padding: $padding-y $padding-x;
 }
 
 @mixin va-code-snippet {


### PR DESCRIPTION
closes #520

## Description
Added default padding for buttons and redefine default browser styles. Also now buttons horizontal padding equal to vuestic admin button padding size (`1.25rem` = `20px`).

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
