### PR TITLE
VA-998 move tslib to dependencies

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -44,6 +44,7 @@
     "flatpickr": "4.6.9",
     "lodash-es": "^4.17.21",
     "normalize.css": "^8.0.1",
+    "tslib": "^2.2.0",
     "vue-flatpickr-component": "^9.0.3"
   },
   "devDependencies": {
@@ -111,7 +112,6 @@
     "ts-jest": "^26.5.4",
     "ts-loader": "^8.0.14",
     "ts-node": "^9.1.1",
-    "tslib": "^2.3.0",
     "typescript": "^4.1.3",
     "vue": "^3.0.4",
     "vue-book": "0.2.0-alpha.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17004,15 +17004,15 @@ tslib@2.1.0, tslib@^2.0.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
+tslib@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
+
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
-  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
 tsutils@^3.17.1:
   version "3.21.0"


### PR DESCRIPTION
Moved the `tslib` from `devDependencies` to `dependencies` to remove the warning when installing the project.

## Description
Close https://github.com/epicmaxco/vuestic-ui/issues/998

Installed minimum version 2.2.0, same as in child library which requires this dependency ([asvae-executors](https://github.com/asvae/executors)).

![image](https://user-images.githubusercontent.com/60774386/129018857-dcf71cf5-d13e-419f-a2d1-71f1b3090466.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
