### PR TITLE
fix: va-button clickable area

### DIFF
--- a/packages/ui/src/components/vuestic-components/va-button/VaButton.vue
+++ b/packages/ui/src/components/vuestic-components/va-button/VaButton.vue
@@ -19,11 +19,11 @@
     :tabindex="loading ? -1 : 0"
     @mouseenter="updateHoverState(true)"
     @mouseleave="updateHoverState(false)"
+    v-on="inputListeners"
   >
     <div
       class="va-button__content"
       :class="{'va-button__content--loading': loading}"
-      v-on="inputListeners"
     >
       <va-icon
         v-if="icon"


### PR DESCRIPTION
Fix #822.

The `v-on="inputListeners"` used to be attached to the contents block (which is basically the button's text (usually)) and not to the button element itself. Changed the behavior and it seems working as intended to.

Was it some kind of a mistake/typo or am I missing something?