### PR TITLE
fixed VaDropdown when v-model true by default

### DIFF
--- a/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.demo.vue
+++ b/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.demo.vue
@@ -152,6 +152,17 @@
       </va-dropdown>
     </VbCard>
 
+    <VbCard title="Anchor width with v-model true by default">
+      <va-dropdown v-model="anchorDefaultValue" keep-anchor-width>
+        <template #anchor>
+          <button>
+            ------- Anchor ------
+          </button>
+        </template>
+        Same width as anchor
+      </va-dropdown>
+    </VbCard>
+
     <VbCard title="Disabled">
       <va-dropdown disabled>
         <template #anchor>
@@ -355,6 +366,7 @@ export default {
       eventsValue: false,
       logEvents: false,
       redrawContentSize: 100,
+      anchorDefaultValue: true,
     }
   },
 }

--- a/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.vue
+++ b/packages/ui/src/components/vuestic-components/va-dropdown/VaDropdown.vue
@@ -74,7 +74,7 @@ export default class VaDropdown extends mixins(
   DropdownPropsMixin,
 ) {
   popperInstance: PopperInstance = null
-  anchorWidth!: number
+  anchorWidth = 0
   hoverOverDebounceLoader!: DebounceLoader
   hoverOutDebounceLoader!: DebounceLoader
 
@@ -256,7 +256,6 @@ export default class VaDropdown extends mixins(
       },
       this.hoverOverTimeout,
     )
-    this.handlePopperInstance()
     this.hoverOutDebounceLoader = new DebounceLoader(
       async () => {
         this.valueComputed = false
@@ -268,6 +267,10 @@ export default class VaDropdown extends mixins(
       return
     }
     this.registerClickOutsideListener()
+  }
+
+  mounted (): void {
+    this.handlePopperInstance()
   }
 
   beforeUnmount (): void {


### PR DESCRIPTION
close #900 

## Description
The bug occurred when the default v-model was true and the keep-anchor-width prop was set.

It was:
<img width="868" alt="Снимок экрана 2021-06-30 в 09 55 37" src="https://user-images.githubusercontent.com/20461547/123916547-72d1d300-d98a-11eb-8e23-40d2242e3051.png">

Now:
<img width="644" alt="Снимок экрана 2021-06-30 в 09 47 33" src="https://user-images.githubusercontent.com/20461547/123916563-78c7b400-d98a-11eb-9bf1-f0f251d65c42.png">


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
