### PR TITLE
feat: invisible prop for va-progress-bar and va-progress-circle (#802)

### DIFF
--- a/packages/docs/src/components/page-configs/ui-elements/va-progress-bar/api-options.ts
+++ b/packages/docs/src/components/page-configs/ui-elements/va-progress-bar/api-options.ts
@@ -9,6 +9,9 @@ export default {
     indeterminate: {
       local: true,
     },
+    invisible: {
+      local: true,
+    },
     buffer: {
       local: true,
     },

--- a/packages/docs/src/components/page-configs/ui-elements/va-progress-bar/page-config.ts
+++ b/packages/docs/src/components/page-configs/ui-elements/va-progress-bar/page-config.ts
@@ -42,6 +42,18 @@ export default [
   },
   {
     type: BlockType.HEADLINE,
+    translationString: 'progressBar.examples.visibility.title',
+  },
+  {
+    type: BlockType.PARAGRAPH,
+    translationString: 'progressBar.examples.visibility.text',
+  },
+  {
+    type: BlockType.EXAMPLE,
+    component: 'va-progress-bar/Visibility',
+  },
+  {
+    type: BlockType.HEADLINE,
     translationString: 'progressBar.examples.coloring.title',
   },
   {

--- a/packages/docs/src/components/page-configs/ui-elements/va-progress-circle/api-options.ts
+++ b/packages/docs/src/components/page-configs/ui-elements/va-progress-circle/api-options.ts
@@ -9,6 +9,9 @@ export default {
     indeterminate: {
       local: true,
     },
+    invisible: {
+      local: true,
+    },
     thickness: {
       local: true,
     },

--- a/packages/docs/src/components/page-configs/ui-elements/va-progress-circle/page-config.ts
+++ b/packages/docs/src/components/page-configs/ui-elements/va-progress-circle/page-config.ts
@@ -20,6 +20,11 @@ export default [
     'va-progress-circle/Indeterminate',
   ),
   ...DocsHelper.exampleBlock(
+    'progressCircle.examples.visibility.title',
+    'progressCircle.examples.visibility.text',
+    'va-progress-circle/Visibility',
+  ),
+  ...DocsHelper.exampleBlock(
     'progressCircle.examples.coloring.title',
     'progressCircle.examples.coloring.text',
     'va-progress-circle/Coloring',

--- a/packages/docs/src/examples/va-progress-bar/Visibility.vue
+++ b/packages/docs/src/examples/va-progress-bar/Visibility.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="flex lg6 xs12 py-4">
+    <va-checkbox
+      v-model="invisible"
+      label="Hide the large progress bar"
+    />
+    <br>
+    <va-progress-bar
+      :invisible="invisible"
+      size="large"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+export default {
+  data () {
+    return {
+      invisible: true,
+    }
+  },
+}
+</script>

--- a/packages/docs/src/examples/va-progress-circle/Visibility.vue
+++ b/packages/docs/src/examples/va-progress-circle/Visibility.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="flex lg6 xs12 py-4">
+    <va-checkbox
+      v-model="invisible"
+      label="Hide the progress circle"
+    />
+    <br>
+    <va-progress-circle
+      :modelValue="60"
+      :invisible="invisible"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+export default {
+  data () {
+    return {
+      invisible: true,
+    }
+  },
+}
+</script>

--- a/packages/docs/src/locales/en/en.json
+++ b/packages/docs/src/locales/en/en.json
@@ -496,6 +496,7 @@
       "props": {
         "value": "The progress value",
         "indeterminate": "Create a indeterminate loading bar",
+        "invisible": "Make the `va-progress-bar` component invisible (sets its `opacity` css property to `0` which allows to keep the space allocated for it in the layout even when the component is hidden)",
         "buffer": "Create a loading bar with a buffer. Commonly used in videos",
         "reverse": "Reverse the progress bar direction",
         "rounded": "Add a border radius to the `va-progress-bar` component (default: true)"
@@ -508,6 +509,7 @@
       "props": {
         "value": "The progress value",
         "indeterminate": "Using the `indeterminate` prop, the `va-progress-circle` continues to  animate indefinitely.",
+        "invisible": "Make the `va-progress-circle` component invisible (sets its `opacity` css property to `0` which allows to keep the space allocated for it in the layout even when the component is hidden)",
         "thickness": "Circle border size between 0 and 1"
       },
       "slots": {
@@ -1900,6 +1902,10 @@
         "title": "Indeterminate",
         "text": "Use the `indeterminate` prop so that the `va-progress-bar` continuously animates."
       },
+      "visibility": {
+        "title": "Visibility",
+        "text": "Use the `invisible` prop to hide the `va-progress-bar` while keeping the space for it in the layout."
+      },
       "coloring": {
         "title": "Coloring",
         "text": "Use predefined colors or use your own with the `color` prop."
@@ -1929,6 +1935,10 @@
       "indeterminate": {
         "title": "Indeterminate",
         "text": "Use the `indeterminate` prop so that the `va-progress-circle` continuously animates."
+      },
+      "visibility": {
+        "title": "Visibility",
+        "text": "Use the `invisible` prop to hide the `va-progress-circle` while keeping the space for it in the layout."
       },
       "coloring": {
         "title": "Coloring",

--- a/packages/ui/src/components/vuestic-components/va-progress-bar/VaProgressBar.demo.vue
+++ b/packages/ui/src/components/vuestic-components/va-progress-bar/VaProgressBar.demo.vue
@@ -12,6 +12,9 @@
         :rounded="false"
         :modelValue="value"
       />
+      <br>
+      Invisible
+      <va-progress-bar :invisible="invisible" />
     </VbCard>
 
     <VbCard title="Color">
@@ -52,6 +55,13 @@
         size="2rem"
         :modelValue="value"
       />
+      <br>
+      Size rem invisible
+      <va-progress-bar
+        size="2rem"
+        :modelValue="value"
+        :invisible="invisible"
+      />
     </VbCard>
 
     <VbCard title="Slotted">
@@ -79,6 +89,14 @@
       <br>
       Dynamic slot
       <va-progress-bar :modelValue="value">
+        {{ value + '%' }}
+      </va-progress-bar>
+      <br>
+      Invisible
+      <va-progress-bar
+        :modelValue="value"
+        :invisible="invisible"
+      >
         {{ value + '%' }}
       </va-progress-bar>
     </VbCard>
@@ -117,6 +135,14 @@
         :modelValue="value"
         :buffer="bufferValue"
       />
+      <br>
+      Invisible reversed buffer
+      <va-progress-bar
+        :modelValue="value"
+        :buffer="bufferValue"
+        :invisible="invisible"
+        reverse
+      />
     </VbCard>
 
     <VbCard title="context checks">
@@ -153,6 +179,12 @@
       <div>
         rounded (false):
         <VaContext :components="{VaProgressBar: {rounded: false}}">
+          <VaProgressBar />
+        </VaContext>
+      </div>
+      <div>
+        invisible (true):
+        <VaContext :components="{VaProgressBar: {invisible: true}}">
           <VaProgressBar />
         </VaContext>
       </div>
@@ -200,6 +232,14 @@
           +100
         </button>
       </div>
+      <br>
+      Invisible:
+      <div>
+        <input
+          type="checkbox"
+          v-model="invisible"
+        >
+      </div>
     </VbCard>
   </VbDemo>
 </template>
@@ -217,6 +257,7 @@ export default {
     return {
       bufferValue: 45,
       value: 35,
+      invisible: true,
     }
   },
 }

--- a/packages/ui/src/components/vuestic-components/va-progress-bar/VaProgressBar.vue
+++ b/packages/ui/src/components/vuestic-components/va-progress-bar/VaProgressBar.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="va-progress-bar">
+  <div
+    class="va-progress-bar"
+    :class="{ 'va-progress-bar--invisible': invisible }"
+  >
     <div
       :style="{colorComputed}"
       class="va-progress-bar__info"
@@ -58,6 +61,7 @@ class ProgressBarProps {
   size = prop<string | number>({ type: [Number, String], default: 'medium' })
   reverse = prop<boolean>({ type: Boolean, default: false })
   color = prop<string>({ type: String, default: 'primary' })
+  invisible = prop<boolean>({ type: Boolean, default: false })
 }
 
 const ProgressBarPropsMixin = Vue.with(ProgressBarProps)
@@ -117,6 +121,8 @@ export default class VaProgressBar extends mixins(
   width: var(--va-progress-bar-width);
   position: var(--va-progress-bar-position);
   overflow: var(--va-progress-bar-overflow);
+  opacity: var(--va-progress-bar-opacity);
+  transition: var(--va-progress-bar--invisible-transition);
 
   &__small {
     height: var(--va-progress-bar-sm-height);
@@ -124,6 +130,10 @@ export default class VaProgressBar extends mixins(
 
   &__large {
     height: var(--va-progress-bar-lg-height);
+  }
+
+  &--invisible {
+    opacity: var(--va-progress-bar-zero-opacity);
   }
 
   &__info {

--- a/packages/ui/src/components/vuestic-components/va-progress-bar/VaProgressCircle.demo.vue
+++ b/packages/ui/src/components/vuestic-components/va-progress-bar/VaProgressCircle.demo.vue
@@ -9,6 +9,13 @@
         Value
         <VaProgressCircle :modelValue="value" />
       </div>
+      <div>
+        Invisible
+        <VaProgressCircle
+          :modelValue="value"
+          :invisible="invisible"
+        />
+      </div>
     </VbCard>
 
     <VbCard title="Slotted">
@@ -27,6 +34,15 @@
       <div>
         Indeterminate Slot:
         <VaProgressCircle indeterminate>
+          {{ value + '%' }}
+        </VaProgressCircle>
+      </div>
+      <div>
+        Invisible with Dynamic Slot:
+        <VaProgressCircle
+          :modelValue="value"
+          :invisible="invisible"
+        >
           {{ value + '%' }}
         </VaProgressCircle>
       </div>
@@ -118,6 +134,12 @@
           <VaProgressCircle :modelValue="value" />
         </VaContext>
       </div>
+      <div>
+        invisible (true):
+        <VaContext :components="{VaProgressCircle: {invisible: true}}">
+          <VaProgressCircle :modelValue="60" />
+        </VaContext>
+      </div>
     </VbCard>
 
     <VbCard title="controls">
@@ -134,6 +156,13 @@
       <button @click="value += 100">
         +100
       </button>
+      <div>
+        <input
+          type="checkbox"
+          v-model="invisible"
+        >
+        Invisible
+      </div>
     </VbCard>
   </VbDemo>
 </template>
@@ -150,6 +179,7 @@ export default {
   data () {
     return {
       value: 35,
+      invisible: true,
     }
   },
 }

--- a/packages/ui/src/components/vuestic-components/va-progress-bar/VaProgressCircle.vue
+++ b/packages/ui/src/components/vuestic-components/va-progress-bar/VaProgressCircle.vue
@@ -40,6 +40,7 @@ import { SizeMixin } from '../../../mixins/SizeMixin'
 class ProgressCircleProps {
   thickness = prop<number>({ type: Number, default: 0.06 })
   color = prop<string>({ type: String, default: 'primary' })
+  invisible = prop<boolean>({ type: Boolean, default: false })
 }
 
 const ProgressCirclePropsMixin = Vue.with(ProgressCircleProps)
@@ -76,6 +77,7 @@ export default class VaProgressCircle extends mixins(
   get computedClass () {
     return {
       'va-progress-circle--indeterminate': this.indeterminate,
+      'va-progress-circle--invisible': this.invisible,
     }
   }
 
@@ -104,6 +106,12 @@ export default class VaProgressCircle extends mixins(
 .va-progress-circle {
   position: var(--va-progress-circle-position);
   overflow: var(--va-progress-circle-overflow); // Prevents resizing container back and forth.
+  opacity: var(--va-progress-circle-opacity);
+  transition: var(--va-progress-circle--invisible-transition);
+
+  &--invisible {
+    opacity: var(--va-progress-circle-zero-opacity);
+  }
 
   &__wrapper {
     position: var(--va-progress-circle-wrapper-position);

--- a/packages/ui/src/components/vuestic-components/va-progress-bar/_variables.scss
+++ b/packages/ui/src/components/vuestic-components/va-progress-bar/_variables.scss
@@ -2,12 +2,17 @@
   --va-progress-bar-width: 100%;
   --va-progress-bar-position: relative;
   --va-progress-bar-overflow: hidden;
+  --va-progress-bar-opacity: 1;
+  --va-progress-bar--invisible-transition: opacity ease 1s;
 
   /* Small */
   --va-progress-bar-sm-height: 2px;
 
   /* Large */
   --va-progress-bar-lg-height: 16px;
+
+  /* Invisible */
+  --va-progress-bar-zero-opacity: 0;
 
   /* Info */
   --va-progress-bar-info-font-weight: 700;

--- a/packages/ui/src/components/vuestic-components/va-progress-bar/_variables.scss
+++ b/packages/ui/src/components/vuestic-components/va-progress-bar/_variables.scss
@@ -49,6 +49,11 @@
   /* Circle */
   --va-progress-circle-position: relative;
   --va-progress-circle-overflow: hidden;
+  --va-progress-circle-opacity: 1;
+  --va-progress-circle--invisible-transition: opacity ease 1s;
+
+  /* Invisible */
+  --va-progress-circle-zero-opacity: 0;
 
   /* Circle Wrapper */
   --va-progress-circle-wrapper-position: absolute;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail -->
This PR adds an `invisible` prop to both the `va-progress-bar` and `va-progress-circle` components. The prop allows to hide/show a component it's applied to by toggling the `opacity` css property which allows to show/hide a corresponding element on a page without runtime-layout-corruption (other elements on the page jumping/moving).

Also provided demos for the `:book` mode and updated the docs' example sections for the both components, though couldn't managed to update the API sections for some reason, therefore **need help** with that.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
