### PR TITLE
Fix #962 Add markdown-it plugins for processing links in MarkdownView

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -21,6 +21,7 @@
     "docsearch.js": "^2.6.3",
     "lodash": "^4.17.21",
     "markdown-it": "^12.0.6",
+    "markdown-it-attrs": "^4.0.0",
     "prismjs": "^1.24.0",
     "raw-loader": "^4.0.2",
     "smart-grid": "^2.1.2",

--- a/packages/docs/src/components/DocsLink.vue
+++ b/packages/docs/src/components/DocsLink.vue
@@ -54,10 +54,10 @@ export default defineComponent({
     const { locale } = useI18n()
 
     const linkHref = computed(() => {
-      if (props.href[0] === '/') {
+      if (props.href.startsWith('/')) {
         return `/${locale.value}${props.href}`
       }
-      return props.href
+      return `/${locale.value}/${props.href}`
     })
   
     return {

--- a/packages/docs/src/components/page-configs/contribution/documentation-page/page-config.ts
+++ b/packages/docs/src/components/page-configs/contribution/documentation-page/page-config.ts
@@ -1,5 +1,4 @@
-import { BlockType, ApiDocsBlock } from '../../../../types/configTypes'
-import apiOptions from './api-options'
+import { ApiDocsBlock } from '../../../../types/configTypes'
 import linkOptions from './link-options'
 import { tableData, columns } from './table-options'
 import { DocsHelper } from '../../../../helpers/DocsHelper'
@@ -23,10 +22,37 @@ columns = [
 ]
 
 tableData = [
-  ['d1C1', 'd1C2', '[d1C3](https://en.wikipedia.org/wiki/Markdown)', 'd1C4'],
+  ['d1C1', 'd1C2', '[d1C3](https://en.wikipedia.org/wiki/Markdown)[[target=_blank]]', 'd1C4'],
   ['d2C1', 'd2C2', '<mark>d2C3</mark>', 'd2C4'],
   ['d3C1', 'd3C2', '~~d3C3~~', 'd3C4'],
 ]`
+export const apiOptions = `{
+  version: '1.1',
+  props: {
+    value: {
+      hidden: false,
+      types: 'String',
+      version: '1.0',
+    },
+  },
+  events: {
+    input: {
+      types: '(value: boolean) => void',
+      version: '1.0',
+    },
+  },
+  methods: {
+    hide: {
+      types: '() => void',
+      version: '1.0',
+    },
+  },
+  slots: {
+    default: {
+      version: '1.0',
+    },
+  },
+}`
 
 export default [
   DocsHelper.title('documentationPage.title'),
@@ -61,7 +87,7 @@ export default [
   DocsHelper.paragraph('documentationPage.blocktypes.paragraph.text'),
   DocsHelper.code('DocsHelper.paragraph(\'translation.path\')'),
   DocsHelper.paragraph('documentationPage.compilesTo'),
-  DocsHelper.paragraph('translation.path'),
+  DocsHelper.paragraph('documentationPage.blocktypes.paragraph.example'),
 
   DocsHelper.headline('documentationPage.blocktypes.list.title'),
   DocsHelper.paragraph('documentationPage.blocktypes.list.text'),
@@ -88,56 +114,32 @@ export default [
   DocsHelper.paragraph('documentationPage.blocktypes.api.text'),
   DocsHelper.code('DocsHelper.api(VaComponent, apiOptions)'),
 
-  {
-    type: BlockType.SUBTITLE,
-    translationString: 'documentationPage.apiOptionsTitle',
-  },
-  {
-    type: BlockType.PARAGRAPH,
-    translationString: 'documentationPage.apiOptions.text',
-  },
-  {
-    type: BlockType.PARAGRAPH,
-    translationString: 'documentationPage.apiOptions.version',
-  },
-  {
-    type: BlockType.PARAGRAPH,
-    translationString: 'documentationPage.apiOptions.local',
-  },
-  {
-    type: BlockType.PARAGRAPH,
-    translationString: 'documentationPage.apiOptions.hidden',
-  },
-  {
-    type: BlockType.PARAGRAPH,
-    translationString: 'documentationPage.apiOptions.types',
-  },
-  {
-    type: BlockType.CODE,
-    code: apiOptions,
-  },
+  DocsHelper.headline('documentationPage.apiOptionsTitle'),
+  DocsHelper.paragraph('documentationPage.apiOptions.text'),
+  DocsHelper.paragraph('documentationPage.apiOptions.hidden'),
+  DocsHelper.paragraph('documentationPage.apiOptions.types'),
+  DocsHelper.paragraph('documentationPage.apiOptions.version'),
+  DocsHelper.code(apiOptions),
 
   DocsHelper.headline('documentationPage.blocktypes.table.title'),
   DocsHelper.paragraph('documentationPage.blocktypes.table.text'),
-  DocsHelper.code(`${tableDataBlock}`),
+  DocsHelper.code(tableDataBlock),
   DocsHelper.code('DocsHelper.table(columns, tableData)'),
   DocsHelper.paragraph('documentationPage.compilesTo'),
   DocsHelper.table(columns, tableData),
 
   DocsHelper.headline('documentationPage.blocktypes.link.title'),
   DocsHelper.paragraph('documentationPage.blocktypes.link.text'),
-  DocsHelper.code(`${linkOptionsBlock}`),
-  // eslint-disable-next-line no-template-curly-in-string
-  DocsHelper.code("DocsHelper.link('translation.path', `/contribution/documentation-page#translation-path`, options)"),
-  // eslint-disable-next-line no-template-curly-in-string
-  DocsHelper.code("DocsHelper.link('translation.path', `/services/components-config`)"),
+  DocsHelper.code(linkOptionsBlock),
+  DocsHelper.code('DocsHelper.link(\'translation.path\', \'/contribution/documentation-page#translation-path\', options)'),
+  DocsHelper.code('DocsHelper.link(\'translation.path\', \'/services/components-config\')'),
   DocsHelper.paragraph('documentationPage.compilesTo'),
-  DocsHelper.link('translation.path', `/contribution/documentation-page#translation-path`, linkOptions),
-  DocsHelper.link('translation.path', `/services/components-config#scoped-config`),
+  DocsHelper.link('documentationPage.blocktypes.link.exampleWithOptions', '/contribution/documentation-page#translation-path', linkOptions),
+  DocsHelper.link('documentationPage.blocktypes.link.example', '/services/components-config#scoped-config'),
 
   DocsHelper.headline('documentationPage.blocktypes.alert.title'),
   DocsHelper.paragraph('documentationPage.blocktypes.alert.text'),
   DocsHelper.code('DocsHelper.alert(\'translation.path\', \'#ff0000\')'),
   DocsHelper.paragraph('documentationPage.compilesTo'),
-  DocsHelper.alert('translation.path', '#ff0000'),
+  DocsHelper.alert('documentationPage.blocktypes.alert.example', '#ff0000'),
 ] as ApiDocsBlock[]

--- a/packages/docs/src/components/page-configs/contribution/documentation-page/table-options.ts
+++ b/packages/docs/src/components/page-configs/contribution/documentation-page/table-options.ts
@@ -8,7 +8,7 @@ export const columns: TableColumn[] = [
 ]
 
 export const tableData: TableData = [
-  ['d1C1', 'd1C2', '[d1C3](https://en.wikipedia.org/wiki/Markdown)', 'd1C4'],
+  ['d1C1', 'd1C2', '[d1C3](https://en.wikipedia.org/wiki/Markdown)[[target=_blank]]', 'd1C4'],
   ['d2C1', 'd2C2', '<mark>d2C3</mark>', 'd2C4'],
   ['d3C1', 'd3C2', '~~d3C3~~', 'd3C4'],
 ]

--- a/packages/docs/src/components/page-configs/styles/typography/page-config.ts
+++ b/packages/docs/src/components/page-configs/styles/typography/page-config.ts
@@ -1,6 +1,7 @@
 import { ApiDocsBlock } from '../../../../types/configTypes'
 import { DocsHelper } from '../../../../helpers/DocsHelper'
-import { t } from '@/helpers/I18nHelper'
+
+const toClass = (className: string): string => `\`class=\"${className}\"\``
 
 const display1 = `
 <h1 class="display-1">Display 1 Heading</h1>
@@ -147,30 +148,30 @@ export default [
   DocsHelper.table(
     [{ title: 'typography.headings', type: 'markdown' }, { title: 'typography.affected', type: 'markdown' }],
     [
-      [display1, t('typography.display1')],
-      [display2, t('typography.display2')],
-      [display3, t('typography.display3')],
-      [display4, t('typography.display4')],
-      [display5, t('typography.display5')],
-      [title, t('typography.titled')],
-      [primary, t('typography.primary')],
-      [secondary, t('typography.secondary')],
-      [codeSnippet, t('typography.codeSnippet')],
-      [textCode, t('typography.textCode')],
+      [display1, toClass('display-1')],
+      [display2, toClass('display-2')],
+      [display3, toClass('display-3')],
+      [display4, toClass('display-4')],
+      [display5, toClass('display-5')],
+      [title, toClass('title')],
+      [primary, 'typography.primary'],
+      [secondary, toClass('text--secondary')],
+      [codeSnippet, toClass('code-snippet')],
+      [textCode, toClass('text--code')],
     ]),
   DocsHelper.subtitle('typography.other'),
   DocsHelper.table(
     [{ title: 'typography.other', type: 'markdown' }, { title: 'typography.affected', type: 'markdown' }],
     [
-      ['typography.lists', ''],
-      [orderedLists, t('typography.orderedLists')],
-      [unorderedLists, t('typography.unorderedLists')],
-      ['typography.links', ''],
-      [link, t('typography.link')],
-      [linkSecondary, t('typography.linkSecondary')],
-      ['typography.otherElements', ''],
-      [textHighlighted, t('typography.textHighlighted')],
-      [blockquote, t('typography.blockquote')],
-      [textBlock, t('typography.textBlock')],
+      ['typography.lists'],
+      [orderedLists, toClass('va-ordered')],
+      [unorderedLists, toClass('va-unordered')],
+      ['typography.links'],
+      [link, toClass('link')],
+      [linkSecondary, toClass('link-secondary')],
+      ['typography.otherElements'],
+      [textHighlighted, toClass('text--highlighted')],
+      [blockquote, toClass('va-blockquote')],
+      [textBlock, toClass('text-block')],
     ]),
 ] as ApiDocsBlock[]

--- a/packages/docs/src/locales/en/en.json
+++ b/packages/docs/src/locales/en/en.json
@@ -119,14 +119,14 @@
         "color": "Color of the component (theme string or *HEX* string).",
         "textColor": "Text color (theme string or *HEX* string).",
         "rules": "Validation rules <!-- TODO Add link -->.",
-        "to": "The target route of the link. [More info here](https://router.vuejs.org/api/#to \"Vue router docs\").",
-        "replace": "When set, calls `router.replace()` instead of `router.push()` when navigated, so it will not leave a history record. [More info here](https://router.vuejs.org/api/#replace \"Vue router docs\").",
-        "append": "When set, always appends the relative path to the current path. [More info here](https://router.vuejs.org/api/#append \"Vue router docs\").",
-        "exact": "Exactly match the link. Without this, '/' will match every route. [More info here](https://router.vuejs.org/api/#exact \"Vue router docs\").",
-        "activeClass": "Applied when the link is active. [More info here](https://router.vuejs.org/api/#active-class \"Vue router docs\").",
-        "exactActiveClass": "Applied when the link is active with exact match. [More info here](https://router.vuejs.org/api/#exact-active-class \"Vue router docs\").",
-        "href": "Designates the component as anchor and applies the href attribute. [More info here](https://router.vuejs.org/api/#href \"Vue router docs\").",
-        "target": "Navigation target, [More info here](https://developer.mozilla.org/docs/Web/HTML/Element/A).",
+        "to": "The target route of the link. [More info here](https://router.vuejs.org/api/#to \"Vue router docs\")[[target=_blank]].",
+        "replace": "When set, calls `router.replace()` instead of `router.push()` when navigated, so it will not leave a history record. [More info here](https://router.vuejs.org/api/#replace \"Vue router docs\")[[target=_blank]].",
+        "append": "When set, always appends the relative path to the current path. [More info here](https://router.vuejs.org/api/#append \"Vue router docs\")[[target=_blank]].",
+        "exact": "Exactly match the link. Without this, '/' will match every route. [More info here](https://router.vuejs.org/api/#exact \"Vue router docs\")[[target=_blank]].",
+        "activeClass": "Applied when the link is active. [More info here](https://router.vuejs.org/api/#active-class \"Vue router docs\")[[target=_blank]].",
+        "exactActiveClass": "Applied when the link is active with exact match. [More info here](https://router.vuejs.org/api/#exact-active-class \"Vue router docs\")[[target=_blank]].",
+        "href": "Designates the component as anchor and applies the href attribute. [More info here](https://router.vuejs.org/api/#href \"Vue router docs\")[[target=_blank]].",
+        "target": "Navigation target, [More info here](https://developer.mozilla.org/docs/Web/HTML/Element/A)[[target=_blank]].",
         "src": "Source URL.",
         "arrayValue": "Same as native `value`. It is used with `v-model` of an array type.",
         "label": "Same as native `label`.",
@@ -1149,7 +1149,7 @@
     "description": "This page is intended for vuestic-ui contributors: it will explain how to create and modify documentation.",
     "introduction": {
       "title": "Introduction",
-      "description": "Instead of using the established documentation system, such as [vue-press](https://vuepress.vuejs.org/) or [docsify](https://docsify.js.org/#/), we’ve decided to create a system specifically tailored for Vuestic. It’s meant to provide excellent flexibility for future growth."
+      "description": "Instead of using the established documentation system, such as [vue-press](https://vuepress.vuejs.org/)[[target=_blank]] or [docsify](https://docsify.js.org/#/)[[target=_blank]], we’ve decided to create a system specifically tailored for Vuestic. It’s meant to provide excellent flexibility for future growth."
     },
     "pageConfig": {
       "title": "Page Config",
@@ -1174,7 +1174,8 @@
       },
       "paragraph": {
         "title": "Paragraph",
-        "text": "Should be used for all non-special text blocks."
+        "text": "Should be used for all non-special text blocks. For links to external resources, you can specify the **target** attribute in markdown markup as follows: `[name](href)[[target=_blank]]`.",
+        "example": "Paragraph (example). Link in the text leading to an external resource: [markdown-it-attrs](https://github.com/arve0/markdown-it-attrs)[[target=_blank]]."
       },
       "list": {
         "title": "List",
@@ -1185,7 +1186,7 @@
       },
       "code": {
         "title": "Code",
-        "text": "Code preview. We use [prism](https://prismjs.com/)."
+        "text": "Code preview. We use [prism](https://prismjs.com/)[[target=_blank]]."
       },
       "example": {
         "title": "Example",
@@ -1201,11 +1202,14 @@
       },
       "link": {
         "title": "Link",
-        "text": "Used for local links (with <i>options</i> and without them)."
+        "text": "Used for relative (local) links processed by router (with *options* and without them).",
+        "exampleWithOptions": "Link with options (example)",
+        "example": "Link (example)"
       },
       "alert": {
         "title": "Alert",
-        "text": "Used to display an important message."
+        "text": "Used to display an important message.",
+        "example": "Alert (example)"
       }
     },
     "apiOptionsTitle": "API Options",
@@ -1213,7 +1217,6 @@
       "text": "With automated code analysis we can't go too far. Most of the API documentation has to be declared explicitly. API options allow you to configure things such as: version, props, events, methods and slots.",
       "version": "`version` - specifies at which version of vuestic this component or feature were implemented.",
       "types": "`types` - simpler prop types documentation engine can figure from component options (`String`, `Number` etc). For almost everything else it has to be defined.",
-      "local": "`local` - forces to use component-specific translation. Default behavior is using 'all' section of the translation object.",
       "hidden": "`hidden` - allows you to hide the prop from the API section of the documentation page. As some props could be intended for internal use."
     }
   },
@@ -2016,7 +2019,7 @@
   },
   "progressBar": {
     "title": "Progress Bar",
-    "summaryText": "The `va-progress-bar` component is used to display an indicator of an app loading content. Also check the <a href=\"/en/progress-circle\">va-progress-circle</a> component.",
+    "summaryText": "The `va-progress-bar` component is used to display an indicator of an app loading content. Also check the [va-progress-circle](/ui-elements/progress-circle) component.",
     "examples": {
       "default": {
         "title": "Default",
@@ -2046,7 +2049,7 @@
   },
   "progressCircle": {
     "title": "Progress Circle",
-    "summaryText": "The `va-progress-circle` component is used to display an indicator of an app loading content. Also check the <a href=\"/en/progress-bar\">va-progress-bar</a> component.",
+    "summaryText": "The `va-progress-circle` component is used to display an indicator of an app loading content. Also check the [va-progress-bar](/ui-elements/progress-bar) component.",
     "examples": {
       "default": {
         "title": "Default",
@@ -2122,7 +2125,7 @@
       },
       "mask": {
         "title": "Mask",
-        "text": "Support possibility to force/help the user to input a specific format with help from mask prop. You can pass some mask presets or custom options based on [cleave.js](https://nosir.github.io/cleave.js/). By default returning a raw value."
+        "text": "Support possibility to force/help the user to input a specific format with help from mask prop. You can pass some mask presets or custom options based on [cleave.js](https://nosir.github.io/cleave.js/)[[target=_blank]]. By default returning a raw value."
       },
       "styles": {
         "title": "Styles",
@@ -2174,7 +2177,7 @@
   },
   "icon": {
     "title": "Icon",
-    "summaryText": "The `va-icon` component allows you to use different icon fonts. By default Vuestic UI provides [Material Design icons](https://fonts.google.com/icons).",
+    "summaryText": "The `va-icon` component allows you to use different icon fonts. By default Vuestic UI provides [Material Design icons](https://fonts.google.com/icons)[[target=_blank]].",
     "examples": {
       "default": {
         "title": "Default",
@@ -2320,7 +2323,7 @@
   },
   "grid": {
     "title": "Grid System",
-    "summaryText": "We give you helper classes for flex grid. For [css grid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout) - we don't. That doesn't mean you *have* to use flex grid, just that CSS grid doesn't benefit from helper classes. But it remains a powerful tool.",
+    "summaryText": "We give you helper classes for flex grid. For [css grid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout)[[target=_blank]] - we don't. That doesn't mean you *have* to use flex grid, just that CSS grid doesn't benefit from helper classes. But it remains a powerful tool.",
     "examples": {
       "default": {
         "title": "Enabling flexbox"
@@ -2552,12 +2555,12 @@
       "title": "Reset features",
       "info": "Below is a list of features that are provided by reset.scss:",
       "list": "* Margin and padding reset. \n * Border reset. \n * Hide quotes. \n * Font reset. \n * Hidden-attribute fix for newer browsers. \n * HTML5 display-role reset for older browsers",
-      "more": "For a complete list of all applied styles, see the [reset.scss](https://github.com/epicmaxco/vuestic-ui/blob/develop/packages/ui/src/styles/global/reset.scss) stylesheet."
+      "more": "For a complete list of all applied styles, see the [reset.scss](https://github.com/epicmaxco/vuestic-ui/blob/develop/packages/ui/src/components/vuestic-sass/global/reset.scss)[[target=_blank]] stylesheet."
     }
   },
   "colorPicker": {
     "title": "Color Picker",
-    "summaryText": "A component which helps to pick the color. We use the [vue-color](https://github.com/xiaokaike/vue-color) library for this component. Will be replaced in next versions.",
+    "summaryText": "A component which helps to pick the color. We use the [vue-color](https://github.com/xiaokaike/vue-color)[[target=_blank]] library for this component. Will be replaced in next versions.",
     "examples": {
       "default": {
         "title": "Basic usage",
@@ -2814,8 +2817,8 @@
     "description": "Get started with Vuestic UI to create feature-rich and user-friendly apps thanks to our highly configurable framework. We’ve simplified the installation process as much as possible to save you extra effort. Installation is possible in a few ways",
     "subtitle": "You could start usage of Vuestic with a simple steps the way you like",
     "prerequisites": "First, make sure you have all prerequisites installed:",
-    "node": "<a href=\"https://nodejs.org/en/\">Node.js</a> ( >=14.*)",
-    "npm": "<a href=\"https://www.npmjs.com/get-npm\">npm</a> version 3+ ( or <a href=\"https://yarnpkg.com/lang/en/docs/install\">yarn</a> version 1.16+) and <a href=\"https://git-scm.com/\">Git</a>.",
+    "node": "[Node.js](https://nodejs.org/en/)[[target=_blank]] ( >=14.*)",
+    "npm": "[npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)[[target=_blank]] version 3+ (or [yarn](https://yarnpkg.com/lang/en/docs/install)[[target=_blank]] version 1.16+) and [Git](https://git-scm.com/)[[target=_blank]]",
     "afterCheck": "After checking the prerequisites, install Vuestic UI via npm/yarn:",
     "fonts": {
       "title": "Fonts installation",
@@ -2829,8 +2832,8 @@
     },
     "cli": {
       "title": "Vue CLI installation",
-      "prepare": "Before install make sure [Vue CLI](https://cli.vuejs.org/guide/installation.html) is installed globally and has version 4+:",
-      "upgrade": "Here is a [guide](https://cli.vuejs.org/migrating-from-v3/#migrating-from-v3) for Vue CLI version 3 to help you update your app",
+      "prepare": "Before install make sure [Vue CLI](https://cli.vuejs.org/guide/installation.html)[[target=_blank]] is installed globally and has version 4+:",
+      "upgrade": "Here is a [guide](https://cli.vuejs.org/migrating-from-v3/#migrating-from-v3)[[target=_blank]] for Vue CLI version 3 to help you update your app",
       "description": "An easy way if you use the Vue-CLI setup or you want to try out Vuestic UI on a fresh project",
       "attention": "Vuestic UI installation will modify package.json and main.js(ts) files. Make sure you’ve committed your code before installing it to avoid data loss",
       "codeAnnotation": "Then install Vuestic UI as a Vue-CLI plugin:"
@@ -2865,7 +2868,7 @@
     },
     "0-1": {
       "title": "v0.1",
-      "description": "Not even alpha, we've just split components from [vuestic-admin](https://github.com/epicmaxco/vuestic-admin) into separate repository to simplify updates."
+      "description": "Not even alpha, we've just split components from [vuestic-admin](https://github.com/epicmaxco/vuestic-admin)[[target=_blank]] into separate repository to simplify updates."
     },
     "released": {
       "title": "Released",
@@ -2912,12 +2915,12 @@
       "action": "To solve that problem - in your `main.js` add:",
       "result": "Now your buttons will look like this:",
       "example": "You can globally configure any props for Vuestic UI components similarly.",
-      "more": "If your customization runs deeper - you may override [css variables](https://vuestic.dev/en/styles/css-variables#overriding) or class properties directly (components use BEM, so selectors are easy to guess)."
+      "more": "If your customization runs deeper - you may override [css variables](/styles/css-variables#overriding) or class properties directly (components use BEM, so selectors are easy to guess)."
     }
   },
   "browserSupport": {
     "title": "Browser Support",
-    "description": "We design Vuestic UI to be future proof. That's why we support modern browsers, but some old browsers, such as IE had to go, sorry. That decision was influenced by [dropped support in Vue 3](https://github.com/vuejs/rfcs/discussions/296) and [falling usage rate](https://caniuse.com/usage-table).",
+    "description": "We design Vuestic UI to be future proof. That's why we support modern browsers, but some old browsers, such as IE had to go, sorry. That decision was influenced by [dropped support in Vue 3](https://github.com/vuejs/rfcs/discussions/296)[[target=_blank]] and [falling usage rate](https://caniuse.com/usage-table)[[target=_blank]].",
     "table": {
       "browser": "Browser",
       "supported": "Supported"
@@ -2983,7 +2986,7 @@
         "dontSubmitToMaster": "**Do not submit PRs against the `master` branch.**",
         "checkoutFeat": "Checkout a `feat/` branch from `develop`, then create pull request against that branch.",
         "multipleSmallCommits": "It's OK to have multiple small commits as you work on the PR - we will let GitHub automatically squash it before merging.",
-        "fixBugSteps": "If fixing a bug:\n  * If you are resolving a special issue, add `close #xxxx[,#xxx]` (#xxxx is the issue id) to the PR description so that github [will close](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) the issue once it's up on `master`.\n  * Provide detailed description of the bug in the PR if it's not done in the issue."
+        "fixBugSteps": "If fixing a bug:\n  * If you are resolving a special issue, add `close #xxxx[,#xxx]` (#xxxx is the issue id) to the PR description so that github [will close](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)[[target=_blank]] the issue once it's up on `master`.\n  * Provide detailed description of the bug in the PR if it's not done in the issue."
       }
     },
     "branches": {
@@ -3004,10 +3007,10 @@
       "smallIssues": "For small issues you may push to `develop` branch directly while adding (`close #123`) to commit message.",
       "singlePrPerIssue": "Create single PR for one issue. If we have several PRs - move all the code into a single one and close the rest. If one PR covers several issues - either split it in several PRs or mark one of the issues as duplicate.",
       "onePersonPerIssue": "Be sure to have only one person assigned per issue.",
-      "checkYourCode": "Check your code: [conventions](https://github.com/epicmaxco/vuestic-ui/blob/master/packages/docs/conventions.md).",
-      "weUseYarn": "We use [yarn](https://yarnpkg.com/lang/en/) for package management.",
+      "checkYourCode": "Check your code: [conventions](https://github.com/epicmaxco/vuestic-ui/blob/master/packages/docs/conventions.md)[[target=_blank]].",
+      "weUseYarn": "We use [yarn](https://yarnpkg.com/lang/en/)[[target=_blank]] for package management.",
       "beProactive": "Be proactive. If you think something is wrong - create an issue or discuss.",
-      "recommendedTools": "Recommended tools: [GitKraken](https://www.gitkraken.com/), [WebStorm](https://www.jetbrains.com/webstorm/), [ShareX](https://getsharex.com/).",
+      "recommendedTools": "Recommended tools: [GitKraken](https://www.gitkraken.com/)[[target=_blank]], [WebStorm](https://www.jetbrains.com/webstorm/)[[target=_blank]], [ShareX](https://getsharex.com/)[[target=_blank]].",
       "workInBook": "If you work on UI components - work in book environment (`yarn serve:book`). We want to keep global stuff out of components."
     },
     "componentFolderStructure": {
@@ -3022,7 +3025,7 @@
     },
     "credits": {
       "title": "Credits",
-      "description": "<a href=\"https://github.com/epicmaxco/vuestic-ui/graphs/contributors\">Hall of fame!</a>"
+      "description": "[Hall of fame!](https://github.com/epicmaxco/vuestic-ui/graphs/contributors)[[target=_blank]]"
     }
   },
   "globalConfig": {
@@ -3047,7 +3050,7 @@
   },
   "iconsConfig": {
     "title": "Icons config",
-    "about": "By default Vuestic UI provides [Material Design icons](https://fonts.google.com/icons). If you want to use other font libraries you can configure VaIcon to use them.",
+    "about": "By default Vuestic UI provides [Material Design icons](https://fonts.google.com/icons)[[target=_blank]]. If you want to use other font libraries you can configure VaIcon to use them.",
     "readMore": "Read more",
     "readBeforeStart": "Read about icons component",
     "example": "Example",
@@ -3155,14 +3158,14 @@
   },
   "cssVariables": {
     "title": "Css Variables",
-    "description": "Vuestic UI extracts css as [CSS variables (custom properties)](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties). No need to install any loaders or additional packages to override components styles. You can deeply customize components by using simple syntax to change css in your project.",
+    "description": "Vuestic UI extracts css as [CSS variables (custom properties)](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties)[[target=_blank]]. No need to install any loaders or additional packages to override components styles. You can deeply customize components by using simple syntax to change css in your project.",
     "convention": {
       "title": "Convention",
       "description": "Vuestic UI uses the following convention to organize CSS Variables for more convenient use:"
     },
     "overriding": {
       "title": "Overriding",
-      "description": "You don't need any specific knowledges or packages. Just create file like `overrides.css`, import it into your main.js(ts) file and start redefining as easy as you write css properties:"
+      "description": "You don't need any specific knowledge or packages. Just create file like `overrides.css`, import it into your main.js(ts) file and start redefining as easy as you write css properties:"
     }
   },
   "navbar": {
@@ -3272,27 +3275,11 @@
     "description": "Vuestic UI uses the following typography styling",
     "headings": "Headings",
     "affected": "Affected",
-    "display1": "`class=\"display-1\"`",
-    "display2": "`class=\"display-2\"`",
-    "display3": "`class=\"display-3\"`",
-    "display4": "`class=\"display-4\"`",
-    "display5": "`class=\"display-5\"`",
-    "titled": "`class=\"title\"`",
     "primary": "Default text style",
-    "secondary": "`class=\"text--secondary\"`",
-    "codeSnippet": "`class=\"code-snippet\"`",
-    "textCode": "`class=\"text--code\"`",
     "other": "Other typography styles",
     "lists": "Lists",
-    "orderedLists": "`class=\"va-ordered\"`",
-    "unorderedLists": "`class=\"va-unordered\"`",
     "links": "Links",
-    "link": "`class=\"link\"`",
-    "linkSecondary": "`class=\"link-secondary\"`",
-    "otherElements": "Other elements",
-    "textHighlighted": "`class=\"text--highlighted\"`",
-    "blockquote": "`class=\"va-blockquote\"`",
-    "textBlock": "`class=\"text-block\"`"
+    "otherElements": "Other elements"
   },
   "ag-grid-wrapper": {
     "title": "AG Grid wrapper",
@@ -3312,7 +3299,7 @@
     "highLevelStrategy": {
       "title": "High Level Strategy",
       "description": {
-        "userExpectations": "Components should be as user expects them to be. We achieve that by checking refs ([Vuetify](https://vuetifyjs.com), [Quasar](https://quasar.dev), [Ant Design](https://ant.design), [iView](http://iview.talkingdata.com), [Element UI](https://element.eleme.io), etc.).",
+        "userExpectations": "Components should be as user expects them to be. We achieve that by checking refs ([Vuetify](https://vuetifyjs.com)[[target=_blank]], [Quasar](https://quasar.dev)[[target=_blank]], [Ant Design](https://ant.design)[[target=_blank]], [iView](http://iview.talkingdata.com)[[target=_blank]], [Element UI](https://element.eleme.io)[[target=_blank]], etc.).",
         "qualityComponents": "Components should be of high quality. We achieve that by manually testing edge cases + refactoring early."
       }
     },
@@ -3321,7 +3308,7 @@
       "description": {
         "visualFeedback": "**Visual feedback** - When user interacts with component they should see result of their actions (could be implemented with :active selector or somehow else depending on case).",
         "keyboardNavigation": "**Keyboard navigation** - You must ensure that UI elements are keyboard accessible, and you must disable this functionality for elements that should not receive keyboard focus.",
-        "statelessSupport": "**Stateless support** (read about [StatefulMixin](https://github.com/epicmaxco/vuestic-ui/blob/develop/packages/ui/src/components/vuestic-mixins/StatefulMixin/README.md))."
+        "statelessSupport": "**Stateless support** (read about [StatefulMixin](https://github.com/epicmaxco/vuestic-ui/blob/develop/packages/ui/src/components/vuestic-mixins/StatefulMixin/README.md)[[target=_blank]])."
       }
     }
   }

--- a/packages/docs/src/locales/ru/ru.json
+++ b/packages/docs/src/locales/ru/ru.json
@@ -118,15 +118,15 @@
         "stateful": "Добавляет возможность работы с компонентом без настройки `v-model`",
         "color": "Цвет компонента (поддерживаемые темой опции или `HEX`)",
         "textColor": "Цвет текста (поддерживаемые темой опции или `HEX`)",
-        "rules": "Правила валидации<!-- TODO Add link -->",
-        "to": "Целевой маршрут ссылки, [подробнее](https://router.vuejs.org/api/#to \"Vue router docs\")",
-        "replace": "Если установлено, при навигации вызывается `router.replace()` вместо `router.push()`, поэтому запись в истории не сохраняется. [Подробнее](https://router.vuejs.org/api/#replace \"Vue router docs\")",
-        "append": "Если установлено, всегда добавляется относительный путь к текущему, [подробнее](https://router.vuejs.org/api/#append \"Vue router docs\")",
-        "exact": "Проверяет точное соотвествие ссылки. Без знака `'/'` будет соответствовать каждому маршруту, [подробнее](https://router.vuejs.org/api/#exact \"Vue router docs\")",
-        "activeClass": "Применяется к активной ссылке, [подробнее](https://router.vuejs.org/api/#active-class \"Vue router docs\")",
-        "exactActiveClass": "Применяется к активной ссылке c точным соотвествием, [подробнее](https://router.vuejs.org/api/#exact-active-class \"Vue router docs\")",
-        "href": "Определяет компонент как привязку и применяет атрибут href, [подробнее](https://router.vuejs.org/api/#href \"Vue router docs\").",
-        "target": "Целевой указатель навигации, [подробнее](https://developer.mozilla.org/docs/Web/HTML/Element/A).",
+        "rules": "Правила валидации <!-- TODO Add link -->",
+        "to": "Целевой маршрут ссылки, [подробнее](https://router.vuejs.org/api/#to \"Vue router docs\")[[target=_blank]]",
+        "replace": "Если установлено, при навигации вызывается `router.replace()` вместо `router.push()`, поэтому запись в истории не сохраняется. [Подробнее](https://router.vuejs.org/api/#replace \"Vue router docs\")[[target=_blank]]",
+        "append": "Если установлено, всегда добавляется относительный путь к текущему, [подробнее](https://router.vuejs.org/api/#append \"Vue router docs\")[[target=_blank]]",
+        "exact": "Проверяет точное соотвествие ссылки. Без знака `'/'` будет соответствовать каждому маршруту, [подробнее](https://router.vuejs.org/api/#exact \"Vue router docs\")[[target=_blank]]",
+        "activeClass": "Применяется к активной ссылке, [подробнее](https://router.vuejs.org/api/#active-class \"Vue router docs\")[[target=_blank]]",
+        "exactActiveClass": "Применяется к активной ссылке c точным соотвествием, [подробнее](https://router.vuejs.org/api/#exact-active-class \"Vue router docs\")[[target=_blank]]",
+        "href": "Определяет компонент как привязку и применяет атрибут href, [подробнее](https://router.vuejs.org/api/#href \"Vue router docs\")[[target=_blank]].",
+        "target": "Целевой указатель навигации, [подробнее](https://developer.mozilla.org/docs/Web/HTML/Element/A)[[target=_blank]].",
         "src": "Исходный URL",
         "arrayValue": "То же, что и нативный `value`, используется с массивом в `v-model`",
         "label": "То же, что и нативный `label`",
@@ -1069,7 +1069,7 @@
     "description": "Эта страница предназначена для контрибьюторов `vuestic-ui`, на ней объясняется, как создавать и изменять документацию.",
     "introduction": {
       "title": "Введение",
-      "description": "Вместо использования готовой системы документации, такой как [vue-press](https://vuepress.vuejs.org/) или [docsify](https://docsify.js.org/#/), мы решили создать систему, специально предназначенную для Vuestic. Она призвана обеспечить отличную гибкость для будущего развития."
+      "description": "Вместо использования готовой системы документации, такой как [vue-press](https://vuepress.vuejs.org/)[[target=_blank]] или [docsify](https://docsify.js.org/#/)[[target=_blank]], мы решили создать систему, специально предназначенную для Vuestic. Она призвана обеспечить отличную гибкость для будущего развития."
     },
     "pageConfig": {
       "title": "Конфигурация страницы",
@@ -1094,7 +1094,8 @@
       },
       "paragraph": {
         "title": "Параграф",
-        "text": "Следует использовать для всех неспециальных текстовых блоков."
+        "text": "Следует использовать для всех неспециальных текстовых блоков. Для ссылок, ведущих на внешние ресурсы, в markdown-разметке можно указать атрибут **target** следующим образом: `[name](href)[[target=_blank]]`.",
+        "example": "Параграф (пример). Ссылка в тексте, ведущая на внешний ресурс: [markdown-it-attrs](https://github.com/arve0/markdown-it-attrs)[[target=_blank]]."
       },
       "list": {
         "title": "Список",
@@ -1105,7 +1106,7 @@
       },
       "code": {
         "title": "Код",
-        "text": "Предварительный просмотр кода. Мы используем [prism](https://prismjs.com/)."
+        "text": "Предварительный просмотр кода. Мы используем [prism](https://prismjs.com/)[[target=_blank]]."
       },
       "example": {
         "title": "Пример",
@@ -1121,11 +1122,14 @@
       },
       "link": {
         "title": "Ссылка",
-        "text": "Используется для локальных ссылок (с <i>options</i> и без)."
+        "text": "Используется для относительных (локальных) ссылок, обрабатываемых маршрутизатором (с *options* и без).",
+        "exampleWithOptions": "Ссылка с options (пример)",
+        "example": "Ссылка (пример)"
       },
       "alert": {
         "title": "Предупреждение",
-        "text": "Используется для отображения важного сообщения."
+        "text": "Используется для отображения важного сообщения.",
+        "example": "Предупреждение (пример)"
       }
     },
     "apiOptionsTitle": "Параметры API",
@@ -1133,7 +1137,6 @@
       "text": "Мы не можем сделать глубокий автоматический анализ кода. Большая часть документации API должна быть объявлена явно. Параметры API позволяют настраивать такие опции, как: `version`, `props`, `events`, `methods` и `slots`.",
       "version": "`version` - указывает, в какой версии vuestic был реализован этот компонент или функция.",
       "types": "`types` - более простой механизм документирования типов свойств может быть определен из параметров компонентов (`String`, `Number`, etc). Почти для всего остального это должно быть определено.",
-      "local": "`local` - принудительное использование компонентного перевода. По умолчанию используется раздел «все» объекта перевода.",
       "hidden": "`hidden` - позволяет скрыть свойство из раздела API на странице документации. Так как некоторые свойства могут быть предназначены для внутреннего использования."
     }
   },
@@ -1162,7 +1165,7 @@
       },
       "withEmail": {
         "title": "Gravatar",
-        "text": "Свойство `email` и [gravatar](https://en.gravatar.com/support/what-is-gravatar/) используются для получения изображения профиля пользователя."
+        "text": "Свойство `email` и [gravatar](https://en.gravatar.com/support/what-is-gravatar/)[[target=_blank]] используются для получения изображения профиля пользователя."
       }
     }
   },
@@ -1694,7 +1697,7 @@
       },
       "withList": {
         "title": "Разделитель списков",
-        "text": "Разделитель отлично работает с компонентом [va-list](https://vuestic.dev/en/ui-elements/list)."
+        "text": "Разделитель отлично работает с компонентом [va-list](https://vuestic.dev/en/ui-elements/list)[[target=_blank]]."
       }
     }
   },
@@ -1831,7 +1834,7 @@
   },
   "sidebarItem": {
     "title": "Sidebar Item",
-    "summaryText": "Компонент `va-sidebar-item` используется как ссылка в [боковой панели](https://vuestic.dev/ui-elements/sidebar).",
+    "summaryText": "Компонент `va-sidebar-item` используется как ссылка в [боковой панели](https://vuestic.dev/ui-elements/sidebar)[[target=_blank]].",
     "examples": {
       "simple": {
         "title": "Базовое использование",
@@ -1847,11 +1850,11 @@
       },
       "icons": {
         "title": "Компоненты `va-sidebar-title` и `va-icon`",
-        "text": "`va-sidebar-title` используется для заполнения всего оставшегося свободного места в `va-sidebar-item`. Вы также можете добавить любые другие компоненты (например [иконки](https://vuestic.dev/ui-elements/icon), [фишки](https://vuestic.dev/ui-elements/chip) или [кнопки](https://vuestic.dev/ui-elements/button))."
+        "text": "`va-sidebar-title` используется для заполнения всего оставшегося свободного места в `va-sidebar-item`. Вы также можете добавить любые другие компоненты (например [иконки](https://vuestic.dev/ui-elements/icon)[[target=_blank]], [фишки](https://vuestic.dev/ui-elements/chip)[[target=_blank]] или [кнопки](https://vuestic.dev/ui-elements/button)[[target=_blank]])."
       },
       "components": {
         "title": "Продвинутый пример с `va-accordion`",
-        "text": "Компонент `va-sidebar-item` может быть использован с компонентами [va-accordion](https://vuestic.dev/ui-elements/accordion) и [va-сollapse](https://vuestic.dev/ui-elements/сollapse)."
+        "text": "Компонент `va-sidebar-item` может быть использован с компонентами [va-accordion](https://vuestic.dev/ui-elements/accordion)[[target=_blank]] и [va-сollapse](https://vuestic.dev/ui-elements/сollapse)[[target=_blank]]."
       }
     }
   },
@@ -1940,7 +1943,7 @@
   },
   "progressBar": {
     "title": "Progress Bar",
-    "summaryText": "Компонент `va-progress-bar` используется для отображения индикатора загрузки содержимого приложения. Так же ознакомьтесь с компонентом [va-progress-circle](https://vuestic.dev/ui-elements/progress-circle).",
+    "summaryText": "Компонент `va-progress-bar` используется для отображения индикатора загрузки содержимого приложения. Так же ознакомьтесь с компонентом [va-progress-circle](/ui-elements/progress-circle).",
     "examples": {
       "default": {
         "title": "Базовое использование",
@@ -1970,7 +1973,7 @@
   },
   "progressCircle": {
     "title": "Progress Circle",
-    "summaryText": "Компонент `va-progress-circle` используется для отображения индикатора загрузки содержимого приложения. Так же ознакомьтесь с компонентом [va-progress-circle](https://vuestic.dev/ui-elements/progress-bar).",
+    "summaryText": "Компонент `va-progress-circle` используется для отображения индикатора загрузки содержимого приложения. Так же ознакомьтесь с компонентом [va-progress-bar](/ui-elements/progress-bar).",
     "examples": {
       "default": {
         "title": "Базовое использование",
@@ -2046,7 +2049,7 @@
       },
       "mask": {
         "title": "Маска",
-        "text": "Свойство `mask` добавляет возможность помочь пользователю ввести определенный формат данных с помощью маски. Вы можете использовать некоторые пресеты масок или пользовательские параметры на основе [cleave.js](https://nosir.github.io/cleave.js/). По умолчанию возвращается необработанное значение."
+        "text": "Свойство `mask` добавляет возможность помочь пользователю ввести определенный формат данных с помощью маски. Вы можете использовать некоторые пресеты масок или пользовательские параметры на основе [cleave.js](https://nosir.github.io/cleave.js/)[[target=_blank]]. По умолчанию возвращается необработанное значение."
       },
       "styles": {
         "title": "Стили",
@@ -2176,7 +2179,7 @@
   },
   "accordion": {
     "title": "Accordion",
-    "summaryText": "Позволяет управлять группой [раскрываемых панелей](https://vuestic.dev/ui-elements/collapse).",
+    "summaryText": "Позволяет управлять группой [раскрываемых панелей](https://vuestic.dev/ui-elements/collapse)[[target=_blank]].",
     "examples": {
       "default": {
         "title": "Базовое использование",
@@ -2240,7 +2243,7 @@
   },
   "grid": {
     "title": "Grid Layout",
-    "summaryText": "Мы предоставляем вам вспомогательные классы для [flex](https://developer.mozilla.org/ru/docs/Web/CSS/flex). Для [css grid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout) встроенных классов не предоставляется. Это не означает, что вам *нужно* использовать `flex`, но он остается мощным инструментом.",
+    "summaryText": "Мы предоставляем вам вспомогательные классы для [flex](https://developer.mozilla.org/ru/docs/Web/CSS/flex)[[target=_blank]]. Для [css grid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout)[[target=_blank]] встроенных классов не предоставляется. Это не означает, что вам *нужно* использовать `flex`, но он остается мощным инструментом.",
     "examples": {
       "default": {
         "title": "Включение flexbox"
@@ -2429,7 +2432,7 @@
       },
       "styles": {
         "title": "Стили",
-        "text": "Применяются те же стили, что и для компонента [va-input](https://vuestic.dev/ui-elements/input)."
+        "text": "Применяются те же стили, что и для компонента [va-input](https://vuestic.dev/ui-elements/input)[[target=_blank]]."
       }
     }
   },
@@ -2472,12 +2475,12 @@
       "title": "Reset возможности",
       "info": "Ниже находится список возможностей которые предоставляет reset.scss:",
       "list": "* Margin и padding reset. \n * Border reset. \n * Hide quotes. \n * Font reset. \n * Hidden-attribute fix для более новых браузеров. \n * HTML5 display-role reset для более старых браузеров",
-      "more": "Полный список всех примененных стилей можно посмотреть здесь [reset.scss](https://github.com/epicmaxco/vuestic-ui/blob/develop/packages/ui/src/styles/global/reset.scss) stylesheet."
+      "more": "Полный список всех примененных стилей можно посмотреть здесь [reset.scss](https://github.com/epicmaxco/vuestic-ui/blob/develop/packages/ui/src/components/vuestic-sass/global/reset.scss)[[target=_blank]] stylesheet."
     }
   },
   "colorPicker": {
     "title": "Color Picker",
-    "summaryText": "Компонент который помогает выбрать цвет. Мы используем [vue-color](https://github.com/xiaokaike/vue-color) библиотеку для этого компонента. Будет изменено в следующих версиях.",
+    "summaryText": "Компонент который помогает выбрать цвет. Мы используем [vue-color](https://github.com/xiaokaike/vue-color)[[target=_blank]] библиотеку для этого компонента. Будет изменено в следующих версиях.",
     "examples": {
       "default": {
         "title": "Базовое использование",
@@ -2612,7 +2615,7 @@
       },
       "styles": {
         "title": "Разные стили",
-        "text": "Вы можете использовать стили компонента [va-button](https://vuestic.dev/ui-elements/button)."
+        "text": "Вы можете использовать стили компонента [va-button](https://vuestic.dev/ui-elements/button)[[target=_blank]]."
       },
       "icons": {
         "title": "Иконки",
@@ -2646,7 +2649,7 @@
       },
       "styles": {
         "title": "Разные стили",
-        "text": "Вы можете использовать стили компонента [va-button](https://vuestic.dev/ui-elements/button)."
+        "text": "Вы можете использовать стили компонента [va-button](https://vuestic.dev/ui-elements/button)[[target=_blank]]."
       },
       "disabled": {
         "title": "Недоступная кнопка",
@@ -2707,8 +2710,8 @@
     "description": "Начните работу с Vuestic UI, чтобы создавать многофункциональные и удобные приложения благодаря нашей гибко настраиваемой структуре. Мы максимально упростили процесс установки, чтобы сэкономить ваши усилия. Установка возможна несколькими способами.",
     "subtitle": "Вы можете начать использовать Vuestic с простых шагов, как вам удобнее.",
     "prerequisites": "Во-первых, убедитесь, что у вас установлены все необходимые зависимости:",
-    "node": "<a href=\"https://nodejs.org/en/\">Node.js</a> ( >=14.*)",
-    "npm": "<a href=\"https://www.npmjs.com/get-npm\">npm</a> версия 3+ ( or <a href=\"https://yarnpkg.com/lang/en/docs/install\">yarn</a> version 1.16+) и <a href=\"https://git-scm.com/\">Git</a",
+    "node": "[Node.js](https://nodejs.org/en/)[[target=_blank]] ( >=14.*)",
+    "npm": "[npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)[[target=_blank]] версия 3+ (или [yarn](https://yarnpkg.com/lang/en/docs/install)[[target=_blank]] версия 1.16+) и [Git](https://git-scm.com/)[[target=_blank]]",
     "afterCheck": "После проверки предварительных требований установите Vuestic UI через `npm/yarn`:",
     "fonts": {
       "title": "Установка шрифтов",
@@ -2722,8 +2725,8 @@
     },
     "cli": {
       "title": "Установка через Vue CLI",
-      "prepare": "Перед установкой убедитесь, что [Vue CLI](https://cli.vuejs.org/guide/installation.html) установлен глобально и имеет версию 4+:",
-      "upgrade": "Ознакомьтесь с [руководством](https://cli.vuejs.org/migrating-from-v3/#migrating-from-v3) для Vue CLI версии 3, которое поможет вам обновить приложение",
+      "prepare": "Перед установкой убедитесь, что [Vue CLI](https://cli.vuejs.org/guide/installation.html)[[target=_blank]] установлен глобально и имеет версию 4+:",
+      "upgrade": "Ознакомьтесь с [руководством](https://cli.vuejs.org/migrating-from-v3/#migrating-from-v3)[[target=_blank]] для Vue CLI версии 3, которое поможет вам обновить приложение",
       "description": "Простой способ, если вы используете настройку через Vue-CLI или хотите опробовать Vuestic UI в новом проекте.",
       "attention": "Установка Vuestic UI изменит файлы package.json и main.js (ts). Убедитесь, что вы закоммитили свой код перед его установкой, чтобы избежать потери данных",
       "codeAnnotation": "Затем установите Vuestic UI как плагин Vue-CLI:"
@@ -2758,7 +2761,7 @@
     },
     "0-1": {
       "title": "v0.1",
-      "description": "Даже не альфа, мы просто выделили компоненты из [vuestic-admin](https://github.com/epicmaxco/vuestic-admin) в отдельный репозиторий, чтобы упростить обновления."
+      "description": "Даже не альфа, мы просто выделили компоненты из [vuestic-admin](https://github.com/epicmaxco/vuestic-admin)[[target=_blank]] в отдельный репозиторий, чтобы упростить обновления."
     },
     "released": {
       "title": "Выпущено",
@@ -2804,13 +2807,13 @@
       "description": "Допустим, вам нужно, чтобы все ваши кнопки были `outline` и `small` в соответствии с дизайном, но по умолчанию это не так:",
       "action": "Чтобы решить эту проблему - добавьте в свой `main.js`:",
       "result": "Теперь ваши кнопки будут выглядеть так:",
-      "example": "Аналогичным образом вы можете глобально настроить любые свойства для компонентов Vuestic Ui.",
-      "more": "Если вам нужна более глубокая кастомизация, то вы можете переопределить [переменные css](https://vuestic.dev/en/styles/css-variables#overriding) или свойства класса напрямую (в компонентах используется БЭМ, так что селекторы легко угадать)."
+      "example": "Аналогичным образом вы можете глобально настроить любые свойства для компонентов Vuestic UI.",
+      "more": "Если вам нужна более глубокая кастомизация, то вы можете переопределить [переменные css](/styles/css-variables#overriding) или свойства класса напрямую (в компонентах используется БЭМ, так что селекторы легко угадать)."
     }
   },
   "browserSupport": {
     "title": "Поддрежка браузеров",
-    "description": "Мы разрабатываем Vuestic UI с расчетом на будущее. Вот почему мы поддерживаем современные браузеры, но извините, пришлось отказаться от некоторых старых браузеров, таких как IE. На это решение повлияло [прекращение его поддержки во Vue 3](https://github.com/vuejs/rfcs/discussions/296) и [падение рейтинга использования](https://caniuse.com/usage-table).",
+    "description": "Мы разрабатываем Vuestic UI с расчетом на будущее. Вот почему мы поддерживаем современные браузеры, но извините, пришлось отказаться от некоторых старых браузеров, таких как IE. На это решение повлияло [прекращение его поддержки во Vue 3](https://github.com/vuejs/rfcs/discussions/296)[[target=_blank]] и [падение рейтинга использования](https://caniuse.com/usage-table)[[target=_blank]].",
     "table": {
       "browser": "Браузер",
       "supported": "Поддержка"
@@ -2876,7 +2879,7 @@
         "dontSubmitToMaster": "**Не отправляйте ваши PR в ветку master.**",
         "checkoutFeat": "Сделайте checkout ветки `feat/` из ветки `develop`, затем создайте pull request в ту же ветку.",
         "multipleSmallCommits": "Совершенно нормально иметь несколько небольших коммитов, когда вы работаете над вашим PR - мы позволим GitHub сделать автоматический squash изменений перед слянием.",
-        "fixBugSteps": "В случае исправления бага:\n  * Если вы решаете особую проблему, добавьте `close #xxxx[,#xxx]` (#xxxx - id проблемы) в описание PR так что github [закроет](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) проблему, как только изменения сольются в `master`.\n  * Предоставьте подробное описание ошибки в PR, если это не было сделано в вопросе (issue)."
+        "fixBugSteps": "В случае исправления бага:\n  * Если вы решаете особую проблему, добавьте `close #xxxx[,#xxx]` (#xxxx - id проблемы) в описание PR так что github [закроет](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)[[target=_blank]] проблему, как только изменения сольются в `master`.\n  * Предоставьте подробное описание ошибки в PR, если это не было сделано в вопросе (issue)."
       }
     },
     "branches": {
@@ -2897,10 +2900,10 @@
       "smallIssues": "Для небольших изменений вы можете пушить в ветку `develop` напрямую при добавлении (`close #123`) в сообщение коммита.",
       "singlePrPerIssue": "Создавайте один PR для одной проблемы. Если у нас несколько PR - переместите весь код в один, а остальные закройте. Если один PR охватывает несколько вопросов - либо разделите его на несколько PR, либо отметьте одну из проблем как повторяющуюся.",
       "onePersonPerIssue": "Убедитесь, что на каждую проблему назначен только один человек.",
-      "checkYourCode": "Проверьте свой код: [соглашения](https://github.com/epicmaxco/vuestic-ui/blob/master/packages/docs/conventions.md).",
-      "weUseYarn": "Мы используем [yarn](https://yarnpkg.com/lang/en/) для управления пакетами.",
+      "checkYourCode": "Проверьте свой код: [соглашения](https://github.com/epicmaxco/vuestic-ui/blob/master/packages/docs/conventions.md)[[target=_blank]].",
+      "weUseYarn": "Мы используем [yarn](https://yarnpkg.com/lang/en/)[[target=_blank]] для управления пакетами.",
       "beProactive": "Будьте инициативными. Если вы считаете, что что-то не так - создайте вопрос (issue) или обсужденеи (discuss).",
-      "recommendedTools": "Рекомендуемые инструменты: [GitKraken](https://www.gitkraken.com/), [WebStorm](https://www.jetbrains.com/webstorm/), [ShareX](https://getsharex.com/).",
+      "recommendedTools": "Рекомендуемые инструменты: [GitKraken](https://www.gitkraken.com/)[[target=_blank]], [WebStorm](https://www.jetbrains.com/webstorm/)[[target=_blank]], [ShareX](https://getsharex.com/)[[target=_blank]].",
       "workInBook": "Если вы работаете над UI компонентами - работайте в book environment (`yarn serve:book`). Мы хотим исключить глобальные материалы из компонентов."
     },
     "componentFolderStructure": {
@@ -2915,7 +2918,7 @@
     },
     "credits": {
       "title": "Credits",
-      "description": "<a href=\"https://github.com/epicmaxco/vuestic-ui/graphs/contributors\">Зал славы!</a>"
+      "description": "[Зал славы!](https://github.com/epicmaxco/vuestic-ui/graphs/contributors)[[target=_blank]]"
     }
   },
   "globalConfig": {
@@ -3048,7 +3051,7 @@
   },
   "cssVariables": {
     "title": "Переменные CSS",
-    "description": "Vuestic UI выделяет `CSS` как [переменные CSS (пользовательские свойства)](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties). Нет необходимости устанавливать какие-либо загрузчики или дополнительные пакеты для переопределения стилей компонентов. Вы можете глубоко настраивать компоненты, используя простой синтаксис для изменения CSS в вашем проекте.",
+    "description": "Vuestic UI выделяет `CSS` как [переменные CSS (пользовательские свойства)](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties)[[target=_blank]]. Нет необходимости устанавливать какие-либо загрузчики или дополнительные пакеты для переопределения стилей компонентов. Вы можете глубоко настраивать компоненты, используя простой синтаксис для изменения CSS в вашем проекте.",
     "convention": {
       "title": "Соглашения",
       "description": "В Vuestic UI применяются следующие соглашения для организации переменных CSS для более удобного использования:"
@@ -3097,7 +3100,7 @@
       },
       "styles": {
         "title": "Стили",
-        "text": "Применяются те же стили, что и для компонента [va-button](https://vuestic.dev/ui-elements/button)."
+        "text": "Применяются те же стили, что и для компонента [va-button](https://vuestic.dev/ui-elements/button)[[target=_blank]]."
       },
       "disabled": {
         "title": "Недоступная кнопка",
@@ -3165,27 +3168,11 @@
     "description": "В Vuestic UI применяются следующие стили типографики.",
     "headings": "Заголовки",
     "affected": "Применено",
-    "display1": "`class=\"display-1\"`",
-    "display2": "`class=\"display-2\"`",
-    "display3": "`class=\"display-3\"`",
-    "display4": "`class=\"display-4\"`",
-    "display5": "`class=\"display-5\"`",
-    "titled": "`class=\"title\"`",
     "primary": "Стиль текста по умолчанию",
-    "secondary": "`class=\"text--secondary\"`",
-    "codeSnippet": "`class=\"code-snippet\"`",
-    "textCode": "`class=\"text--code\"`",
     "other": "Другие типографические стили",
     "lists": "Списки",
-    "orderedLists": "`class=\"va-ordered\"`",
-    "unorderedLists": "`class=\"va-unordered\"`",
     "links": "Ссылки",
-    "link": "`class=\"link\"`",
-    "linkSecondary": "`class=\"link-secondary\"`",
-    "otherElements": "Другие элементы",
-    "textHighlighted": "`class=\"text--highlighted\"`",
-    "blockquote": "`class=\"va-blockquote\"`",
-    "textBlock": "`class=\"text-block\"`"
+    "otherElements": "Другие элементы"
   },
   "ag-grid-wrapper": {
     "title": "AG Grid Wrapper",
@@ -3205,7 +3192,7 @@
     "highLevelStrategy": {
       "title": "Высокоуровневая стратегия",
       "description": {
-        "userExpectations": "Компоненты должны быть такими, какими их ожидает видеть пользователь. Мы достигаем этого, изучая следующие проекты ([Vuetify](https://vuetifyjs.com), [Quasar](https://quasar.dev), [Ant Design](https://ant.design), [iView](http://iview.talkingdata.com), [Element UI](https://element.eleme.io), etc.).",
+        "userExpectations": "Компоненты должны быть такими, какими их ожидает видеть пользователь. Мы достигаем этого, изучая следующие проекты ([Vuetify](https://vuetifyjs.com)[[target=_blank]], [Quasar](https://quasar.dev)[[target=_blank]], [Ant Design](https://ant.design)[[target=_blank]], [iView](http://iview.talkingdata.com)[[target=_blank]], [Element UI](https://element.eleme.io), etc.)[[target=_blank]].",
         "qualityComponents": "Компоненты должны быть качественными. Мы достигаем этого путем ручного тестирования особых случаев + раннего и частого рефакторинга."
       }
     },
@@ -3214,7 +3201,7 @@
       "description": {
         "visualFeedback": "**Визуальная обратная связь** - когда пользователь взаимодействует с компонентом, он должен видеть результат своих действий (может быть реализован с помощью :active селектора или как-то иначе в зависимости от компонента).",
         "keyboardNavigation": "**Клавиатурная навигация** - Вы должны убедиться, что элементы пользовательского интерфейса доступны с клавиатуры, или же отключить эту функцию для элементов, которые не должны получать фокус через клавиатуру.",
-        "statelessSupport": "Поддержка **внутреннего состояния** компонента (прочтите об [StatefulMixin](https://github.com/epicmaxco/vuestic-ui/blob/develop/packages/ui/src/components/vuestic-mixins/StatefulMixin/README.md))."
+        "statelessSupport": "Поддержка **внутреннего состояния** компонента (прочтите об [StatefulMixin](https://github.com/epicmaxco/vuestic-ui/blob/develop/packages/ui/src/components/vuestic-mixins/StatefulMixin/README.md)[[target=_blank]])."
       }
     }
   }

--- a/packages/docs/src/main.ts
+++ b/packages/docs/src/main.ts
@@ -11,7 +11,14 @@ import { VuesticConfig } from './config/vuestic-config'
 import { useGtag } from './services/gtag'
 import { useMeta } from '@/services/vue-meta'
 
-export const i18n = createI18n({ locale: 'en', messages, fallbackLocale: 'en' })
+export const i18n = createI18n({
+  locale: DEFAULT_LANGUAGE,
+  fallbackLocale: 'en',
+  messages,
+  missing(_, key) {
+    return key
+  },
+})
 
 const app = createApp(App)
 

--- a/packages/docs/src/markdown-it-attrs.d.ts
+++ b/packages/docs/src/markdown-it-attrs.d.ts
@@ -1,0 +1,1 @@
+declare module 'markdown-it-attrs'

--- a/packages/docs/src/utilities/markdown-view/MarkdownIt.ts
+++ b/packages/docs/src/utilities/markdown-view/MarkdownIt.ts
@@ -1,0 +1,36 @@
+// @ts-ignore
+import MarkdownIt from 'markdown-it'
+import markdownItAttrs from 'markdown-it-attrs'
+import { locale } from '../../helpers/I18nHelper'
+import { setClassAttributeToExternalLinks, AttributesOptions } from './set-class-attribute-to-external-links'
+import {
+  setOriginLocationToRelativeLinks,
+  LocaleOptions,
+  ExternalLinkStartWith,
+} from './set-origin-location-to-relative-links'
+
+const md = new MarkdownIt({
+  breaks: true,
+  typographer: true,
+  html: true,
+})
+
+export const externalLinkStartWith: ExternalLinkStartWith = ['http://', 'https://']
+
+export const localeOptions: LocaleOptions = {
+  currentLocale: locale,
+  externalLinkStartWith,
+}
+
+export const attributesOptions: AttributesOptions = {
+  className: '',
+}
+
+md.use(setOriginLocationToRelativeLinks, localeOptions)
+  .use(setClassAttributeToExternalLinks, attributesOptions)
+  .use(markdownItAttrs, {
+    leftDelimiter: '[[',
+    rightDelimiter: ']]',
+  })
+
+export default md

--- a/packages/docs/src/utilities/markdown-view/MarkdownView.vue
+++ b/packages/docs/src/utilities/markdown-view/MarkdownView.vue
@@ -3,37 +3,54 @@
 </template>
 
 <script lang="ts">
-import { Options, Vue, prop, mixins } from 'vue-class-component'
-// @ts-ignore
-import MarkdownIt from 'markdown-it'
-
-const md = new MarkdownIt({
-  breaks: true,
-  typographer: true,
-  html: true,
-})
-
-class Props {
-  value = prop<string>({ type: String, required: true })
-  tag = prop<string>({ type: String, default: 'div' })
-  inline = prop<boolean>({ type: Boolean, default: false })
-}
-
-const PropsMixin = Vue.with(Props)
+import { defineComponent, computed, toRefs, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import md, { localeOptions, attributesOptions } from './MarkdownIt'
 
 /**
  * This component converts markdown to html and presents it.
  */
-@Options({})
-export default class MarkdownView extends mixins(PropsMixin) {
-  get text () {
-    if (this.inline) {
-      return md.renderInline(this.value)
+export default defineComponent({
+  name: 'MarkdownView',
+  components: {},
+  props: {
+    value: {
+      type: String,
+      required: true,
+    },
+    tag: {
+      type: String,
+      default: 'div',
+    },
+    inline: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  setup (props) {
+    const { inline, value } = toRefs(props)
+    const { locale } = useI18n()
+
+    attributesOptions.className = 'MarkdownView__link--external'
+
+    watch(locale, (newValue) => {
+      localeOptions.currentLocale = newValue
+    })
+
+    const text = computed(() => {
+      if (inline.value) {
+        return md.renderInline(value.value)
+      }
+      return md.render(value.value)
+    })
+
+    return {
+      text
     }
-    return md.render(this.value)
-  }
-}
+  },
+})
 </script>
+
 <style lang="scss">
 @import "~vuestic-ui/src/styles/resources/resources";
 
@@ -41,6 +58,20 @@ export default class MarkdownView extends mixins(PropsMixin) {
   code {
     margin: 0 0.3rem;
     color: $markdown-code;
+  }
+}
+
+.MarkdownView__link--external {
+  position: relative;
+  padding-right: 0.85rem;
+
+  &::after {
+    content: '\279A';
+    position: absolute;
+    right: 0;
+    top: 0;
+    opacity: 0.4;
+    line-height: 1;
   }
 }
 </style>

--- a/packages/docs/src/utilities/markdown-view/set-class-attribute-to-external-links.ts
+++ b/packages/docs/src/utilities/markdown-view/set-class-attribute-to-external-links.ts
@@ -1,0 +1,23 @@
+export type AttributesOptions = {
+  className: string,
+} 
+
+export const setClassAttributeToExternalLinks = (md: any, attributesOptions: AttributesOptions): void => {
+  const defaultRender = md.renderer.rules.link_open || function(tokens: any, idx: number, options: any, env: any, self: any) {
+    return self.renderToken(tokens, idx, options)
+  }
+
+  md.renderer.rules.link_open = function (tokens: any, idx: number, options: any, env: any, self: any) {
+    const token = tokens[idx]
+    
+    if (token.attrIndex('target') >= 0) {
+      const isExternalLink = (token.attrGet('target') === '_blank')
+      
+      if (isExternalLink) {
+        token.attrJoin('class', attributesOptions.className)
+      }
+    }
+
+    return defaultRender(tokens, idx, options, env, self)
+  }
+}

--- a/packages/docs/src/utilities/markdown-view/set-origin-location-to-relative-links.ts
+++ b/packages/docs/src/utilities/markdown-view/set-origin-location-to-relative-links.ts
@@ -1,0 +1,37 @@
+export type ExternalLinkStartWith = Array<string>
+
+export type LocaleOptions = {
+  currentLocale: string,
+  externalLinkStartWith: ExternalLinkStartWith,
+} 
+
+export const setOriginLocationToRelativeLinks = (md: any, localeOptions: LocaleOptions): void => {
+  const defaultRender = md.renderer.rules.link_open || function(tokens: any, idx: number, options: any, env: any, self: any) {
+    return self.renderToken(tokens, idx, options)
+  }
+
+  md.renderer.rules.link_open = function (tokens: any, idx: number, options: any, env: any, self: any) {
+    const token = tokens[idx]
+
+    if (token.attrIndex('href') >= 0) {
+      const hrefAttrValue: string = token.attrGet('href')
+  
+      const isInternalLink = localeOptions.externalLinkStartWith.reduce((is, item) => {
+        if (hrefAttrValue.startsWith(item)) {
+          return is = false
+        }
+        return is
+      }, true)
+      
+      if (isInternalLink) {
+        const normalizedHref = hrefAttrValue.startsWith('/')
+          ? hrefAttrValue.substring(1)
+          : hrefAttrValue
+
+        token.attrSet('href' ,`${location.origin}/${localeOptions.currentLocale}/${normalizedHref}`)
+      }
+    }
+
+    return defaultRender(tokens, idx, options, env, self)
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11127,6 +11127,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-it-attrs@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-attrs/-/markdown-it-attrs-4.0.0.tgz#eadae3ea0c7d17c5e83b98a4ec95a47f4e4960f5"
+  integrity sha512-uLjtdCmhhmL3BuZsReYkFxk74qKjj5ahe34teBpOCJ4hYZZl7/ftLyXWLowngC2moRkbLEvKwN/7TMwbhbHE/A==
+
 markdown-it@^12.0.6:
   version "12.0.6"
   resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.0.6.tgz#adcc8e5fe020af292ccbdf161fe84f1961516138"


### PR DESCRIPTION
## Description
close #962

Some of the changes:
- add external package and connect plugin "markdown-it-attrs", allowed to include attributes (with special delimiters) to markdown tokens (in our case, to links: `[[target="_blank"]]`)
- add `setClassAttributeToExternalLinks` plugin
- add `setOriginLocationToRelativeLinks` plugin (set `window.location.origin` and locale (from `useI18n` hook))
- split `MarkdownIt` into a separate instance
- rewrite `MarkdownView` in Composition API style
- replace `<a>` tags with markdown syntax in locale strings, add `[[target="_blank"]]` to all external links
- minor updates locales, page-config files

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
