### PR TITLE
Now accorditon value two way binded with collapse children.

### DIFF
--- a/packages/ui/src/components/vuestic-mixins/StatefulMixin/cStatefulMixin.ts
+++ b/packages/ui/src/components/vuestic-mixins/StatefulMixin/cStatefulMixin.ts
@@ -4,7 +4,7 @@ import { ref, computed, toRefs } from 'vue'
  * Returns `valueComputed` that is proxy for `modelValue`
  * if `stateful` prop is `false`
  */
-export function useStateful (props: Record<any, any>, emit: (event: string, ...args: any[]) => void) {
+export function useStateful (props: Record<any, any>, emit: (event: 'update:modelValue', ...args: any[]) => void) {
   const valueState = ref(props.modelValue)
   const { modelValue } = toRefs(props)
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
closes #589

There was a problem: accordion wasn't updating its modelValue when collapses.
This probleb was caused becouse `vue-class-component` doesn't provide fully this in setup function. So `this.valueComputed` in `onChildChange` was undefined. 
I rewrite this component to composition api without using `vue-class-component`. Now it's works fine.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
