### PR TITLE
#862 Fixed multiline button and removed unnecessary sccs variable

### DIFF
--- a/packages/docs/src/utilities/markdown-view/MarkdownView.vue
+++ b/packages/docs/src/utilities/markdown-view/MarkdownView.vue
@@ -39,6 +39,7 @@ export default class MarkdownView extends mixins(PropsMixin) {
 
 .MarkdownView {
   code {
+    margin: 0 0.3rem;
     color: $markdown-code;
   }
 }

--- a/packages/ui/src/components/vuestic-components/va-badge/VaBadge.vue
+++ b/packages/ui/src/components/vuestic-components/va-badge/VaBadge.vue
@@ -89,7 +89,6 @@ export default class VaBadge extends mixins(
     display: var(--va-badge-text-wrapper-display);
     border: var(--va-badge-text-wrapper-border, var(--va-control-border));
     border-radius: var(--va-badge-text-wrapper-border-radius);
-    font-size: var(--va-badge-text-wrapper-font-size);
     font-weight: var(--va-badge-text-wrapper-font-weight);
     font-family: var(--va-badge-text-wrapper-font-family, var(--va-font-family));
     line-height: var(--va-badge-text-wrapper-line-height);
@@ -182,6 +181,7 @@ export default class VaBadge extends mixins(
     justify-content: center;
     text-overflow: clip;
     white-space: nowrap;
+    font-size: var(--va-badge-font-size);
 
     .va-badge--multiLine & {
       overflow: auto;

--- a/packages/ui/src/components/vuestic-components/va-badge/_variables.scss
+++ b/packages/ui/src/components/vuestic-components/va-badge/_variables.scss
@@ -18,7 +18,6 @@
   --va-badge-text-wrapper-display: inline-flex;
   --va-badge-text-wrapper-border: solid 0.125rem;
   --va-badge-text-wrapper-border-radius: 0.6rem;
-  --va-badge-text-wrapper-font-size: 0.625rem;
   --va-badge-text-wrapper-font-weight: 700;
   --va-badge-text-wrapper-font-family: 'Source Sans Pro', sans-serif;
   --va-badge-text-wrapper-line-height: 1.4;

--- a/packages/ui/src/components/vuestic-components/va-button/VaButton.demo.vue
+++ b/packages/ui/src/components/vuestic-components/va-button/VaButton.demo.vue
@@ -480,6 +480,23 @@
             </va-button>
           </td>
         </tr>
+
+        <tr>
+          <td>
+            Multiline text
+          </td>
+          <td style="padding-top: 10px;">
+            <va-button style="width: 150px;">
+              Default Button with long text
+            </va-button>
+            <va-button size="large" style="width: 150px;">
+              Large Button with long text
+            </va-button>
+            <va-button size="small" style="width: 150px;">
+              Small Button with long text
+            </va-button>
+          </td>
+        </tr>
       </table>
     </VbCard>
   </VbDemo>

--- a/packages/ui/src/components/vuestic-components/va-button/VaButton.vue
+++ b/packages/ui/src/components/vuestic-components/va-button/VaButton.vue
@@ -341,7 +341,7 @@ export default class VaButton extends mixins(
     @include va-button(var(--va-button-lg-content-py), var(--va-button-lg-content-px), var(--va-button-lg-font-size), var(--va-button-lg-line-height), var(--va-button-lg-border-radius));
 
     letter-spacing: var(--va-button-lg-letter-spacing);
-    height: var(--va-button-lg-size);
+    min-height: var(--va-button-lg-size);
     min-width: var(--va-button-lg-size);
 
     .va-button__content {
@@ -375,7 +375,7 @@ export default class VaButton extends mixins(
     @include va-button(var(--va-button-sm-content-py), var(--va-button-sm-content-px), var(--va-button-sm-font-size), var(--va-button-sm-line-height), var(--va-button-sm-border-radius));
 
     letter-spacing: var(--va-button-sm-letter-spacing);
-    height: var(--va-button-sm-size);
+    min-height: var(--va-button-sm-size);
     min-width: var(--va-button-sm-size);
 
     .va-button__content {
@@ -409,7 +409,7 @@ export default class VaButton extends mixins(
     @include va-button(var(--va-button-content-py), var(--va-button-content-px), var(--va-button-font-size), var(--va-button-line-height), var(--va-button-border-radius));
 
     letter-spacing: var(--va-button-letter-spacing, var(--va-letter-spacing));
-    height: var(--va-button-size);
+    min-height: var(--va-button-size);
     min-width: var(--va-button-size);
 
     .va-button__content {


### PR DESCRIPTION
close #862 
close #791 

va-button should  display multiline text without errors now.

Also I removed the variable --va-badge-text-wrapper-font-size, it is not needed because --va-badge-font-size does the same

Added indentation for code elements in a paragraph