### PR TITLE
Added language auto-detection.

### DIFF
--- a/packages/docs/src/components/header/components/LanguageDropdown.vue
+++ b/packages/docs/src/components/header/components/LanguageDropdown.vue
@@ -52,6 +52,8 @@ export default defineComponent({
     const setLanguage = (newLocale: string) => {
       if (locale.value === newLocale) { return }
 
+      localStorage.setItem('language', newLocale)
+      
       const currentPathWithoutLocale = getCurrentPathWithoutLocale()
 
       router.push('/' + newLocale + currentPathWithoutLocale)

--- a/packages/docs/src/locales/index.ts
+++ b/packages/docs/src/locales/index.ts
@@ -5,4 +5,8 @@ export const messages = languages.reduce((result, { code, name }) => ({
   [code]: require(`./${code}/${code}.json`),
 }), {})
 
-export const DEFAULT_LANGUAGE = localStorage.language || window.navigator.language || 'en'
+const extractLanguageCode = (languageInISOFormat: string) => languageInISOFormat.slice(0, 2)
+
+const getLanguageCode = () => extractLanguageCode(window.navigator.language)
+
+export const DEFAULT_LANGUAGE = localStorage.language || getLanguageCode() || 'en'

--- a/packages/docs/src/locales/index.ts
+++ b/packages/docs/src/locales/index.ts
@@ -5,4 +5,4 @@ export const messages = languages.reduce((result, { code, name }) => ({
   [code]: require(`./${code}/${code}.json`),
 }), {})
 
-export const DEFAULT_LANGUAGE = 'en'
+export const DEFAULT_LANGUAGE = localStorage.language || window.navigator.language || 'en'


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail -->
Closes #903

Now, DOC's homepage takes local storage/navigator language value as default.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
