### PR TITLE
Fix / VaSelect additional margins

### DIFF
--- a/packages/ui/src/components/vuestic-components/va-input/VaInput.vue
+++ b/packages/ui/src/components/vuestic-components/va-input/VaInput.vue
@@ -10,11 +10,12 @@
     @click:prepend="onPrependClick"
     @click:append="onAppendClick"
   >
-    <template #prepend>
+    <template v-if="$slots.prepend" #prepend>
       <slot
         name="prepend"
       />
     </template>
+
     <div
       class="va-input__container"
       :class="{'va-input__container--textarea': isTextarea}"
@@ -103,7 +104,8 @@
         />
       </div>
     </div>
-    <template #append>
+
+    <template v-if="$slots.append" #append>
       <slot
         name="append"
       />

--- a/packages/ui/src/components/vuestic-components/va-input/VaInput.vue
+++ b/packages/ui/src/components/vuestic-components/va-input/VaInput.vue
@@ -160,11 +160,14 @@ export default class VaInput extends mixins(
   get containerStyles (): any {
     return {
       backgroundColor:
-        this.computedError ? (this.computeColor('danger') ? getHoverColor(this.computeColor('danger')) : '')
+        this.computedError
+          ? (this.computeColor('danger') ? getHoverColor(this.computeColor('danger')) : '')
           : this.success ? (this.computeColor('success') ? getHoverColor(this.computeColor('success')) : '') : '#f5f8f9',
       borderColor:
-        this.computedError ? this.computeColor('danger')
-          : this.success ? this.computeColor('success')
+        this.computedError
+          ? this.computeColor('danger')
+          : this.success
+            ? this.computeColor('success')
             : this.isFocused ? this.computeColor('dark') : this.computeColor('gray'),
     }
   }

--- a/packages/ui/src/components/vuestic-components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/vuestic-components/va-select/VaSelect.vue
@@ -6,8 +6,8 @@
     :messages="$props.messages"
     :style="{ width: $props.width }"
   >
-    <template #prepend>
-      <slot name="prepend"/>
+    <template v-if="$slots.prepend" #prepend>
+      <slot name="prepend" />
     </template>
 
     <va-dropdown
@@ -157,8 +157,8 @@
       </template>
     </va-dropdown>
 
-    <template #append>
-      <slot name="append"/>
+    <template v-if="$slots.append" #append>
+      <slot name="append" />
     </template>
   </va-input-wrapper>
 </template>

--- a/packages/ui/src/components/vuestic-components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/vuestic-components/va-select/VaSelect.vue
@@ -70,7 +70,7 @@
           <div class="va-select__content-wrapper">
             <div class="va-select__controls" v-if="$slots.prependInner">
               <div class="va-select__prepend-slot">
-                <slot name="prependInner"/>
+                <slot name="prependInner" />
               </div>
             </div>
             <div
@@ -126,7 +126,7 @@
             <div class="va-select__controls">
 
               <div class="va-select__append-slot">
-                <slot name="appendInner"/>
+                <slot name="appendInner" />
               </div>
 
               <div v-if="showClearIcon" class="va-select__icon">
@@ -186,10 +186,11 @@ type DropdownIcon = {
 }
 
 class SelectProps {
-  modelValue = prop<string | number | object | any[]>({
+  modelValue = prop<string | number | Record<string, any> | any[]>({
     type: [String, Number, Object, Array],
     default: '',
   })
+
   label = prop<string>({ type: String, default: '' })
   placeholder = prop<string>({ type: String, default: '' })
   position = prop<string>({
@@ -318,19 +319,24 @@ export default class VaSelect extends mixins(
   get selectStyle () {
     return {
       backgroundColor:
-        this.computedError ? getHoverColor(this.computeColor('danger'))
+        this.computedError
+          ? getHoverColor(this.computeColor('danger'))
           : this.$props.success ? getHoverColor(this.computeColor('success')) : '#f5f8f9',
       borderColor:
-        this.computedError ? this.computeColor('danger')
-          : this.$props.success ? this.computeColor('success')
-          : this.isFocused || this.showOptionList ? this.colorComputed : this.computeColor('gray'),
+        this.computedError
+          ? this.computeColor('danger')
+          : this.$props.success
+            ? this.computeColor('success')
+            : this.isFocused || this.showOptionList ? this.colorComputed : this.computeColor('gray'),
     }
   }
 
   get labelStyle () {
     return {
-      color: this.computedError ? this.computeColor('danger')
-        : this.$props.success ? this.computeColor('success')
+      color: this.computedError
+        ? this.computeColor('danger')
+        : this.$props.success
+          ? this.computeColor('success')
           : this.isFocused || this.showOptionList ? this.colorComputed : this.computeColor('gray'),
     }
   }
@@ -508,9 +514,11 @@ export default class VaSelect extends mixins(
       isLetter && (this.hintedSearch += event.key)
     }
     // Search for an option that matches the query
-    this.hintedOption = this.hintedSearch ? (this.$props.options as []).find((option: any) => {
-      return this.getText(option).toLowerCase().startsWith(this.hintedSearch.toLowerCase())
-    }) : ''
+    this.hintedOption = this.hintedSearch
+      ? (this.$props.options as []).find((option: any) => {
+        return this.getText(option).toLowerCase().startsWith(this.hintedSearch.toLowerCase())
+      })
+      : ''
     this.timer = setTimeout(() => {
       this.hintedSearch = ''
     }, 1000)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Remove annoying margin from VaSelect and VaInput if `prepend` and `append` slots not passed. in 2847dad
![изображение](https://user-images.githubusercontent.com/23530004/111279130-09c88880-8643-11eb-94e2-58b2d11e1511.png)

Also fixes by eslint in ba65861 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
