### PR TITLE
fix: #844 don't use <a> for collapse custom headers in docs' sidebar

### DIFF
--- a/packages/docs/src/components/sidebar/Sidebar.vue
+++ b/packages/docs/src/components/sidebar/Sidebar.vue
@@ -9,10 +9,10 @@
       >
         <template #header="{ value, hasKeyboardFocus }">
           <div
-            class="collapse-custom-header"
+            class="sidebar__collapse-custom-header"
             :class="{
-              'collapse-custom-header--active': isRouteHasActiveChild(route),
-              'collapse-custom-header--keyboard-focused': hasKeyboardFocus
+              'sidebar__collapse-custom-header--active': isRouteHasActiveChild(route),
+              'sidebar__collapse-custom-header--keyboard-focused': hasKeyboardFocus
             }"
           >
             {{ $t(route.displayName) }}
@@ -127,7 +127,8 @@ export default class Sidebar extends Vue.with(Props) {
 <style lang="scss" scoped>
 @import "~vuestic-ui/src/components/vuestic-sass/resources/resources.scss";
 
-  .collapse-custom-header {
+.sidebar {
+  &__collapse-custom-header {
     padding: 1rem 1.2rem;
     display: flex;
     justify-content: space-between;
@@ -151,56 +152,57 @@ export default class Sidebar extends Vue.with(Props) {
     }
   }
 
-.va-sidebar {
-  z-index: 1;
-  height: 100%;
-  min-width: 16rem;
-  color: var(--va-dark, #323742);
+  .va-sidebar {
+    z-index: 1;
+    height: 100%;
+    min-width: 16rem;
+    color: var(--va-dark, #323742);
 
-  &.va-sidebar--hidden {
-    min-width: 0;
-  }
-
-  @include media-breakpoint-down(xs) {
-    z-index: 100;
-    position: absolute;
-  }
-
-  .va-sidebar-item-content {
-    cursor: pointer;
-  }
-
-  .va-sidebar-item {
-    cursor: pointer;
-  }
-
-  .va-sidebar-item-title {
-    font-weight: 500;
-    font-size: 16px;
-    line-height: 20px;
-  }
-
-  .va-sidebar-item--active {
-    color: var(--primary, #4591e3);
-
-    .va-sidebar-item-title {
-      color: var(--primary, #4591e3);
+    &.va-sidebar--hidden {
+      min-width: 0;
     }
-  }
 
-  &__child {
-    &__label {
-      padding-left: 2rem;
-      text-align: left;
+    @include media-breakpoint-down(xs) {
+      z-index: 100;
+      position: absolute;
     }
 
     .va-sidebar-item-content {
-      padding-left: 3rem;
+      cursor: pointer;
     }
 
-    &:first-child {
-      .va-sidebar__child__label {
-        padding-top: 0;
+    .va-sidebar-item {
+      cursor: pointer;
+    }
+
+    .va-sidebar-item-title {
+      font-weight: 500;
+      font-size: 16px;
+      line-height: 20px;
+    }
+
+    .va-sidebar-item--active {
+      color: var(--primary, #4591e3);
+
+      .va-sidebar-item-title {
+        color: var(--primary, #4591e3);
+      }
+    }
+
+    &__child {
+      &__label {
+        padding-left: 2rem;
+        text-align: left;
+      }
+
+      .va-sidebar-item-content {
+        padding-left: 3rem;
+      }
+
+      &:first-child {
+        .va-sidebar__child__label {
+          padding-top: 0;
+        }
       }
     }
   }

--- a/packages/docs/src/components/sidebar/Sidebar.vue
+++ b/packages/docs/src/components/sidebar/Sidebar.vue
@@ -16,7 +16,7 @@
             }"
           >
             {{ $t(route.displayName) }}
-            <va-icon v-if="route.children" :name="value ? 'expand_less' : 'expand_more'" />
+            <va-icon :name="value ? 'expand_less' : 'expand_more'" />
           </div>
         </template>
         <div

--- a/packages/docs/src/components/sidebar/Sidebar.vue
+++ b/packages/docs/src/components/sidebar/Sidebar.vue
@@ -7,15 +7,17 @@
         v-for="(route, key) in navigationRoutes"
         :key="key"
       >
-        <template #header="{ value }">
-          <va-sidebar-item :activeColor="activeColor" @keydown.stop>
-            <va-sidebar-item-content :class="{ 'va-sidebar-item--active': isRouteHasActiveChild(route) }">
-              <va-sidebar-item-title>
-                {{ $t(route.displayName) }}
-              </va-sidebar-item-title>
-              <va-icon v-if="route.children" :name="value ? 'expand_less' : 'expand_more'" />
-            </va-sidebar-item-content>
-          </va-sidebar-item>
+        <template #header="{ value, hasKeyboardFocus }">
+          <div
+            class="collapse-custom-header"
+            :class="{
+              'collapse-custom-header--active': isRouteHasActiveChild(route),
+              'collapse-custom-header--keyboard-focused': hasKeyboardFocus
+            }"
+          >
+            {{ $t(route.displayName) }}
+            <va-icon v-if="route.children" :name="value ? 'expand_less' : 'expand_more'" />
+          </div>
         </template>
         <div
           v-for="(childRoute, index) in route.children"
@@ -124,6 +126,30 @@ export default class Sidebar extends Vue.with(Props) {
 
 <style lang="scss" scoped>
 @import "~vuestic-ui/src/components/vuestic-sass/resources/resources.scss";
+
+  .collapse-custom-header {
+    padding: 1rem 1.2rem;
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    height: 56px;
+    font-weight: 500;
+    font-size: 16px;
+    line-height: 20px;
+    cursor: pointer;
+
+    &:hover {
+      background-color: rgba(184, 201, 236, 0.2);
+    }
+
+    &--active {
+      color: var(--primary, #4591e3);
+    }
+
+    &--keyboard-focused {
+      background-color: rgba(184, 201, 236, 0.2);
+    }
+  }
 
 .va-sidebar {
   z-index: 1;

--- a/packages/ui/src/components/vuestic-components/va-collapse/VaCollapse.vue
+++ b/packages/ui/src/components/vuestic-components/va-collapse/VaCollapse.vue
@@ -9,7 +9,7 @@
       @keydown.space="changeValue()"
       :tabindex="collapseIndexComputed"
     >
-      <slot name="header" v-bind="{ value: valueProxy }">
+      <slot name="header" v-bind="{ value: valueProxy, hasKeyboardFocus: SetupContext.hasKeyboardFocus }">
         <div
           class="va-collapse__header__content"
           :style="contentStyle"


### PR DESCRIPTION
closes #844 

This also fixes the keyboard-tab'ing issue.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
