### PR TITLE
Fix #847: VaSelect searchBar focus won't scroll up

### DIFF
--- a/packages/ui/src/components/vuestic-components/va-input/VaInput.vue
+++ b/packages/ui/src/components/vuestic-components/va-input/VaInput.vue
@@ -246,7 +246,7 @@ export default class VaInput extends mixins(
   /** @public */
   focus (): void {
     if (this.$refs.input) {
-      (this as any).$refs.input.focus()
+      (this as any).$refs.input.focus({ preventScroll: true })
     } else if (this.$refs.textarea) {
       (this as any).$refs.textarea.focus()
     } else if (!this.$slots.content) {

--- a/packages/ui/src/components/vuestic-components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/vuestic-components/va-select/VaSelect.vue
@@ -13,7 +13,6 @@
       :disabled="$props.disabled"
       :max-height="$props.maxHeight"
       :fixed="$props.fixed"
-      :close-on-anchor-click="$props.multiple"
       :close-on-content-click="toClose()"
       trigger="none"
       class="va-select__dropdown"
@@ -359,7 +358,7 @@ export default class VaSelect extends mixins(
 
   selectOption (option: any): void {
     if (this.doShowSearchInput) {
-      (this as any).$refs.searchBar.focus()
+      (this as any).$refs.searchBar.focus({ preventScroll: true })
       this.searchInputValue = ''
     }
 


### PR DESCRIPTION
## Description
close #847

Selecting an item from VaSelect options list will not scroll up to the top anymore,

It will be a lot easier to keep selecting other items when "multiple" prop is set to true.

</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
