### PR TITLE
Now active sidebar item uses exacly activeColor without alpha by default

### DIFF
--- a/packages/docs/src/components/sidebar/Sidebar.vue
+++ b/packages/docs/src/components/sidebar/Sidebar.vue
@@ -8,7 +8,7 @@
         :key="key"
       >
         <template #header>
-          <va-sidebar-item>
+          <va-sidebar-item :activeColor="activeColor">
             <va-sidebar-item-content :class="{ 'va-sidebar-item--active': isRouteHasActiveChild(route) }">
               <va-sidebar-item-title>
                 {{ $t(route.displayName) }}
@@ -32,7 +32,8 @@
           <va-sidebar-item
             :to="`/${$root.$i18n.locale}/${route.name}/${childRoute.name}`"
             :active="isActiveChildRoute(childRoute, route)"
-            :hoverColor="getColor('secondary')"
+            :activeColor="activeColor"
+            border-color="primary"
             @click="onSidebarItemClick"
           >
             <va-sidebar-item-content>
@@ -50,7 +51,7 @@ import { watch } from 'vue'
 import { Options, Vue, prop } from 'vue-class-component'
 import AlgoliaSearch from './algolia-search/AlgoliaSearch.vue'
 import VaSidebarLink from './SidebarLink.vue'
-import { getColor } from 'vuestic-ui/src/main'
+import { getColor, useColors } from 'vuestic-ui/src/main'
 
 class Props {
   navigationRoutes = prop<any[]>({ type: Array, default: () => [] })
@@ -70,6 +71,10 @@ export default class Sidebar extends Vue.with(Props) {
 
   getColor (color: string) {
     return getColor(color)
+  }
+
+  get activeColor () {
+    return '#b8c9ec'
   }
 
   onRouteChange () {

--- a/packages/ui/src/components/vuestic-components/va-sidebar/VaSidebarItem/VaSidebarItem.vue
+++ b/packages/ui/src/components/vuestic-components/va-sidebar/VaSidebarItem/VaSidebarItem.vue
@@ -17,7 +17,6 @@
 <script lang="ts">
 import { defineComponent, PropType, ref, computed } from 'vue'
 import { useColors } from '../../../../services/color-config/color-config'
-import { getHoverColor, getFocusColor } from '../../../../services/color-config/color-functions'
 
 const useHover = () => {
   const isHovered = ref(false)
@@ -37,26 +36,32 @@ export default defineComponent({
     active: { type: Boolean, default: false },
     textColor: { type: String, default: undefined },
     activeColor: { type: String, default: 'primary' },
-    hoverColor: { type: String, default: 'secondary' },
+    hoverColor: { type: String, default: undefined },
+    borderColor: { type: String, default: undefined },
   },
   setup (props) {
     const { isHovered, onMouseEnter, onMouseLeave } = useHover()
-    const { getColor } = useColors()
+    const { getColor, getHoverColor, getTextColor } = useColors()
 
     const computedStyle = computed(() => {
       const style: Record<string, string> = {}
 
-      // Override default link color from VaContent
-      style.color = getColor(props.textColor, '') + ' !important'
+      style.color = getColor(props.textColor, 'inherit')
 
       if (isHovered.value) {
-        style['background-color'] = getHoverColor(getColor(props.hoverColor))
+        style['background-color'] = getHoverColor(getColor(props.hoverColor || props.activeColor))
       }
 
       if (props.active) {
-        style['border-color'] = getColor(props.activeColor)
-        style['background-color'] = getFocusColor(getColor(props.activeColor))
+        const border = props.borderColor === undefined ? props.activeColor : props.borderColor
+
+        style['border-color'] = getColor(border)
+        style['background-color'] = getColor(props.activeColor)
+        style.color = getTextColor(style['background-color'], getColor('dark'), '#ffffff')
       }
+
+      // Override default link color from VaContent
+      style.color = `${style.color} !important`
 
       return style
     })

--- a/packages/ui/src/services/color-config/color-functions.ts
+++ b/packages/ui/src/services/color-config/color-functions.ts
@@ -5,10 +5,10 @@ export const colorToRgba = (color: ColorInput, opacity: number) => {
   return new ColorTranslator(color).setA(opacity).RGBA
 }
 
-export const getTextColor = (color: ColorInput) => {
+export const getTextColor = (color: ColorInput, darkColor = 'inherit', lightColor = '#ffffff') => {
   const { R, G, B } = new ColorTranslator(color)
-  const isDarkBackground = Math.sqrt(R * R * 0.241 + G * G * 0.691 + B * B * 0.068) > 130
-  return isDarkBackground ? 'inherit' : '#ffffff'
+  const isLightBackground = Math.sqrt(R * R * 0.241 + G * G * 0.691 + B * B * 0.068) > 130
+  return isLightBackground ? darkColor : lightColor
 }
 
 export const getBoxShadowColor = (color: ColorInput) => {


### PR DESCRIPTION

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
From 
![image](https://user-images.githubusercontent.com/23530004/118361842-c84a5000-b595-11eb-9634-0903e93dee8b.png)
To
![image](https://user-images.githubusercontent.com/23530004/118361858-d8fac600-b595-11eb-9a9c-548593a92cfe.png)


Looks less pretty, but now if the user select the `primary` color as active color it will be the `primary` color, not `primary` with 20% alpha.

Users still can use this pretty sidebar item as we have in docs.
![image](https://user-images.githubusercontent.com/23530004/118361965-398a0300-b596-11eb-92ed-326f31ba613a.png)


Also, I have fixed the hover color in our docs.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
