### PR TITLE
add selectors for text styles

### DIFF
--- a/packages/ui/src/components/vuestic-sass/global/_typography.scss
+++ b/packages/ui/src/components/vuestic-sass/global/_typography.scss
@@ -101,8 +101,12 @@
     padding: 0.1rem 0.2rem;
   }
 
-  &--secondary {
-    opacity: 0.4;
+  $text-theme-colors: "primary", "secondary", "success", "info", "danger", "warning", "gray", "dark";
+
+  @each $color in $text-theme-colors {
+    &--#{$color} {
+      color: var(--va-#{$color});
+    }
   }
 }
 

--- a/packages/ui/src/components/vuestic-sass/global/_typography.scss
+++ b/packages/ui/src/components/vuestic-sass/global/_typography.scss
@@ -100,12 +100,16 @@
     background-color: $vue-darkest-blue;
     padding: 0.1rem 0.2rem;
   }
+}
 
-  $text-theme-colors: "primary", "secondary", "success", "info", "danger", "warning", "gray", "dark";
+.va {
+  &-text {
+    $text-theme-colors: "primary", "secondary", "success", "info", "danger", "warning", "gray", "dark";
 
-  @each $color in $text-theme-colors {
-    &--#{$color} {
-      color: var(--va-#{$color});
+    @each $color in $text-theme-colors {
+      &--#{$color} {
+        color: var(--va-#{$color});
+      }
     }
   }
 }

--- a/packages/ui/src/components/vuestic-sass/global/typography.demo.vue
+++ b/packages/ui/src/components/vuestic-sass/global/typography.demo.vue
@@ -1,34 +1,42 @@
 <template>
   <VbDemo>
-    <VbCard>
+    <VbCard title="Links">
       <a
         href="/default-link"
         class="link"
       >Default Link</a>
-    </VbCard>
-    <VbCard>
+      <br>
       <a
         href="/not-visited-link"
         class="link-secondary"
       >Secondary Link</a>
-    </VbCard>
-    <VbCard>
+      <br>
       <a
         href="#"
         class="link"
       >Default link Visited</a>
-    </VbCard>
-    <VbCard>
+      <br>
       <a
         href="#"
         class="link-secondary"
       >Secondary link Visited</a>
     </VbCard>
+    <VbCard title="Text styles">
+      <div>Default Text</div>
+      <div v-for="color in textStyleColors" :key="color" :class="`text--${color}`">{{ color }} text</div>
+    </VbCard>
   </VbDemo>
 </template>
 
 <script>
-export default {}
+export default {
+  setup () {
+    const textStyleColors = ['primary', 'secondary', 'success', 'info', 'danger', 'warning', 'gray', 'dark']
+    return {
+      textStyleColors,
+    }
+  },
+}
 </script>
 
 <style scoped lang="scss">

--- a/packages/ui/src/components/vuestic-sass/global/typography.demo.vue
+++ b/packages/ui/src/components/vuestic-sass/global/typography.demo.vue
@@ -23,7 +23,7 @@
     </VbCard>
     <VbCard title="Text styles">
       <div>Default Text</div>
-      <div v-for="color in textStyleColors" :key="color" :class="`text--${color}`">{{ color }} text</div>
+      <div v-for="color in textStyleColors" :key="color" :class="`va-text--${color}`">{{ color }} text</div>
     </VbCard>
   </VbDemo>
 </template>


### PR DESCRIPTION
close #764 

## Description
Added selectors for text styles next colors: "primary", "secondary", "success", "info", "danger", "warning", "gray", "dark".
Rule: --va-[color]
![Снимок экрана 2021-07-07 в 17 24 44](https://user-images.githubusercontent.com/20461547/124873262-e8632200-dfce-11eb-9f8b-ccd6e51a2724.png)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
