### PR TITLE
Fix#533/input double class

### DIFF
--- a/packages/ui/src/components/vuestic-components/va-input/VaInput.vdemo.vue
+++ b/packages/ui/src/components/vuestic-components/va-input/VaInput.vdemo.vue
@@ -247,6 +247,15 @@
     <VbCard title="Number input">
       <va-input type="number" v-model="num" />
     </VbCard>
+    <VbCard title="CSS Classes" class="va-input-css-classes-demo" style="width: 66%;">
+      <va-input class="mb-4" inputClass="red" modelValue="This input must have margin bottom and red text in input" />
+      <va-input
+        class="bg-gray"
+        inputClass="p-2 red"
+        modelValue="Native input element must have red text and big padding. Va-input - grey background"
+        type="textarea"
+      />
+    </VbCard>
   </VbDemo>
 </template>
 
@@ -286,3 +295,20 @@ export default {
   },
 }
 </script>
+
+<style lang="scss">
+.va-input-css-classes-demo {
+ .mb-4 {
+   margin-bottom: 4rem;
+ }
+ .red {
+   color: red;
+ }
+ .p-2 {
+   padding: 2rem;
+ }
+ .bg-gray {
+   background-color: grey;
+ }
+}
+</style>

--- a/packages/ui/src/components/vuestic-components/va-input/VaInput.vue
+++ b/packages/ui/src/components/vuestic-components/va-input/VaInput.vue
@@ -50,7 +50,7 @@
           :readonly="readonly"
           :value="computedValue"
           v-on="eventListeners"
-          v-bind="$attrs"
+          v-bind="computedAttributes"
           ref="input"
           :tabindex="tabindex"
         />
@@ -66,7 +66,7 @@
           :readonly="readonly"
           :value="modelValue"
           v-on="eventListeners"
-          v-bind="$attrs"
+          v-bind="computedAttributes"
           ref="textarea"
           :tabindex="tabindex"
         />
@@ -153,6 +153,10 @@ export default class VaInput extends mixins(
     }
 
     return { color: this.colorComputed }
+  }
+
+  get computedAttributes () {
+    return { ...this.$attrs, class: this.$attrs.inputClass }
   }
 
   get containerStyles (): any {

--- a/packages/ui/src/components/vuestic-components/va-input/VaInput.vue
+++ b/packages/ui/src/components/vuestic-components/va-input/VaInput.vue
@@ -158,11 +158,14 @@ export default class VaInput extends mixins(
   get containerStyles (): any {
     return {
       backgroundColor:
-        this.computedError ? (this.computeColor('danger') ? getHoverColor(this.computeColor('danger')) : '')
+        this.computedError
+          ? (this.computeColor('danger') ? getHoverColor(this.computeColor('danger')) : '')
           : this.success ? (this.computeColor('success') ? getHoverColor(this.computeColor('success')) : '') : '#f5f8f9',
       borderColor:
-        this.computedError ? this.computeColor('danger')
-          : this.success ? this.computeColor('success')
+        this.computedError
+          ? this.computeColor('danger')
+          : this.success
+            ? this.computeColor('success')
             : this.isFocused ? this.computeColor('dark') : this.computeColor('gray'),
     }
   }


### PR DESCRIPTION
## Description
closes #533 

I propose to use two attributes for `va-input` and `input` classes, 

Example:
```
<va-input
        class="mb-4"
        inputClass="p-2 text-red"
        ...
/>
```

This way `mb-4` class will not affect `input` element inside `va-input` and will prevent this class from being used twice.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
