### PR TITLE
Fix #789: Dropdown refactor, closeOnContentClick prop, StatefulMixin are added

### DIFF
--- a/packages/docs/src/components/header/components/LanguageDropdown.vue
+++ b/packages/docs/src/components/header/components/LanguageDropdown.vue
@@ -5,6 +5,7 @@
       flat
       :label="currentLanguageName"
       :offset="[0, 25]"
+      :isContentClosable="true"
     >
       <div class="language-dropdown__content">
         <!-- <va-list-item

--- a/packages/docs/src/components/header/components/LanguageDropdown.vue
+++ b/packages/docs/src/components/header/components/LanguageDropdown.vue
@@ -5,7 +5,6 @@
       flat
       :label="currentLanguageName"
       :offset="[0, 25]"
-      :isContentClosable="true"
     >
       <div class="language-dropdown__content">
         <!-- <va-list-item

--- a/packages/docs/src/components/page-configs/ui-elements/va-button-dropdown/api-options.ts
+++ b/packages/docs/src/components/page-configs/ui-elements/va-button-dropdown/api-options.ts
@@ -17,7 +17,7 @@ export default {
     keepAnchorWidth: { local: true },
     offset: { local: true },
     modelValue: { local: true },
-    closeOnClickInside: { local: true },
+    closeOnContentClick: { local: true },
   },
   events: {
     click: { local: true, types: '`() => Event`' },

--- a/packages/docs/src/components/page-configs/ui-elements/va-button-dropdown/api-options.ts
+++ b/packages/docs/src/components/page-configs/ui-elements/va-button-dropdown/api-options.ts
@@ -17,7 +17,7 @@ export default {
     keepAnchorWidth: { local: true },
     offset: { local: true },
     modelValue: { local: true },
-    isContentClosable: { local: true },
+    closeOnClickInside: { local: true },
   },
   events: {
     click: { local: true, types: '`() => Event`' },

--- a/packages/docs/src/components/page-configs/ui-elements/va-button-dropdown/api-options.ts
+++ b/packages/docs/src/components/page-configs/ui-elements/va-button-dropdown/api-options.ts
@@ -17,6 +17,7 @@ export default {
     keepAnchorWidth: { local: true },
     offset: { local: true },
     modelValue: { local: true },
+    isContentClosable: { local: true },
   },
   events: {
     click: { local: true, types: '`() => Event`' },

--- a/packages/docs/src/components/page-configs/ui-elements/va-button-dropdown/page-config.ts
+++ b/packages/docs/src/components/page-configs/ui-elements/va-button-dropdown/page-config.ts
@@ -47,6 +47,11 @@ export default [
     'buttonDropdown.examples.events.text',
     'va-button-dropdown/Events',
   ),
+  ...DocsHelper.exampleBlock(
+    'buttonDropdown.examples.clickInside.title',
+    'buttonDropdown.examples.clickInside.text',
+    'va-button-dropdown/ClickInside',
+  ),
   DocsHelper.subtitle('all.api'),
   DocsHelper.api(VaButtonDropdown, apiOptions),
 ] as ApiDocsBlock[]

--- a/packages/docs/src/examples/va-button-dropdown/ClickInside.vue
+++ b/packages/docs/src/examples/va-button-dropdown/ClickInside.vue
@@ -1,5 +1,4 @@
 <template>
-<div>
   <va-button-dropdown
     class="mr-2 mb-2"
     label="Will not close dropdown on click"
@@ -7,5 +6,4 @@
   >
     Content
   </va-button-dropdown>
-</div>
 </template>

--- a/packages/docs/src/examples/va-button-dropdown/ClickInside.vue
+++ b/packages/docs/src/examples/va-button-dropdown/ClickInside.vue
@@ -2,7 +2,7 @@
   <va-button-dropdown
     class="mr-2 mb-2"
     label="Will not close dropdown on click"
-    :close-on-click-inside="false"
+    :close-on-content-click="false"
   >
     Content
   </va-button-dropdown>

--- a/packages/docs/src/examples/va-button-dropdown/ClickInside.vue
+++ b/packages/docs/src/examples/va-button-dropdown/ClickInside.vue
@@ -1,0 +1,11 @@
+<template>
+<div>
+  <va-button-dropdown
+    class="mr-2 mb-2"
+    label="Will not close dropdown on click"
+    :close-on-click-inside="false"
+  >
+    Content
+  </va-button-dropdown>
+</div>
+</template>

--- a/packages/docs/src/locales/en/en.json
+++ b/packages/docs/src/locales/en/en.json
@@ -791,7 +791,7 @@
         "keepAnchorWidth": "Keeps anchor position the same.",
         "offset": "Sets the distance between dropdown and anchor.",
         "modelValue": "Sets a dropdown state.",
-        "closeOnClickInside": "Sets dropdown content on click behavior."
+        "closeOnContentClick": "Sets dropdown content on click behavior."
       },
       "events": {
         "click": "Emitted when user clicks on button.",

--- a/packages/docs/src/locales/en/en.json
+++ b/packages/docs/src/locales/en/en.json
@@ -3056,7 +3056,7 @@
       },
       "clickInside": {
         "title": "Click inside",
-        "text": "You could set the dropdown to be closed or not after clicking on it's content."
+        "text": "You could set the dropdown to be closed or not after clicking on its content."
       }
     }
   },

--- a/packages/docs/src/locales/en/en.json
+++ b/packages/docs/src/locales/en/en.json
@@ -3053,6 +3053,10 @@
       "events": {
         "title": "Events",
         "text": "The `va-dropdown-button` can handle click events."
+      },
+      "clickInside": {
+        "title": "Click inside",
+        "text": "You could set the dropdown to be closed or not after clicking on it."
       }
     }
   },

--- a/packages/docs/src/locales/en/en.json
+++ b/packages/docs/src/locales/en/en.json
@@ -790,7 +790,8 @@
         "position": "Sets the position of the dropdown content.",
         "keepAnchorWidth": "Keeps anchor position the same.",
         "offset": "Sets the distance between dropdown and anchor.",
-        "modelValue": "Sets a dropdown state."
+        "modelValue": "Sets a dropdown state.",
+        "isContentClosable": "Sets dropdown content on click behavior."
       },
       "events": {
         "click": "Emitted when user clicks on button.",

--- a/packages/docs/src/locales/en/en.json
+++ b/packages/docs/src/locales/en/en.json
@@ -3056,7 +3056,7 @@
       },
       "clickInside": {
         "title": "Click inside",
-        "text": "You could set the dropdown to be closed or not after clicking on it."
+        "text": "You could set the dropdown to be closed or not after clicking on it's content."
       }
     }
   },

--- a/packages/docs/src/locales/en/en.json
+++ b/packages/docs/src/locales/en/en.json
@@ -791,7 +791,7 @@
         "keepAnchorWidth": "Keeps anchor position the same.",
         "offset": "Sets the distance between dropdown and anchor.",
         "modelValue": "Sets a dropdown state.",
-        "isContentClosable": "Sets dropdown content on click behavior."
+        "closeOnClickInside": "Sets dropdown content on click behavior."
       },
       "events": {
         "click": "Emitted when user clicks on button.",

--- a/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.demo.vue
+++ b/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.demo.vue
@@ -183,12 +183,6 @@
     </VbCard>
     <VbCard title="Stateful">
       <va-button-dropdown
-        label="Stateful"
-        stateful
-      >
-        Content
-      </va-button-dropdown>
-      <va-button-dropdown
         label="Stateless without v-model"
         :stateful=false
       >

--- a/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.demo.vue
+++ b/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.demo.vue
@@ -175,7 +175,7 @@
     </VbCard>
     <VbCard title="Click inside">
       <va-button-dropdown
-        label="Dropdown content will not be closed on click"
+        label="Dropdown content click will not close it"
         :closeOnClickInside="false"
       >
         Content

--- a/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.demo.vue
+++ b/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.demo.vue
@@ -173,6 +173,28 @@
         Content
       </va-button-dropdown>
     </VbCard>
+    <VbCard title="Click inside">
+      <va-button-dropdown
+        label="Dropdown content will not be closed on click"
+        :closeOnClickInside="false"
+      >
+        Content
+      </va-button-dropdown>
+    </VbCard>
+    <VbCard title="Stateful">
+      <va-button-dropdown
+        label="Stateful"
+        stateful
+      >
+        Content
+      </va-button-dropdown>
+      <va-button-dropdown
+        label="Stateless without v-model"
+        :stateful=false
+      >
+        Content
+      </va-button-dropdown>
+    </VbCard>
   </VbDemo>
 </template>
 
@@ -192,6 +214,11 @@ export default {
       console.log('click', e)
     },
   },
+  data () {
+    return {
+      value: true
+    }
+  }
 }
 </script>
 

--- a/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.demo.vue
+++ b/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.demo.vue
@@ -176,7 +176,7 @@
     <VbCard title="Click inside">
       <va-button-dropdown
         label="Open"
-        :closeOnClickInside="false"
+        :closeOnContentClick="false"
       >
         Clicking here won't close dropdown content
       </va-button-dropdown>

--- a/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.demo.vue
+++ b/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.demo.vue
@@ -181,7 +181,7 @@
         Clicking here won't close dropdown content
       </va-button-dropdown>
     </VbCard>
-    <VbCard title="Stateful">
+    <VbCard title="Stateless">
       <va-button-dropdown
         label="Stateless without v-model"
         :stateful=false

--- a/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.demo.vue
+++ b/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.demo.vue
@@ -175,10 +175,10 @@
     </VbCard>
     <VbCard title="Click inside">
       <va-button-dropdown
-        label="Dropdown content click will not close it"
+        label="Open"
         :closeOnClickInside="false"
       >
-        Content
+        Clicking here won't close dropdown content
       </va-button-dropdown>
     </VbCard>
     <VbCard title="Stateful">

--- a/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.vue
+++ b/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.vue
@@ -7,6 +7,7 @@
       :offset="$props.offset"
       @update:modelValue="toggleDropdown"
       :keep-anchor-width="keepAnchorWidth"
+      :isContentClosable="$props.isContentClosable"
     >
       <template #anchor>
         <va-button
@@ -80,6 +81,7 @@ import VaButton from '../va-button'
 import VaButtonGroup from '../va-button-group'
 
 class ButtonDropdownProps {
+  isContentClosable = prop<boolean>({ type: Boolean, default: false })
   modelValue = prop<boolean>({ type: Boolean })
   color = prop<string>({ type: String, default: 'primary' })
   outline = prop<boolean>({ type: Boolean, default: false })

--- a/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.vue
+++ b/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.vue
@@ -7,7 +7,7 @@
       :offset="$props.offset"
       @update:modelValue="toggleDropdown"
       :keep-anchor-width="keepAnchorWidth"
-      :isContentClosable="$props.isContentClosable"
+      :is-content-closable="isContentClosable"
     >
       <template #anchor>
         <va-button
@@ -81,7 +81,7 @@ import VaButton from '../va-button'
 import VaButtonGroup from '../va-button-group'
 
 class ButtonDropdownProps {
-  isContentClosable = prop<boolean>({ type: Boolean, default: false })
+  isContentClosable = prop<boolean>({ type: Boolean, default: true })
   modelValue = prop<boolean>({ type: Boolean })
   color = prop<string>({ type: String, default: 'primary' })
   outline = prop<boolean>({ type: Boolean, default: false })

--- a/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.vue
+++ b/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.vue
@@ -7,7 +7,7 @@
       :offset="$props.offset"
       @update:modelValue="toggleDropdown"
       :keep-anchor-width="keepAnchorWidth"
-      :is-content-closable="isContentClosable"
+      :close-on-click-inside="closeOnClickInside"
     >
       <template #anchor>
         <va-button
@@ -81,7 +81,7 @@ import VaButton from '../va-button'
 import VaButtonGroup from '../va-button-group'
 
 class ButtonDropdownProps {
-  isContentClosable = prop<boolean>({ type: Boolean, default: true })
+  closeOnClickInside = prop<boolean>({ type: Boolean, default: true })
   modelValue = prop<boolean>({ type: Boolean })
   color = prop<string>({ type: String, default: 'primary' })
   outline = prop<boolean>({ type: Boolean, default: false })

--- a/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.vue
+++ b/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.vue
@@ -122,8 +122,6 @@ export default class VaButtonDropdown extends mixins(
   ColorMixin,
   ButtonDropdownPropsMixin,
 ) {
-  // showDropdown = false
-
   get computedIcon (): string {
     // @ts-ignore
     return this.showDropdown ? this.$props.openedIcon : this.$props.icon

--- a/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.vue
+++ b/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.vue
@@ -6,7 +6,7 @@
       :position="position"
       :offset="$props.offset"
       :keep-anchor-width="keepAnchorWidth"
-      :close-on-click-inside="closeOnClickInside"
+      :close-on-content-click="closeOnContentClick"
       v-model="showDropdown"
       :stateful="stateful"
     >
@@ -106,7 +106,7 @@ class ButtonDropdownProps {
   position = prop<string>({ type: String, default: 'bottom' })
   label = prop<string>({ type: String })
   offset = prop<number | number[]>({ type: [Array, Number], default: () => [] })
-  closeOnClickInside = prop<boolean>({ type: Boolean, default: true })
+  closeOnContentClick = prop<boolean>({ type: Boolean, default: true })
   stateful = prop<boolean>({ type: Boolean, default: true })
 }
 

--- a/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.vue
+++ b/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.vue
@@ -5,9 +5,10 @@
       :disabled="disabled"
       :position="position"
       :offset="$props.offset"
-      @update:modelValue="toggleDropdown"
       :keep-anchor-width="keepAnchorWidth"
       :close-on-click-inside="closeOnClickInside"
+      v-model="valueComputed"
+      :stateful="stateful"
     >
       <template #anchor>
         <va-button
@@ -49,7 +50,8 @@
         :disabled="disabled || disableDropdown"
         :position="position"
         :offset="$props.offset"
-        @update:modelValue="toggleDropdown"
+        v-model="valueComputed"
+        :stateful="stateful"
       >
         <template #anchor>
           <va-button
@@ -75,13 +77,13 @@ import { Options, Vue, prop, mixins } from 'vue-class-component'
 
 import ColorMixin from '../../../services/color-config/ColorMixin'
 import { SizeMixin } from '../../../mixins/SizeMixin'
+import { StatefulMixin } from '../../vuestic-mixins/StatefulMixin/StatefulMixin'
 
 import VaDropdown from '../va-dropdown'
 import VaButton from '../va-button'
 import VaButtonGroup from '../va-button-group'
 
 class ButtonDropdownProps {
-  closeOnClickInside = prop<boolean>({ type: Boolean, default: true })
   modelValue = prop<boolean>({ type: Boolean })
   color = prop<string>({ type: String, default: 'primary' })
   outline = prop<boolean>({ type: Boolean, default: false })
@@ -105,6 +107,8 @@ class ButtonDropdownProps {
   position = prop<string>({ type: String, default: 'bottom' })
   label = prop<string>({ type: String })
   offset = prop<number | number[]>({ type: [Array, Number], default: () => [] })
+  closeOnClickInside = prop<boolean>({ type: Boolean, default: true })
+  stateful = prop<boolean>({ type: Boolean, default: true })
 }
 
 const ButtonDropdownPropsMixin = Vue.with(ButtonDropdownProps)
@@ -117,13 +121,14 @@ const ButtonDropdownPropsMixin = Vue.with(ButtonDropdownProps)
 export default class VaButtonDropdown extends mixins(
   SizeMixin,
   ColorMixin,
+  StatefulMixin,
   ButtonDropdownPropsMixin,
 ) {
   showDropdown = false
 
   get computedIcon (): string {
     // @ts-ignore
-    return this.showDropdown ? this.$props.openedIcon : this.$props.icon
+    return this.valueComputed ? this.$props.openedIcon : this.$props.icon
   }
 
   get computedClass () {

--- a/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.vue
+++ b/packages/ui/src/components/vuestic-components/va-button-dropdown/VaButtonDropdown.vue
@@ -7,7 +7,7 @@
       :offset="$props.offset"
       :keep-anchor-width="keepAnchorWidth"
       :close-on-click-inside="closeOnClickInside"
-      v-model="valueComputed"
+      v-model="showDropdown"
       :stateful="stateful"
     >
       <template #anchor>
@@ -50,7 +50,7 @@
         :disabled="disabled || disableDropdown"
         :position="position"
         :offset="$props.offset"
-        v-model="valueComputed"
+        v-model="showDropdown"
         :stateful="stateful"
       >
         <template #anchor>
@@ -77,14 +77,13 @@ import { Options, Vue, prop, mixins } from 'vue-class-component'
 
 import ColorMixin from '../../../services/color-config/ColorMixin'
 import { SizeMixin } from '../../../mixins/SizeMixin'
-import { StatefulMixin } from '../../vuestic-mixins/StatefulMixin/StatefulMixin'
 
 import VaDropdown from '../va-dropdown'
 import VaButton from '../va-button'
 import VaButtonGroup from '../va-button-group'
 
 class ButtonDropdownProps {
-  modelValue = prop<boolean>({ type: Boolean })
+  modelValue = prop<boolean>({ type: Boolean, default: false })
   color = prop<string>({ type: String, default: 'primary' })
   outline = prop<boolean>({ type: Boolean, default: false })
   disableButton = prop<boolean>({ type: Boolean, default: false })
@@ -116,19 +115,18 @@ const ButtonDropdownPropsMixin = Vue.with(ButtonDropdownProps)
 @Options({
   name: 'VaButtonDropdown',
   components: { VaButtonGroup, VaButton, VaDropdown },
-  emits: ['click', 'main-button-click'],
+  emits: ['click', 'main-button-click', 'update:modelValue'],
 })
 export default class VaButtonDropdown extends mixins(
   SizeMixin,
   ColorMixin,
-  StatefulMixin,
   ButtonDropdownPropsMixin,
 ) {
-  showDropdown = false
+  // showDropdown = false
 
   get computedIcon (): string {
     // @ts-ignore
-    return this.valueComputed ? this.$props.openedIcon : this.$props.icon
+    return this.showDropdown ? this.$props.openedIcon : this.$props.icon
   }
 
   get computedClass () {
@@ -141,16 +139,20 @@ export default class VaButtonDropdown extends mixins(
     }
   }
 
+  get showDropdown (): boolean {
+    return this.modelValue
+  }
+
+  set showDropdown (value: boolean) {
+    this.$emit('update:modelValue', value)
+  }
+
   click (event: Event): void {
     this.$emit('click', event)
   }
 
   mainButtonClick (event: Event): void {
     this.$emit('main-button-click', event)
-  }
-
-  toggleDropdown (value: boolean): void {
-    this.showDropdown = value
   }
 }
 </script>

--- a/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.demo.vue
+++ b/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.demo.vue
@@ -229,7 +229,6 @@
 
     <VbCard title="Nesting 3x">
       <va-dropdown
-        debug-id="1"
         :close-on-content-click=false
       >
         <template #anchor>
@@ -239,7 +238,6 @@
         </template>
         1
         <va-dropdown
-          debug-id="2"
           :close-on-content-click=false
         >
           <template #anchor>
@@ -249,7 +247,6 @@
           </template>
           2
           <va-dropdown
-            debug-id="3"
             :close-on-content-click=false
           >
             <template #anchor>

--- a/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.demo.vue
+++ b/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.demo.vue
@@ -228,21 +228,30 @@
     </VbCard>
 
     <VbCard title="Nesting 3x">
-      <va-dropdown debug-id="1">
+      <va-dropdown
+        debug-id="1"
+        :close-on-click-inside=false
+      >
         <template #anchor>
           <button>
             Click
           </button>
         </template>
         1
-        <va-dropdown debug-id="2">
+        <va-dropdown
+          debug-id="2"
+          :close-on-click-inside=false
+        >
           <template #anchor>
             <button>
               Click
             </button>
           </template>
           2
-          <va-dropdown debug-id="3">
+          <va-dropdown
+            debug-id="3"
+            :close-on-click-inside=false
+          >
             <template #anchor>
               <button>
                 Click

--- a/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.demo.vue
+++ b/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.demo.vue
@@ -64,7 +64,7 @@
 
     <VbCard title="Doesn't redraw on content change">
       <va-dropdown
-        :close-on-click-inside="false"
+        :close-on-content-click="false"
       >
         <template #anchor>
           <button>
@@ -230,7 +230,7 @@
     <VbCard title="Nesting 3x">
       <va-dropdown
         debug-id="1"
-        :close-on-click-inside=false
+        :close-on-content-click=false
       >
         <template #anchor>
           <button>
@@ -240,7 +240,7 @@
         1
         <va-dropdown
           debug-id="2"
-          :close-on-click-inside=false
+          :close-on-content-click=false
         >
           <template #anchor>
             <button>
@@ -250,7 +250,7 @@
           2
           <va-dropdown
             debug-id="3"
-            :close-on-click-inside=false
+            :close-on-content-click=false
           >
             <template #anchor>
               <button>

--- a/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.demo.vue
+++ b/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.demo.vue
@@ -33,7 +33,7 @@
           Click
         </button>
       </template>
-        Should ignore click outside
+        Should ignore anchor click
       </va-dropdown>
     </VbCard>
 
@@ -63,7 +63,9 @@
     </VbCard>
 
     <VbCard title="Doesn't redraw on content change">
-      <va-dropdown>
+      <va-dropdown
+        :close-on-click-inside="false"
+      >
         <template #anchor>
           <button>
             Click

--- a/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.vue
+++ b/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.vue
@@ -15,6 +15,7 @@
         class="va-dropdown__content-wrapper"
         @mouseover="$props.isContentHoverable && onMouseOver()"
         @mouseout="onMouseOut()"
+        @click="$props.isContentClosable && onAnchorClick()"
         ref="contentWrapper"
       >
         <div :style="$props.keepAnchorWidth ? anchorWidthStyles : ''">
@@ -51,6 +52,7 @@ class DropdownProps {
   closeOnClickOutside = prop<boolean>({ type: Boolean, default: true })
   closeOnAnchorClick = prop<boolean>({ type: Boolean, default: true })
   isContentHoverable = prop<boolean>({ type: Boolean, default: true })
+  isContentClosable = prop<boolean>({ type: Boolean, default: false })
   offset = prop<number | number[]>({ type: [Array, Number], default: () => [] })
   trigger = prop<string | number | any[]>({
     type: [Array, Number, String],

--- a/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.vue
+++ b/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.vue
@@ -52,7 +52,7 @@ class DropdownProps {
   closeOnClickOutside = prop<boolean>({ type: Boolean, default: true })
   closeOnAnchorClick = prop<boolean>({ type: Boolean, default: true })
   isContentHoverable = prop<boolean>({ type: Boolean, default: true })
-  isContentClosable = prop<boolean>({ type: Boolean, default: false })
+  isContentClosable = prop<boolean>({ type: Boolean, default: true })
   offset = prop<number | number[]>({ type: [Array, Number], default: () => [] })
   trigger = prop<string | number | any[]>({
     type: [Array, Number, String],

--- a/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.vue
+++ b/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.vue
@@ -85,25 +85,8 @@ export default class VaDropdown extends mixins(
     }
   }
 
-  get triggeredValue (): boolean {
-    const getTriggeredValue = () => {
-      if (['click', 'hover', 'none'].includes(this.trigger)) {
-        return this.valueComputed
-      }
-      return false
-    }
-
-    const triggeredValue = getTriggeredValue()
-    this.$emit('trigger', triggeredValue)
-
-    return triggeredValue
-  }
-
   get showContent (): boolean {
-    // the idea is to emit 'trigger' in any case
-    const triggeredValue = this.triggeredValue
-
-    return triggeredValue
+    return this.valueComputed
   }
 
   handlePopperInstance (): void {

--- a/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.vue
+++ b/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.vue
@@ -55,7 +55,12 @@ class DropdownProps {
   closeOnAnchorClick = prop<boolean>({ type: Boolean, default: true })
   isContentHoverable = prop<boolean>({ type: Boolean, default: true })
   offset = prop<number | number[]>({ type: [Array, Number], default: () => [] })
-  trigger = prop<string>({ type: String, default: 'click' })
+  trigger = prop<string>({
+    type: String,
+    default: 'click',
+    validator: (trigger: string): boolean => ['click', 'hover', 'none'].includes(trigger),
+  })
+  stateful = prop<boolean>({ type: Boolean, default: true })
 }
 
 const DropdownPropsMixin = Vue.with(DropdownProps)
@@ -65,8 +70,8 @@ const DropdownPropsMixin = Vue.with(DropdownProps)
   emits: ['update:modelValue', 'anchor-click', 'click-outside', 'dropdown-content-click', 'trigger'],
 })
 export default class VaDropdown extends mixins(
-  DropdownPropsMixin,
   StatefulMixin,
+  DropdownPropsMixin,
 ) {
   popperInstance: PopperInstance = null
   anchorWidth!: number
@@ -143,7 +148,6 @@ export default class VaDropdown extends mixins(
       }
       this.valueComputed = true
     }
-
     this.$emit('anchor-click')
   }
 

--- a/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.vue
+++ b/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.vue
@@ -31,6 +31,7 @@ import { watch, nextTick } from 'vue'
 import { Vue, Options, prop, mixins } from 'vue-class-component'
 import { DebounceLoader } from 'asva-executors'
 import { createPopper, Instance } from '@popperjs/core'
+import { StatefulMixin } from '../../vuestic-mixins/StatefulMixin/StatefulMixin'
 
 type PopperInstance = Instance | null
 type ClickType = 'anchor-click' | 'dropdown-content-click' | 'click-outside'
@@ -68,7 +69,10 @@ const DropdownPropsMixin = Vue.with(DropdownProps)
   name: 'VaDropdown',
   emits: ['update:modelValue', 'anchor-click', 'click-outside', 'dropdown-content-click', 'trigger'],
 })
-export default class VaDropdown extends mixins(DropdownPropsMixin) {
+export default class VaDropdown extends mixins(
+  DropdownPropsMixin,
+  StatefulMixin,
+) {
   popperInstance: PopperInstance = null
   isShown = false
   isMouseHovered = false
@@ -91,7 +95,7 @@ export default class VaDropdown extends mixins(DropdownPropsMixin) {
       case 'click':
         return this.isShown
       case 'none':
-        return this.modelValue
+        return this.valueComputed
       default:
         return false
       }
@@ -220,7 +224,7 @@ export default class VaDropdown extends mixins(DropdownPropsMixin) {
       this.isShown = false
     }
     if (this.trigger === 'none') {
-      this.$emit('update:modelValue', false)
+      this.valueComputed = false
     }
   }
 
@@ -230,7 +234,7 @@ export default class VaDropdown extends mixins(DropdownPropsMixin) {
       modifiers: [],
       // strategy: this.fixed ? 'fixed' : undefined,
       onFirstUpdate: () => {
-        this.$emit('update:modelValue', true)
+        this.valueComputed = true
       },
     }
 
@@ -264,7 +268,7 @@ export default class VaDropdown extends mixins(DropdownPropsMixin) {
   }
 
   removePopper (): void {
-    this.$emit('update:modelValue', false)
+    this.valueComputed = false
 
     if (!this.popperInstance) {
       return

--- a/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.vue
+++ b/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.vue
@@ -50,7 +50,7 @@ class DropdownProps {
   keepAnchorWidth = prop<boolean>({ type: Boolean })
   // If set to false - dropdown won't dodge outside container.
   preventOverflow = prop<boolean>({ type: Boolean, default: false })
-  closeOnClickInside = prop<boolean>({ type: Boolean, default: true })
+  closeOnContentClick = prop<boolean>({ type: Boolean, default: true })
   closeOnClickOutside = prop<boolean>({ type: Boolean, default: true })
   closeOnAnchorClick = prop<boolean>({ type: Boolean, default: true })
   isContentHoverable = prop<boolean>({ type: Boolean, default: true })
@@ -58,7 +58,7 @@ class DropdownProps {
   trigger = prop<string>({
     type: String,
     default: 'click',
-    validator: (trigger: string) => ['click', 'hover', 'none'].includes(trigger)
+    validator: (trigger: string) => ['click', 'hover', 'none'].includes(trigger),
   })
   stateful = prop<boolean>({ type: Boolean, default: true })
 }
@@ -113,7 +113,7 @@ export default class VaDropdown extends mixins(
   }
 
   onDropdownContentClick (): void {
-    this.handleClick('dropdown-content-click', this.closeOnClickInside)
+    this.handleClick('dropdown-content-click', this.closeOnContentClick)
   }
 
   onClickOutside (): void {
@@ -149,7 +149,7 @@ export default class VaDropdown extends mixins(
   }
 
   onMouseOut (): void {
-    if( this.trigger !== 'hover') {
+    if (this.trigger !== 'hover') {
       return
     }
     if (this.isContentHoverable) {

--- a/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.vue
+++ b/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.vue
@@ -67,7 +67,7 @@ const DropdownPropsMixin = Vue.with(DropdownProps)
 
 @Options({
   name: 'VaDropdown',
-  emits: ['update:modelValue', 'anchor-click', 'click-outside', 'dropdown-content-click', 'trigger'],
+  emits: ['update:modelValue', 'anchor-click', 'click-outside', 'dropdown-content-click'],
 })
 export default class VaDropdown extends mixins(
   StatefulMixin,
@@ -146,7 +146,6 @@ export default class VaDropdown extends mixins(
       if (!this.valueComputed) {
         this.hoverOverDebounceLoader.run()
       }
-
       this.hoverOutDebounceLoader.reset()
     }
   }

--- a/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.vue
+++ b/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.vue
@@ -44,7 +44,6 @@ class DropdownProps {
   boundaryBody = prop<boolean>({ type: Boolean })
   modelValue = prop<boolean>({ type: Boolean, default: false })
   disabled = prop<boolean>({ type: Boolean })
-  opened = prop<boolean>({ type: Boolean })
   // Makes no sense
   // fixed = prop<boolean>({ type: Boolean })
   // Means dropdown width should be the same as anchor's width.
@@ -56,11 +55,7 @@ class DropdownProps {
   closeOnAnchorClick = prop<boolean>({ type: Boolean, default: true })
   isContentHoverable = prop<boolean>({ type: Boolean, default: true })
   offset = prop<number | number[]>({ type: [Array, Number], default: () => [] })
-  trigger = prop<string | number | any[]>({
-    type: [Array, Number, String],
-    default: 'click',
-    validator: (trigger: string): boolean => ['click', 'hover', 'none'].includes(trigger),
-  })
+  trigger = prop<string>({ type: String, default: 'click' })
 }
 
 const DropdownPropsMixin = Vue.with(DropdownProps)
@@ -86,33 +81,11 @@ export default class VaDropdown extends mixins(
   }
 
   get triggeredValue (): boolean {
-    // const getTriggeredValue = () => {
-    //   return (Array.isArray(this.trigger) ? this.trigger : [this.trigger]).some((trigger) => {
-    //     switch (trigger) {
-    //       case 'hover':
-    //         return this.isMouseHovered
-    //       case 'click':
-    //         return this.isClicked
-    //       case 'none':
-    //         return this.modelValue
-    //       default:
-    //         return false
-    //     }
-    //   })
-    // }
     const getTriggeredValue = () => {
-      switch (this.trigger) {
-      case 'hover':
-        // this.valueComputed
+      if (['click', 'hover', 'none'].includes(this.trigger)) {
         return this.valueComputed
-      case 'click':
-        // this.valueComputed
-        return this.valueComputed
-      case 'none':
-        return this.valueComputed
-      default:
-        return false
       }
+      return false
     }
 
     const triggeredValue = getTriggeredValue()
@@ -124,10 +97,6 @@ export default class VaDropdown extends mixins(
   get showContent (): boolean {
     // the idea is to emit 'trigger' in any case
     const triggeredValue = this.triggeredValue
-
-    if (this.opened) {
-      return true
-    }
 
     return triggeredValue
   }
@@ -164,8 +133,6 @@ export default class VaDropdown extends mixins(
   }
 
   onAnchorClick (): void {
-    debugger
-    // only if click trigger
     if (this.disabled) {
       return
     }
@@ -174,10 +141,8 @@ export default class VaDropdown extends mixins(
         this.handleClick('anchor-click', this.closeOnAnchorClick)
         return
       }
-      // this.valueComputed = true
       this.valueComputed = true
     }
-    // this.valueComputed
 
     this.$emit('anchor-click')
   }
@@ -187,7 +152,6 @@ export default class VaDropdown extends mixins(
   // * Fast mouse-over shouldn't trigger dropdown.
   // * Dropdown shouldn't close when you move mouse from anchor to content (even with offset).
   onMouseOver (): void {
-    // only if trigger hover
     if (this.disabled) {
       return
     }
@@ -198,12 +162,6 @@ export default class VaDropdown extends mixins(
 
       this.hoverOutDebounceLoader.reset()
     }
-    // !this.valueComputed
-    if (!this.valueComputed) {
-      this.hoverOverDebounceLoader.run()
-    }
-
-    this.hoverOutDebounceLoader.reset()
   }
 
   onMouseOut (): void {
@@ -211,7 +169,6 @@ export default class VaDropdown extends mixins(
       if (this.isContentHoverable) {
         this.hoverOutDebounceLoader.run()
       } else {
-        // this.valueComputed = false
         this.valueComputed = false
       }
       this.hoverOverDebounceLoader.reset()
@@ -308,10 +265,8 @@ export default class VaDropdown extends mixins(
     watch(() => this.showContent, () => {
       this.handlePopperInstance()
     })
-
     this.hoverOverDebounceLoader = new DebounceLoader(
       async () => {
-        // this.valueComputed = true
         this.valueComputed = true
       },
       this.hoverOverTimeout,
@@ -319,7 +274,6 @@ export default class VaDropdown extends mixins(
     this.handlePopperInstance()
     this.hoverOutDebounceLoader = new DebounceLoader(
       async () => {
-        // this.valueComputed = true
         this.valueComputed = false
       },
       this.hoverOutTimeout,

--- a/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.vue
+++ b/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.vue
@@ -58,7 +58,7 @@ class DropdownProps {
   trigger = prop<string>({
     type: String,
     default: 'click',
-    validator: (trigger: string): boolean => ['click', 'hover', 'none'].includes(trigger),
+    validator: (trigger: string) => ['click', 'hover', 'none'].includes(trigger)
   })
   stateful = prop<boolean>({ type: Boolean, default: true })
 }
@@ -139,26 +139,25 @@ export default class VaDropdown extends mixins(
   // * Fast mouse-over shouldn't trigger dropdown.
   // * Dropdown shouldn't close when you move mouse from anchor to content (even with offset).
   onMouseOver (): void {
-    if (this.disabled) {
+    if (this.disabled || this.trigger !== 'hover') {
       return
     }
-    if (this.trigger === 'hover') {
-      if (!this.valueComputed) {
-        this.hoverOverDebounceLoader.run()
-      }
-      this.hoverOutDebounceLoader.reset()
+    if (!this.valueComputed) {
+      this.hoverOverDebounceLoader.run()
     }
+    this.hoverOutDebounceLoader.reset()
   }
 
   onMouseOut (): void {
-    if (this.trigger === 'hover') {
-      if (this.isContentHoverable) {
-        this.hoverOutDebounceLoader.run()
-      } else {
-        this.valueComputed = false
-      }
-      this.hoverOverDebounceLoader.reset()
+    if( this.trigger !== 'hover') {
+      return
     }
+    if (this.isContentHoverable) {
+      this.hoverOutDebounceLoader.run()
+    } else {
+      this.valueComputed = false
+    }
+    this.hoverOverDebounceLoader.reset()
   }
 
   registerClickOutsideListener (): void {

--- a/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.vue
+++ b/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.vue
@@ -15,7 +15,7 @@
         class="va-dropdown__content-wrapper"
         @mouseover="$props.isContentHoverable && onMouseOver()"
         @mouseout="onMouseOut()"
-        @click="$props.isContentClosable && onAnchorClick()"
+        @click="$props.closeOnClickInside && onAnchorClick()"
         ref="contentWrapper"
       >
         <div :style="$props.keepAnchorWidth ? anchorWidthStyles : ''">
@@ -49,10 +49,10 @@ class DropdownProps {
   keepAnchorWidth = prop<boolean>({ type: Boolean })
   // If set to false - dropdown won't dodge outside container.
   preventOverflow = prop<boolean>({ type: Boolean, default: false })
+  closeOnClickInside = prop<boolean>({ type: Boolean, default: true })
   closeOnClickOutside = prop<boolean>({ type: Boolean, default: true })
   closeOnAnchorClick = prop<boolean>({ type: Boolean, default: true })
   isContentHoverable = prop<boolean>({ type: Boolean, default: true })
-  isContentClosable = prop<boolean>({ type: Boolean, default: true })
   offset = prop<number | number[]>({ type: [Array, Number], default: () => [] })
   trigger = prop<string | number | any[]>({
     type: [Array, Number, String],

--- a/packages/ui/src/components/vuestic-components/va-popover/VaPopover.demo.vue
+++ b/packages/ui/src/components/vuestic-components/va-popover/VaPopover.demo.vue
@@ -152,7 +152,7 @@
             <va-popover
               placement="right"
               message="Popover dummy text"
-              opened
+              :modelValue="true"
             >
               <va-button>Hover me</va-button>
             </va-popover>

--- a/packages/ui/src/components/vuestic-components/va-popover/VaPopover.vue
+++ b/packages/ui/src/components/vuestic-components/va-popover/VaPopover.vue
@@ -7,8 +7,7 @@
     :hoverOverTimeout="$props.hoverOverTimeout"
     :hoverOutTimeout="$props.hoverOutTimeout"
     :close-on-click-outside="$props.autoHide"
-    :opened="initiallyOpened"
-    @trigger="handleTrigger"
+    :modelValue="modelValue"
   >
     <template #default>
       <div class="va-popover__content-wrapper">
@@ -59,12 +58,12 @@ import VaIcon from '../va-icon'
 import VaDropdown from '../va-dropdown'
 
 class PopoverProps {
+  modelValue = prop<boolean>({ type: Boolean })
   color = prop<string>({ type: String, default: 'success' })
   icon = prop<string>({ type: String, default: '' })
   title = prop<string>({ type: String, default: '' })
   message = prop<string>({ type: String, default: '' })
   trigger = prop<string>({ type: String, default: 'hover' })
-  opened = prop<boolean>({ type: Boolean, default: false })
   disabled = prop<boolean>({ type: Boolean, default: false })
   placement = prop<Placement>({
     type: String as PropType<Placement>,
@@ -100,17 +99,6 @@ export default class VaPopover extends mixins(
   ColorMixin,
   PopoverPropsMixin,
 ) {
-  private initiallyOpened = this.$props.opened
-  private initialHandleTriggerRun = true
-
-  handleTrigger () {
-    if (!this.initialHandleTriggerRun) {
-      this.initiallyOpened = false
-    }
-
-    this.initialHandleTriggerRun = false
-  }
-
   get computedPopoverStyle () {
     return {
       boxShadow: '0px 2px 3px 0 ' + getBoxShadowColor(this.theme.getColor(this.$props.color)),

--- a/packages/ui/src/components/vuestic-components/va-select/VaSelect.demo.vue
+++ b/packages/ui/src/components/vuestic-components/va-select/VaSelect.demo.vue
@@ -77,6 +77,13 @@
         hide-selected
       />
     </VbCard>
+    <VbCard title="html select for example">
+      <select>
+        <option value="one">one</option>
+        <option value="two">two</option>
+        <option value="three">three</option>
+      </select>
+    </VbCard>
     <VbCard
       title="Multi select"
       style="width: 400px;"

--- a/packages/ui/src/components/vuestic-components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/vuestic-components/va-select/VaSelect.vue
@@ -14,7 +14,7 @@
       :max-height="$props.maxHeight"
       :fixed="$props.fixed"
       :close-on-anchor-click="$props.multiple"
-      :close-on-click-inside="!$props.multiple"
+      :close-on-content-click="!$props.multiple"
       trigger="none"
       class="va-select__dropdown"
       keep-anchor-width

--- a/packages/ui/src/components/vuestic-components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/vuestic-components/va-select/VaSelect.vue
@@ -14,10 +14,12 @@
       :max-height="$props.maxHeight"
       :fixed="$props.fixed"
       :close-on-anchor-click="$props.multiple"
+      :close-on-click-inside="!$props.multiple"
       trigger="none"
       class="va-select__dropdown"
       keep-anchor-width
       boundary-body
+      :stateful=false
     >
       <template #anchor>
         <div
@@ -352,14 +354,13 @@ export default class VaSelect extends mixins(
   }
 
   selectOption (option: any): void {
-    const isSelected = this.checkIsOptionSelected(option)
-
     if (this.doShowSearchInput) {
-      (this as any).$refs.searchBar.focus()
       this.searchInputValue = ''
     }
 
     if (this.$props.multiple) {
+      const isSelected = this.checkIsOptionSelected(option)
+
       if (isSelected) {
         // Unselect
         this.valueComputed = this.valueComputed.filter((optionSelected: any) => !this.compareOptions(option, optionSelected))
@@ -517,7 +518,7 @@ export default class VaSelect extends mixins(
   hintedSearchQuery = ''
   hintedSearchQueryTimeoutIndex!: any
 
-  // Hinted serach - hover option if you typing it's value on select without search-bar
+  // Hinted search - hover option if you typing it's value on select without search-bar
   onHintedSearch (event: KeyboardEvent) {
     const isLetter: boolean = event.key.length === 1
     const isDeleteKey: boolean = event.key === 'Backspace' || event.key === 'Delete'

--- a/packages/ui/src/components/vuestic-components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/vuestic-components/va-select/VaSelect.vue
@@ -359,6 +359,7 @@ export default class VaSelect extends mixins(
 
   selectOption (option: any): void {
     if (this.doShowSearchInput) {
+      (this as any).$refs.searchBar.focus()
       this.searchInputValue = ''
     }
 
@@ -465,8 +466,9 @@ export default class VaSelect extends mixins(
     this.toggleDropdown()
 
     this.$nextTick(() => {
-      // We don't focus searchBar because it will mess up manual items selection from the bottom of the list
-      if (this.$refs.optionList) {
+      if (this.$refs.searchBar) {
+        (this.$refs as any).searchBar.focus()
+      } else if (this.$refs.optionList) {
         (this.$refs as any).optionList.focus()
       }
     })

--- a/packages/ui/src/components/vuestic-components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/vuestic-components/va-select/VaSelect.vue
@@ -14,7 +14,7 @@
       :max-height="$props.maxHeight"
       :fixed="$props.fixed"
       :close-on-anchor-click="$props.multiple"
-      :close-on-content-click="!$props.multiple"
+      :close-on-content-click="toClose()"
       trigger="none"
       class="va-select__dropdown"
       keep-anchor-width
@@ -325,6 +325,10 @@ export default class VaSelect extends mixins(
     return this.$props.options.find((option: any) => this.compareOptions(option, this.valueComputed))
   }
 
+  toClose (): boolean {
+    return !(this.$props.multiple || this.$props.searchable || this.$props.allowCreate)
+  }
+
   compareOptions (one: any, two: any) {
     // identity check works nice for strings and exact matches.
     if (one === two) {
@@ -454,19 +458,17 @@ export default class VaSelect extends mixins(
   }
 
   onSelectClick () {
+    // Temporary solution for disabled state before VaSelect refactor
+    if (this.$props.disabled) {
+      return
+    }
     this.toggleDropdown()
 
     this.$nextTick(() => {
+      // We don't focus searchBar because it will mess up manual items selection from the bottom of the list
       if (this.$refs.optionList) {
         (this.$refs as any).optionList.focus()
       }
-
-      // TODO: refactor focus event because when initial focus is on the searchBar items below in the list will not be selectable
-      // if (this.$refs.searchBar) {
-      //   (this.$refs as any).searchBar.focus()
-      // } else if (this.$refs.optionList) {
-      //   (this.$refs as any).optionList.focus()
-      // }
     })
   }
 

--- a/packages/ui/src/components/vuestic-components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/vuestic-components/va-select/VaSelect.vue
@@ -457,11 +457,16 @@ export default class VaSelect extends mixins(
     this.toggleDropdown()
 
     this.$nextTick(() => {
-      if (this.$refs.searchBar) {
-        (this.$refs as any).searchBar.focus()
-      } else if (this.$refs.optionList) {
+      if (this.$refs.optionList) {
         (this.$refs as any).optionList.focus()
       }
+
+      // TODO: refactor focus event because when initial focus is on the searchBar items below in the list will not be selectable
+      // if (this.$refs.searchBar) {
+      //   (this.$refs as any).searchBar.focus()
+      // } else if (this.$refs.optionList) {
+      //   (this.$refs as any).optionList.focus()
+      // }
     })
   }
 

--- a/packages/ui/src/components/vuestic-components/va-select/VaSelectOptionList/VaSelectOptionList.vue
+++ b/packages/ui/src/components/vuestic-components/va-select/VaSelectOptionList/VaSelectOptionList.vue
@@ -7,7 +7,6 @@
     @keydown.left.stop.prevent="hoverPreviousOption"
     @keydown.down.stop.prevent="hoverNextOption"
     @keydown.right.stop.prevent="hoverNextOption"
-    @focus="hoverFirstOption"
   >
     <template v-if="filteredOptions.length">
       <div


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Fix #789: Refactor Dropdown, closeOnContentClick prop, StatefulMixin are added
## Markup:
Now you could use closeOnContentClick as a flag to mark dropdown that should close its content on click.
Default behavior is set to close content on click.

VaButtonDropdown now uses model as described in our docs instead of not doing anything.

Also StatefulMixin is added to VaDropdown & VaButtonDropdown.

VaDropdown refactored - logic improved and simplified.
<details>

```vue
<va-button-dropdown
      color="primary"
      flat
      :label="currentLanguageName"
      :offset="[0, 25]"
      :isContentClosable="true"
    >
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
