### PR TITLE
Fix vite build

### DIFF
--- a/packages/ui/build/rollup/generate-rollup-inputs.js
+++ b/packages/ui/build/rollup/generate-rollup-inputs.js
@@ -1,0 +1,27 @@
+import { readdirSync, existsSync, lstatSync } from 'fs'
+import { resolve } from 'path'
+
+const readDirRecursive = (path) => {
+  return readdirSync(path)
+    .reduce((acc, entry) => {
+      const p = `${path}/${entry}`
+
+      if (lstatSync(p).isDirectory()) {
+        return [...acc, ...readDirRecursive(p)]
+      }
+
+      return [...acc, p]
+    }, [])
+}
+
+export const getInputs = () => {
+  const components = readdirSync('./src/components')
+    .filter((folderName) => !folderName.startsWith('wip-'))
+    .map((folderName) => `./src/components/${folderName}/index.ts`)
+    .filter((filePath) => existsSync(filePath))
+
+  const utils = readdirSync('./src/utils')
+  const services = readDirRecursive('./src/services')
+
+  return [...components]
+}


### PR DESCRIPTION
For some reason, Vite can not build bundled lib using `preserve modules` option. So I decided to split esm bundle into chunks providing multiple inputs, that were generated using readdir of `/src/components` folder.

I checked this PR with `vite preview` command nad `vite dev`.

It also works with webpack (vue-cli).

I think this PR should be merged after tree-shaking tests is ready to prevent unexpected issues.
closes #1024