### PR TITLE
Fix docs locale

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -27,7 +27,6 @@
     "vue": "^3.0.5",
     "vue-gtm": "^3.5.0",
     "vue-i18n": "^9.0.0-rc.6",
-    "vue-lang-router": "^2.1.1",
     "vue-meta": "^3.0.0-alpha.5",
     "vue-prism-component": "^2.0.0",
     "vue-router": "^4.0.3"

--- a/packages/docs/src/components/header/components/LanguageDropdown.vue
+++ b/packages/docs/src/components/header/components/LanguageDropdown.vue
@@ -7,7 +7,7 @@
       :offset="[0, 25]"
     >
       <div class="language-dropdown__content">
-        <!-- <va-list-item
+        <va-list-item
           v-for="(option, id) in options"
           :key="id"
           class="language-dropdown__item row align--center py-2"
@@ -17,7 +17,7 @@
           <va-list-item-section :style="{color: colors.primary}">
             <span class="dropdown-item__text">{{ option.name }}</span>
           </va-list-item-section>
-        </va-list-item> -->
+        </va-list-item>
         <va-list-item class="language-dropdown__item row align--center py-2">
           <va-list-item-section>
             <router-link :to="`/${locale}/contribution/translation`" class="dropdown-item__text" :style="{color: colors.primary}">{{t('landing.header.buttons.translation')}}</router-link>
@@ -32,14 +32,32 @@
 import { computed, defineComponent } from 'vue'
 import { getColors } from 'vuestic-ui/src/main'
 import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
+import { languages } from './../../languages'
 
 export default defineComponent({
   setup () {
-    // const options = languages
-    const options = [{ name: 'English', code: 'en' }]
     const { locale, t } = useI18n()
+    const router = useRouter()
 
-    const setLanguage = (local: string) => null
+    const getCurrentPathWithoutLocale = () => {
+      const path = router.currentRoute.value.fullPath
+      const localeUrlPart = `/${locale.value}`
+
+      if (path.slice(0, localeUrlPart.length) === localeUrlPart) { return path.slice(localeUrlPart.length) }
+
+      return path
+    }
+
+    const setLanguage = (newLocale: string) => {
+      if (locale.value === newLocale) { return }
+
+      const currentPathWithoutLocale = getCurrentPathWithoutLocale()
+
+      router.push('/' + newLocale + currentPathWithoutLocale)
+    }
+
+    const options = languages
     const colors = computed(getColors)
     const currentLanguageName = computed(() => options.find(({ code }) => code === locale.value)?.name)
 

--- a/packages/docs/src/components/languages.ts
+++ b/packages/docs/src/components/languages.ts
@@ -3,9 +3,9 @@ export const languages = [
     code: 'en',
     name: 'English',
   },
-  {
-    code: 'es',
-    name: 'Español',
-  },
+  // {
+  //   code: 'es',
+  //   name: 'Español',
+  // },
   // GENERATOR_ADD - language
 ]

--- a/packages/docs/src/helpers/I18nHelper.ts
+++ b/packages/docs/src/helpers/I18nHelper.ts
@@ -1,13 +1,6 @@
-import { I18n, VueI18n } from 'vue-i18n'
-import { i18n as i18nInstance } from 'vue-lang-router'
+import { i18n } from './../main'
 
-export const instance: I18n = i18nInstance
-export const i18n: VueI18n = instance.global
-
-// Aliases
-export const t = i18n.t
-export const te = i18n.te
-export const locale = i18n.locale
+export const { locale, te, t } = i18n.global
 
 // Helpers
 /**

--- a/packages/docs/src/layouts/default.vue
+++ b/packages/docs/src/layouts/default.vue
@@ -29,7 +29,7 @@
 <!--        </va-breadcrumbs>-->
 
         <div class="layout gutter--xl">
-          <router-view/>
+          <router-view />
         </div>
       </div>
     </main>
@@ -142,8 +142,6 @@ export default class DocsLayout extends Vue {
 
   onRouteChange () {
     const pageContent: Element | undefined = this.$refs['page-content']
-
-    pageContent.scrollTop = 0
 
     if (pageContent) {
       pageContent.scrollTop = 0

--- a/packages/docs/src/locales/index.ts
+++ b/packages/docs/src/locales/index.ts
@@ -1,12 +1,8 @@
 import { languages } from '../components/languages'
 
-const translations = languages.reduce((result, { code, name }) => ({
+export const messages = languages.reduce((result, { code, name }) => ({
   ...result,
-  [code]: {
-    name,
-    messages: require(`./${code}/${code}.json`),
-    // load: () => import(`./${code}/${code}.json`),
-  },
+  [code]: require(`./${code}/${code}.json`),
 }), {})
 
-export default translations
+export const DEFAULT_LANGUAGE = 'en'

--- a/packages/docs/src/main.ts
+++ b/packages/docs/src/main.ts
@@ -1,7 +1,8 @@
 import { createApp } from 'vue'
 import App from './App.vue'
-import router from './router'
-import { i18n } from 'vue-lang-router'
+import { router } from './router'
+import { createI18n } from 'vue-i18n'
+import { messages, DEFAULT_LANGUAGE } from './locales'
 
 // plugin to change algolia colors according docs theme
 import AlgoliaColorPlugin from './components/sidebar/algolia-search/algolia-color-plugin'
@@ -9,6 +10,8 @@ import { VuesticPlugin } from 'vuestic-ui/src/main'
 import { VuesticConfig } from './config/vuestic-config'
 import { useGtag } from './services/gtag'
 import { useMeta } from '@/services/vue-meta'
+
+export const i18n = createI18n({ locale: 'en', messages })
 
 const app = createApp(App)
 
@@ -21,3 +24,13 @@ useMeta(app)
 useGtag(app, router)
 
 app.mount('#app')
+
+// Update i18n locale if needed.
+router.beforeEach((to) => {
+  const newLocale = to.params.locale as string || DEFAULT_LANGUAGE
+  const currentLocale = i18n.global.locale
+
+  if (newLocale === currentLocale) { return }
+
+  i18n.global.locale = newLocale
+})

--- a/packages/docs/src/router/index.ts
+++ b/packages/docs/src/router/index.ts
@@ -1,14 +1,14 @@
-import { createWebHistory } from 'vue-router'
-import { createLangRouter } from 'vue-lang-router'
+import { createWebHistory, createRouter, RouterView } from 'vue-router'
 import routes from 'vue-auto-routing'
-import translations from '../locales'
 
-const langRouterOptions = {
-  defaultLanguage: 'en',
-  translations,
-}
+/**
+ * We can not use aliases because then we lose the opportunity to update the route path.
+ * If "/en" is the alias of "/" then switching from "/" to "/en" will be the same route.
+ *
+ * https://github.com/vuejs/vue-router-next/issues/613
+ */
 
-const routerOptions = {
+export const router = createRouter({
   history: createWebHistory(process.env.BASE_URL),
   routes: [
     {
@@ -18,12 +18,11 @@ const routerOptions = {
       children: routes,
     },
     {
-      path: '/:pathMatch(.*)*',
-      redirect: '/',
+      path: '/:locale/',
+      component: () => import(/* webpackChunkName: "router-layout" */ './RouterLayout.vue'),
+
+      // Remove name from routes to avoid named routes duplicates.
+      children: routes.map((r) => ({ ...r, name: undefined })),
     },
   ],
-}
-
-const router = createLangRouter(langRouterOptions, routerOptions)
-
-export default router
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -3786,7 +3786,7 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
-asva-executors@^0.1.26:
+asva-executors@^0.1.23, asva-executors@^0.1.26:
   version "0.1.26"
   resolved "https://registry.yarnpkg.com/asva-executors/-/asva-executors-0.1.26.tgz#65616ed81bd5507d68f3e8d75bf301ea3b133946"
   integrity sha512-bOLod5SbkGmbC3WibShO2LNjtNAmQDpgVNqG8zFLc4Ksb71q9uTBe3anPwhlJs9YflfLycTPjou5yCmg6LFTaA==
@@ -17096,7 +17096,7 @@ vue-hot-reload-api@^2.3.0:
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz#532955cc1eb208a3d990b3a9f9a70574657e08f2"
   integrity sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==
 
-vue-i18n@^9.0.0, vue-i18n@^9.0.0-rc.6:
+vue-i18n@^9.0.0-rc.6:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-9.0.0.tgz#a04c41d5ed3d5a068e923517bfaa0abcbc84e174"
   integrity sha512-iks0eJDv/4cK/7tl/ooMUroNVVIGOK4kKS1PIHmPQk7QjT/sDfFM84vjPKgpARbw0GjJsOiADL43jufNfs9e9A==
@@ -17115,16 +17115,6 @@ vue-jest@^5.0.0-alpha.7:
     convert-source-map "^1.6.0"
     extract-from-css "^0.4.4"
     tsconfig "^7.0.0"
-
-vue-lang-router@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/vue-lang-router/-/vue-lang-router-2.1.1.tgz#b4bc517643bd001ec3b1c6a4afcc32c28a946083"
-  integrity sha512-N4QSFU12yvGira3zbeUk2/lPfUj4tuzLJNwgI44DZCZCO2kyj6FTJc+nFhrh1fyHmH/acgW4JbIrdOOFQU9ZFA==
-  dependencies:
-    core-js "^3.6.5"
-    vue "^3.0.5"
-    vue-i18n "^9.0.0"
-    vue-router "^4.0.2"
 
 "vue-loader-v15@npm:vue-loader@^15.9.6":
   version "15.9.6"
@@ -17181,7 +17171,7 @@ vue-router@^4.0.0:
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-4.0.6.tgz#91750db507d26642f225b0ec6064568e5fe448d6"
   integrity sha512-Y04llmK2PyaESj+N33VxLjGCUDuv9t4q2OpItEGU7POZiuQZaugV6cJpE6Qm1sVFtxufodLKN2y2dQl9nk0Reg==
 
-vue-router@^4.0.0-0, vue-router@^4.0.0-beta.13, vue-router@^4.0.2, vue-router@^4.0.3:
+vue-router@^4.0.0-0, vue-router@^4.0.0-beta.13, vue-router@^4.0.3:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-4.0.5.tgz#dd0a4134bc950c37aef64b973e9ee1008428d8fa"
   integrity sha512-AQq+pllb6FCc7rS6vh4PPcce3XA1jgK3hKNkQ4hXHwoVN7jOeAOMKCnX7XAX3etV9rmN7iNW8iIwgPk95ckBjw==
@@ -17212,6 +17202,30 @@ vuelidate@^0.7.5:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/vuelidate/-/vuelidate-0.7.6.tgz#84100c13b943470660d0416642845cd2a1edf4b2"
   integrity sha512-suzIuet1jGcyZ4oUSW8J27R2tNrJ9cIfklAh63EbAkFjE380iv97BAiIeolRYoB9bF9usBXCu4BxftWN1Dkn3g==
+
+vuestic-ui@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/vuestic-ui/-/vuestic-ui-1.0.0.tgz#8f52485fe1f6e01ddb407ddfa180ee57dff4782e"
+  integrity sha512-DPWkP5Kw8f56YORCv0u7qH8kTXPR3geK49GwEiyA8GnHHiT4F8UUgQ3RclGzUP0XeAtu5eE14imCubVas+Y78g==
+  dependencies:
+    "@popperjs/core" "^2.9.2"
+    asva-executors "^0.1.23"
+    cleave.js "^1.6.0"
+    colortranslator "^1.7.1"
+    css-minimizer-webpack-plugin "^3.0.0"
+    detect-browser "^5.2.0"
+    element-resize-detector "^1.2.1"
+    flatpickr "4.6.9"
+    gravatar "^1.8.0"
+    lodash "^4.17.20"
+    normalize.css "^8.0.1"
+    spa-http-server "^0.9.0"
+    v-tooltip "^2.1.2"
+    vue "^3.0.4"
+    vue-color "^2.8.1"
+    vue-epic-bus "^0.1.5"
+    vue-flatpickr-component "^9.0.3"
+    vue-router "^4.0.0-beta.13"
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
closes #645

This PR removes the `vue-lang-router` dependency. 

It seems like this dependency is a great solution for vue2, but not for vue3. Because this dependency works with aliases, it uses hacks and works incorrectly anyway. In `vue-router` you can not simply change the route to its alias for some reason. So I decided to simply copy routes, without aliases. Also, `vue-lang-router` has poor support and don't have updates for a 3 month.

Also, in this PR dropdown with English and Español languages become shown. Because this PR fixes localizations I returned this dropdown back. 

We can temporarily remove Español language by just commenting it here packages/docs/src/components/languages.ts

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
