### PR TITLE
fix: #787 (fix horiz. scroll for tables in docs)

### DIFF
--- a/packages/docs/src/components/DocsExample.vue
+++ b/packages/docs/src/components/DocsExample.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="mb-3">
-    <component :is="component" />
+    <div class="docs-example__addressable-component">
+      <component :is="component" />
+    </div>
     <template v-if="!exampleOptions.hideCode">
       <va-button class="mt-2 d-block docs-example__show-code-button" style="background: transparent !important; box-shadow: none !important;" :rounded="false" flat size="small" color="primary" @click="showCode = !showCode">
         {{ $t('docsExample.showCode') }}
@@ -96,6 +98,10 @@ export default {
 
 <style lang="scss">
 .docs-example {
+  &__addressable-component {
+    overflow: auto;
+  }
+  
   &__code {
     &--with-margin {
       margin-bottom: 0.2rem !important;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Added a wrapper-element with `overflow: auto` to wrap addressable components in docs' examples. This allows to horizontally scroll content (e.g. tables) if it doesn't fit a small screen. See #787 for details.

```vue
// Your code
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
