### PR TITLE
Fix #923: Vue Devtools

### DIFF
--- a/packages/docs/src/App.vue
+++ b/packages/docs/src/App.vue
@@ -16,6 +16,7 @@ const eventBus = {
 }
 
 export default {
+  name: 'App',
   data () {
     return {
       eventBus,

--- a/packages/docs/src/components/DocsAlert.vue
+++ b/packages/docs/src/components/DocsAlert.vue
@@ -9,7 +9,7 @@
 <script lang="ts">
 import { Options, Vue, mixins, prop } from 'vue-class-component'
 import MarkdownView from '../utilities/markdown-view/MarkdownView.vue'
-import { TranslationString } from '../components/DocsApi/ManualApiOptions'
+import { TranslationString } from '@/components/DocsApi/ManualApiOptions'
 
 class Props {
   text = prop<TranslationString>({ type: String })
@@ -19,6 +19,7 @@ class Props {
 const PropsMixin = Vue.with(Props)
 
 @Options({
+  name: 'DocsAlert',
   components: { MarkdownView },
 })
 export default class DocsAlert extends mixins(PropsMixin) {

--- a/packages/docs/src/components/DocsApi/ApiDocs.vue
+++ b/packages/docs/src/components/DocsApi/ApiDocs.vue
@@ -159,6 +159,7 @@ class Props {
 const PropsMixin = Vue.with(Props)
 
 @Options({
+  name: 'ApiDocs',
   components: { ApiDocsPropsRow, MarkdownView, DocsTable },
 })
 export default class ApiDocs extends mixins(PropsMixin) {

--- a/packages/docs/src/components/DocsApi/ApiDocsPropsRow.vue
+++ b/packages/docs/src/components/DocsApi/ApiDocsPropsRow.vue
@@ -21,6 +21,7 @@ class Props {
 const PropsMixin = Vue.with(Props)
 
 @Options({
+  name: 'ApiDocsPropsRow',
   components: { MarkdownView },
 })
 export default class ApiDocsPropsRow extends mixins(PropsMixin) {

--- a/packages/docs/src/components/DocsExample.vue
+++ b/packages/docs/src/components/DocsExample.vue
@@ -19,9 +19,10 @@
 // import VaContent from '../../ui/src/components/va-content/VaContent'
 import DocsCode from './DocsCode'
 import DocsNavigation from './DocsNavigation'
-import { readComponent, readTemplate } from '../utilities/utils'
+import { readComponent, readTemplate } from '@/utilities/utils'
 
 export default {
+  name: 'DocsExample',
   components: { DocsCode, DocsNavigation },
   props: {
     value: {

--- a/packages/docs/src/components/DocsNavigation.vue
+++ b/packages/docs/src/components/DocsNavigation.vue
@@ -7,7 +7,7 @@
       color="gray"
       @click="copy"
     >
-      <i class="docs-navigation__button__icon" :class="copyIcon"/>
+      <i class="docs-navigation__button__icon" :class="copyIcon" />
       <span class="docs-navigation__button__text">{{ copyText }}</span>
     </va-button>
 
@@ -20,12 +20,12 @@
       :href="link.url"
       target="_blank"
     >
-      <i class="docs-navigation__button__icon" :class="link.icon"/>
+      <i class="docs-navigation__button__icon" :class="link.icon" />
       <span class="docs-navigation__button__text">{{ link.text }}</span>
     </va-button>
 
     <form :action="sandboxDefineUrl" method="POST" target="_blank">
-      <input type="hidden" name="parameters" :value="sandboxParams"/>
+      <input type="hidden" name="parameters" :value="sandboxParams" />
       <va-button
         flat
         type="submit"
@@ -33,7 +33,7 @@
         class="docs-navigation__button"
         color="gray"
       >
-        <i class="docs-navigation__button__icon" :class="codeIcon"/>
+        <i class="docs-navigation__button__icon" :class="codeIcon" />
         <span class="docs-navigation__button__text">Open in CodeSandbox</span>
       </va-button>
     </form>
@@ -45,6 +45,7 @@ import { getParameters } from 'codesandbox/lib/api/define'
 import packageUi from '../../../ui/package'
 
 export default {
+  name: 'DocsNavigation',
   props: {
     code: {
       type: String,
@@ -71,7 +72,7 @@ export default {
     }
   },
   methods: {
-    updateCopyButton(icon, text) {
+    updateCopyButton (icon, text) {
       this.copyIcon = icon
       this.copyText = text
     },
@@ -79,7 +80,7 @@ export default {
       try {
         await window.navigator.clipboard.writeText(this.code)
         this.updateCopyButton('fa fa-check', 'Copied')
-      } catch(e) {
+      } catch (e) {
         if (e.message === 'NotAllowedError') { this.updateCopyButton('fa fa-times', 'Permission failure!') }
       }
       setTimeout(() => {

--- a/packages/docs/src/components/DocsTable/DocsTable.vue
+++ b/packages/docs/src/components/DocsTable/DocsTable.vue
@@ -17,10 +17,10 @@
             <strong>{{ colData }}</strong>
           </template>
           <template v-else-if="columnsComputed[index].type === 'markdown'">
-            <MarkdownView :value="$te(colData) ? $t(colData) : colData"/>
+            <MarkdownView :value="$te(colData) ? $t(colData) : colData" />
           </template>
           <template v-else-if="columnsComputed[index].type === 'code'">
-            <MarkdownView :value="`\`${colData}\``"/>
+            <MarkdownView :value="`\`${colData}\``" />
           </template>
           <template v-else-if="columnsComputed[index].type === 'pre'">
             <pre>{{ colData }}</pre>
@@ -51,6 +51,7 @@ class Props {
 const PropsMixin = Vue.with(Props)
 
 @Options({
+  name: 'DocsTable',
   components: { MarkdownView },
 })
 export default class DocsTable extends mixins(PropsMixin) {

--- a/packages/docs/src/components/header/Header.vue
+++ b/packages/docs/src/components/header/Header.vue
@@ -47,6 +47,7 @@ class Props {
 const PropsMixin = Vue.with(Props)
 
 @Options({
+  name: 'DocsHeader',
   components: {
     HeaderSelector,
     LanguageDropdown,

--- a/packages/docs/src/components/header/components/ColorDropdown.vue
+++ b/packages/docs/src/components/header/components/ColorDropdown.vue
@@ -21,6 +21,7 @@ import { getColors } from 'vuestic-ui/src/main'
 import { computed, defineComponent } from 'vue'
 
 export default defineComponent({
+  name: 'DocsColorDropdown',
   setup () {
     const capitalizeFirstLetter = (text: string) => text.charAt(0).toUpperCase() + text.slice(1)
 

--- a/packages/docs/src/components/header/components/HeaderSelector.vue
+++ b/packages/docs/src/components/header/components/HeaderSelector.vue
@@ -22,7 +22,7 @@ import VaIconMenuCollapsed from '@/iconset/VaIconMenuCollapsed.vue'
 import { getColors } from '../../../../../ui/src/main'
 
 export default {
-  name: 'HeaderSelector',
+  name: 'DocsHeaderSelector',
   components: {
     VaIconMenu,
     VaIconMenuCollapsed,

--- a/packages/docs/src/components/header/components/LanguageDropdown.vue
+++ b/packages/docs/src/components/header/components/LanguageDropdown.vue
@@ -33,9 +33,10 @@ import { computed, defineComponent } from 'vue'
 import { getColors } from 'vuestic-ui/src/main'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
-import { languages } from '../../../locales'
+import { languages } from '@/locales'
 
 export default defineComponent({
+  name: 'DocsLanguageDropdown',
   setup () {
     const { locale, t } = useI18n()
     const router = useRouter()
@@ -53,7 +54,7 @@ export default defineComponent({
       if (locale.value === newLocale) { return }
 
       localStorage.setItem('language', newLocale)
-      
+
       const currentPathWithoutLocale = getCurrentPathWithoutLocale()
 
       router.push('/' + newLocale + currentPathWithoutLocale)

--- a/packages/docs/src/components/header/components/VersionDropdown.vue
+++ b/packages/docs/src/components/header/components/VersionDropdown.vue
@@ -20,7 +20,12 @@
 
 <script lang="ts">
 // @ts-nocheck
-import { Vue } from 'vue-class-component'
+import { Options, Vue } from 'vue-class-component'
+import VaIcon from 'vuestic-ui/src/components/va-icon'
+
+@Options({
+  name: 'DocsVersionDropdown',
+})
 
 export default class VersionDropdown extends Vue {
   data () {

--- a/packages/docs/src/components/header/components/VuesticDocsLogo.vue
+++ b/packages/docs/src/components/header/components/VuesticDocsLogo.vue
@@ -11,11 +11,11 @@
 </template>
 
 <script>
-import { Options, setup, Vue } from 'vue-class-component'
+import { Options, Vue } from 'vue-class-component'
 import { getColors } from 'vuestic-ui/src/services/color-config/color-config'
 
 @Options({
-  name: 'vuestic-logo',
+  name: 'DocsVuesticLogo',
 })
 export default class VuesticLogo extends Vue {
   get colors () {

--- a/packages/docs/src/components/landing/Admin.vue
+++ b/packages/docs/src/components/landing/Admin.vue
@@ -75,6 +75,7 @@ import { Options, Vue } from 'vue-class-component'
 import StarsButton from './StarsButton.vue'
 
 @Options({
+  name: 'LandingAdmin',
   components: { StarsButton },
 })
 export default class Admin extends Vue {}

--- a/packages/docs/src/components/landing/ColorTab.vue
+++ b/packages/docs/src/components/landing/ColorTab.vue
@@ -71,11 +71,13 @@
 // @ts-nocheck
 import { watch } from 'vue'
 import { Options, Vue } from 'vue-class-component'
-import { ThemeName, ThemeNameIterator } from '../../config/theme-config'
+import { ThemeName, ThemeNameIterator } from '@/config/theme-config'
 import { capitalize } from 'lodash'
-import { getColors } from '../../../../ui/src/services/color-config/color-config'
+import { getColors } from 'vuestic-ui/src/services/color-config/color-config'
 
-@Options({})
+@Options({
+  name: 'LandingColorTab',
+})
 export default class ColorTab extends Vue {
   selectedTheme: string | ThemeName = ThemeName.DEFAULT
 

--- a/packages/docs/src/components/landing/Customize.vue
+++ b/packages/docs/src/components/landing/Customize.vue
@@ -111,7 +111,7 @@
             <div class="customize__content--second">
               <div class="code-wrapper" @click="copyText">
                 <div class="code-subwrapper">
-                  <prism class="code" :code="code"/>
+                  <prism class="code" :code="code" />
                   <input type="hidden" ref="codeInput" :value="code">
                 </div>
               </div>
@@ -136,10 +136,11 @@ import 'prismjs'
 import dedent from 'dedent'
 // @ts-ignore
 import Prism from '../PrismWrapper'
-import { shiftHSLAColor } from '../../../../ui/src/services/color-config/color-functions'
-import { getColors } from '../../../../ui/src/services/color-config/color-config'
+import { shiftHSLAColor } from 'vuestic-ui/src/services/color-config/color-functions'
+import { getColors } from 'vuestic-ui/src/services/color-config/color-config'
 
 @Options({
+  name: 'LandingCustomize',
   components: { Prism, ColorTab },
 })
 export default class Customize extends Vue {

--- a/packages/docs/src/components/landing/Footer.vue
+++ b/packages/docs/src/components/landing/Footer.vue
@@ -84,7 +84,9 @@ import IconAdmin from './icons/IconAdmin.vue'
 import IconSpinners from './icons/IconSpinners.vue'
 import { getColor } from 'vuestic-ui/src/main'
 
-@Options({})
+@Options({
+  name: 'LandingFooter',
+})
 export default class Footer extends Vue {
   IconEpicmax = IconEpicmax
   IconAdmin = IconAdmin

--- a/packages/docs/src/components/landing/OpenSource.vue
+++ b/packages/docs/src/components/landing/OpenSource.vue
@@ -27,7 +27,9 @@
 
 <script lang="ts">
 import { Options, Vue } from 'vue-class-component'
-@Options({})
+@Options({
+  name: 'LandingOpenSource',
+})
 export default class OpenSource extends Vue {}
 </script>
 

--- a/packages/docs/src/components/landing/Preview.vue
+++ b/packages/docs/src/components/landing/Preview.vue
@@ -76,6 +76,12 @@
   </section>
 </template>
 
+<script>
+export default {
+  name: 'LandingPreview',
+}
+</script>
+
 <style lang="scss" scoped>
 @import "src/assets/main";
 

--- a/packages/docs/src/components/landing/SeamlessIntegration/SeamlessIntegration.vue
+++ b/packages/docs/src/components/landing/SeamlessIntegration/SeamlessIntegration.vue
@@ -78,12 +78,13 @@ import SeamlessIntegrationAnotherRangeSlider from './SeamlessIntegrationAnotherR
 import SeamlessIntegrationAnotherCheckbox from './SeamlessIntegrationAnotherCheckbox.vue'
 
 @Options({
+  name: 'LandingSeamlessIntegration',
   components: {
     SeamlessIntegrationAnotherButton,
     SeamlessIntegrationAnotherSelect,
     SeamlessIntegrationAnotherRangeSlider,
-    SeamlessIntegrationAnotherCheckbox
-  }
+    SeamlessIntegrationAnotherCheckbox,
+  },
 })
 export default class Seamless extends Vue {
   value = true

--- a/packages/docs/src/components/landing/StarsButton.vue
+++ b/packages/docs/src/components/landing/StarsButton.vue
@@ -15,6 +15,7 @@
 import { defineComponent, onBeforeMount, ref } from 'vue'
 
 export default defineComponent({
+  name: 'LandingStarsButton',
   props: {
     /** @example epicmaxco/vuestic-ui */
     repo: { type: String, required: true },

--- a/packages/docs/src/components/sidebar/Sidebar.vue
+++ b/packages/docs/src/components/sidebar/Sidebar.vue
@@ -75,6 +75,7 @@ class Props {
 }
 
 @Options({
+  name: 'DocsSidebar',
   components: { AlgoliaSearch, VaSidebarLink },
 })
 export default class Sidebar extends Vue.with(Props) {

--- a/packages/docs/src/components/sidebar/SidebarLink.vue
+++ b/packages/docs/src/components/sidebar/SidebarLink.vue
@@ -16,7 +16,7 @@
 </template>
 <script lang='ts'>
 import { Options, Vue, prop, mixins } from 'vue-class-component'
-import { getHoverColor } from '../../../../ui/src/services/color-config/color-functions'
+import { getHoverColor } from 'vuestic-ui/src/services/color-config/color-functions'
 import ColorMixin from '../../../../ui/src/services/color-config/ColorMixin'
 
 class SidebarLinkProps {
@@ -25,7 +25,9 @@ class SidebarLinkProps {
 
 const SidebarLinkPropsMixin = Vue.with(SidebarLinkProps)
 
-@Options({})
+@Options({
+  name: 'DocsSidebarLink',
+})
 export default class SidebarLink extends mixins(ColorMixin, SidebarLinkPropsMixin) {
   isHovered = false
 

--- a/packages/docs/src/layouts/default.vue
+++ b/packages/docs/src/layouts/default.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="base-layout">
     <div class="base-layout__header">
-      <Header v-model:is-sidebar-visible="isSidebarVisible"/>
+      <Header v-model:is-sidebar-visible="isSidebarVisible" />
     </div>
     <main id="base-layout" class="base-layout__main">
-      <Sidebar v-model:visible="isSidebarVisible" :navigationRoutes="navigationRoutes" :mobile="isSmallScreenDevice"/>
+      <Sidebar v-model:visible="isSidebarVisible" :navigationRoutes="navigationRoutes" :mobile="isSmallScreenDevice" />
       <div
         class="base-layout__content"
         :class="{ 'base-layout__content--expanded': !isSidebarVisible }"
@@ -43,13 +43,14 @@ import { Options, Vue, setup } from 'vue-class-component'
 import type { RouteLocationNormalized } from 'vue-router'
 import Sidebar from '../components/sidebar/Sidebar.vue'
 import Header from '../components/header/Header.vue'
-import { COLOR_THEMES, ThemeName } from '../config/theme-config'
+import { COLOR_THEMES, ThemeName } from '@/config/theme-config'
 import { setColors } from '../../../ui/src/main'
-import { navigationRoutes } from '../components/sidebar/navigationRoutes'
+import { navigationRoutes } from '@/components/sidebar/navigationRoutes'
 import { debounce } from 'lodash'
 import { getSortedNavigationRoutes } from '@/helpers/NavigationRoutesHelper'
 
 @Options({
+  name: 'DocsDefaultLayout',
   components: {
     Header,
     Sidebar,
@@ -159,7 +160,6 @@ export default class DocsLayout extends Vue {
         const el = document.querySelector(newRoute.hash)
         if (el) {
           el.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' })
-          return
         }
       })
     }

--- a/packages/docs/src/pages/MarkdownTest.vue
+++ b/packages/docs/src/pages/MarkdownTest.vue
@@ -8,6 +8,7 @@ import { Options, Vue } from 'vue-class-component'
 import MdView from '@/utilities/markdown-view/MarkdownView.vue'
 
 @Options({
+  name: 'MarkdownTest',
   components: { MdView },
 })
 export default class MarkdownTest extends Vue {

--- a/packages/docs/src/pages/contribution/documentation-page.vue
+++ b/packages/docs/src/pages/contribution/documentation-page.vue
@@ -9,6 +9,7 @@ import DocsContent from '@/components/DocsContent.vue'
 import documentationPageConfig from '@/components/page-configs/contribution/documentation-page/page-config'
 
 @Options({
+  name: 'DocsDocumentationPage',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/contribution/guide.vue
+++ b/packages/docs/src/pages/contribution/guide.vue
@@ -8,6 +8,7 @@ import DocsContent from '@/components/DocsContent.vue'
 import guideConfig from '@/components/page-configs/contribution/guide/page-config'
 
 @Options({
+  name: 'DocsGuide',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/contribution/index.vue
+++ b/packages/docs/src/pages/contribution/index.vue
@@ -5,7 +5,9 @@
 <script lang="ts">
 import { Options, Vue } from 'vue-class-component'
 
-@Options({})
+@Options({
+  name: 'DocsContribution',
+})
 export default class Contribution extends Vue {
 }
 </script>

--- a/packages/docs/src/pages/contribution/translation.vue
+++ b/packages/docs/src/pages/contribution/translation.vue
@@ -9,6 +9,7 @@ import DocsContent from '@/components/DocsContent.vue'
 import translationConfig from '@/components/page-configs/contribution/translation/page-config'
 
 @Options({
+  name: 'DocsTranslation',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/getting-started/accessibility-guide.vue
+++ b/packages/docs/src/pages/getting-started/accessibility-guide.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import accessibilityGuideConfig from '../../components/page-configs/getting-started/accessibility-guide/page-config'
 
 @Options({
+  name: 'DocsAccessibilityGuide',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/getting-started/configuration-guide.vue
+++ b/packages/docs/src/pages/getting-started/configuration-guide.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import configurationGuideConfig from '../../components/page-configs/getting-started/configuration-guide/page-config'
 
 @Options({
+  name: 'DocsConfigurationGuide',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/getting-started/installation.vue
+++ b/packages/docs/src/pages/getting-started/installation.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import installationConfig from '../../components/page-configs/getting-started/installation/page-config'
 
 @Options({
+  name: 'DocsInstallation',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/index.vue
+++ b/packages/docs/src/pages/index.vue
@@ -22,7 +22,7 @@
 
 <script lang="ts">
 // @ts-nocheck
-import { Options, Vue, setup } from 'vue-class-component'
+import { Options, Vue } from 'vue-class-component'
 import Header from '@/components/landing/Header.vue'
 import Preview from '@/components/landing/Preview.vue'
 import Admin from '@/components/landing/Admin.vue'
@@ -32,6 +32,7 @@ import SeamlessIntegration from '@/components/landing/SeamlessIntegration/Seamle
 import Customize from '@/components/landing/Customize.vue'
 
 @Options({
+  name: 'DocsLandingPage',
   components: {
     Header,
     Preview,

--- a/packages/docs/src/pages/index/reset.vue
+++ b/packages/docs/src/pages/index/reset.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import resetConfig from '../../components/page-configs/reset/page-config'
 
 @Options({
+  name: 'DocsReset',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/introduction/browser-support.vue
+++ b/packages/docs/src/pages/introduction/browser-support.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import browserSupportConfig from '../../components/page-configs/introduction/browser-support/page-config'
 
 @Options({
+  name: 'DocsBrowserSupport',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/introduction/overview.vue
+++ b/packages/docs/src/pages/introduction/overview.vue
@@ -1,5 +1,5 @@
 <template>
-  <docs-content :config="configComputed"/>
+  <docs-content :config="configComputed" />
 </template>
 
 <script lang="ts">
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import overviewConfig from '../../components/page-configs/introduction/overview/page-config'
 
 @Options({
+  name: 'DocsOverview',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/introduction/roadmap.vue
+++ b/packages/docs/src/pages/introduction/roadmap.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import roadmapConfig from '../../components/page-configs/introduction/roadmap/page-config'
 
 @Options({
+  name: 'DocsRoadmap',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/services/advanced-icons-config.vue
+++ b/packages/docs/src/pages/services/advanced-icons-config.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import advancedIconsConfigConfig from '../../components/page-configs/services/advanced-icons-config/page-config'
 
 @Options({
+  name: 'DocsAdvancedIconsConfig',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/services/colors-config.vue
+++ b/packages/docs/src/pages/services/colors-config.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import colorsConfigConfig from '../../components/page-configs/services/colors-config/page-config'
 
 @Options({
+  name: 'DocsColorsConfig',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/services/components-config.vue
+++ b/packages/docs/src/pages/services/components-config.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import componentsConfigConfig from '../../components/page-configs/services/components-config/page-config'
 
 @Options({
+  name: 'DocsComponentConfig',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/services/global-config.vue
+++ b/packages/docs/src/pages/services/global-config.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import globalConfigConfig from '../../components/page-configs/services/global-config/page-config'
 
 @Options({
+  name: 'DocsGlobalConfig',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/services/icons-config.vue
+++ b/packages/docs/src/pages/services/icons-config.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import iconsConfigConfig from '../../components/page-configs/services/icons-config/page-config'
 
 @Options({
+  name: 'DocsIconsConfig',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/styles/ag-grid-wrapper.vue
+++ b/packages/docs/src/pages/styles/ag-grid-wrapper.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import config from '../../components/page-configs/styles/ag-grid-wrapper/page-config'
 
 @Options({
+  name: 'DocsStylesAgGridWrapper',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/styles/css-variables.vue
+++ b/packages/docs/src/pages/styles/css-variables.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import cssVariablesConfig from '../../components/page-configs/styles/css-variables/page-config'
 
 @Options({
+  name: 'DocsStylesCssVariables',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/styles/grid.vue
+++ b/packages/docs/src/pages/styles/grid.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import gridConfig from '../../components/page-configs/styles/grid/page-config'
 
 @Options({
+  name: 'DocsStylesGrid',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/styles/table.vue
+++ b/packages/docs/src/pages/styles/table.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import tableConfig from '../../components/page-configs/styles/va-table/page-config'
 
 @Options({
+  name: 'DocsStylesTable',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/styles/typography.vue
+++ b/packages/docs/src/pages/styles/typography.vue
@@ -1,5 +1,5 @@
 <template>
-  <docs-content :config="configComputed"/>
+  <docs-content :config="configComputed" />
 </template>
 
 <script lang="ts">
@@ -9,6 +9,7 @@ import typographyConfig
   from '../../components/page-configs/styles/typography/page-config'
 
 @Options({
+  name: 'DocsStylesTypography',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/accordion.vue
+++ b/packages/docs/src/pages/ui-elements/accordion.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import accordionConfig from '../../components/page-configs/ui-elements/va-accordion/page-config'
 
 @Options({
+  name: 'DocsAccordion',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/affix.vue
+++ b/packages/docs/src/pages/ui-elements/affix.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import affixConfig from '../../components/page-configs/ui-elements/va-affix/page-config'
 
 @Options({
+  name: 'DocsAffix',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/alert.vue
+++ b/packages/docs/src/pages/ui-elements/alert.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import alertConfig from '../../components/page-configs/ui-elements/va-alert/page-config'
 
 @Options({
+  name: 'DocsAlert',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/app-bar.vue
+++ b/packages/docs/src/pages/ui-elements/app-bar.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import appBarConfig from '../../components/page-configs/ui-elements/va-app-bar/page-config'
 
 @Options({
+  name: 'DocsAppBar',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/avatar.vue
+++ b/packages/docs/src/pages/ui-elements/avatar.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import avatarConfig from '../../components/page-configs/ui-elements/va-avatar/page-config'
 
 @Options({
+  name: 'DocsAvatar',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/backtop.vue
+++ b/packages/docs/src/pages/ui-elements/backtop.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import backtopConfig from '../../components/page-configs/ui-elements/va-backtop/page-config'
 
 @Options({
+  name: 'DocsBacktop',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/badge.vue
+++ b/packages/docs/src/pages/ui-elements/badge.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import badgeConfig from '../../components/page-configs/ui-elements/va-badge/page-config'
 
 @Options({
+  name: 'DocsBadge',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/breadcrumbs.vue
+++ b/packages/docs/src/pages/ui-elements/breadcrumbs.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import breadcrumbsConfig from '../../components/page-configs/ui-elements/va-breadcrumbs/page-config'
 
 @Options({
+  name: 'DocsBreadcrumbs',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/button-dropdown.vue
+++ b/packages/docs/src/pages/ui-elements/button-dropdown.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import buttonDropdownConfig from '../../components/page-configs/ui-elements/va-button-dropdown/page-config'
 
 @Options({
+  name: 'DocsButtonDropdown',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/button-group.vue
+++ b/packages/docs/src/pages/ui-elements/button-group.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import buttonGroupConfig from '../../components/page-configs/ui-elements/va-button-group/page-config'
 
 @Options({
+  name: 'DocsButtonGroup',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/button-toggle.vue
+++ b/packages/docs/src/pages/ui-elements/button-toggle.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import buttonToggleConfig from '../../components/page-configs/ui-elements/va-button-toggle/page-config'
 
 @Options({
+  name: 'DocsButtonToggle',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/button.vue
+++ b/packages/docs/src/pages/ui-elements/button.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import buttonConfig from '../../components/page-configs/ui-elements/va-button/page-config'
 
 @Options({
+  name: 'DocsButton',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/card.vue
+++ b/packages/docs/src/pages/ui-elements/card.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import cardConfig from '../../components/page-configs/ui-elements/va-card/page-config'
 
 @Options({
+  name: 'DocsCard',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/checkbox.vue
+++ b/packages/docs/src/pages/ui-elements/checkbox.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import checkboxConfig from '../../components/page-configs/ui-elements/va-checkbox/page-config'
 
 @Options({
+  name: 'DocsCheckbox',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/chip.vue
+++ b/packages/docs/src/pages/ui-elements/chip.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import chipConfig from '../../components/page-configs/ui-elements/va-chip/page-config'
 
 @Options({
+  name: 'DocsChip',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/collapse.vue
+++ b/packages/docs/src/pages/ui-elements/collapse.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import collapseConfig from '../../components/page-configs/ui-elements/va-collapse/page-config'
 
 @Options({
+  name: 'DocsCollapse',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/color-input.vue
+++ b/packages/docs/src/pages/ui-elements/color-input.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import colorInputConfig from '../../components/page-configs/ui-elements/va-color-input/page-config'
 
 @Options({
+  name: 'DocsColorInput',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/color-palette.vue
+++ b/packages/docs/src/pages/ui-elements/color-palette.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import colorPaletteConfig from '../../components/page-configs/ui-elements/va-color-palette/page-config'
 
 @Options({
+  name: 'DocsColorPalette',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/color-picker.vue
+++ b/packages/docs/src/pages/ui-elements/color-picker.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import colorInputConfig from '../../components/page-configs/ui-elements/va-color-input/page-config'
 
 @Options({
+  name: 'DocsColorPicker',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/data-table.vue
+++ b/packages/docs/src/pages/ui-elements/data-table.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import dataTableConfig from '../../components/page-configs/ui-elements/va-data-table/page-config'
 
 @Options({
+  name: 'DocsDataTable',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/date-input.vue
+++ b/packages/docs/src/pages/ui-elements/date-input.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import dateInputConfig from '../../components/page-configs/ui-elements/va-date-input/page-config'
 
 @Options({
+  name: 'DocsDateInput',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/date-picker.vue
+++ b/packages/docs/src/pages/ui-elements/date-picker.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import datePickerConfig from '../../components/page-configs/ui-elements/va-date-picker/page-config'
 
 @Options({
+  name: 'DocsDatePicker',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/divider.vue
+++ b/packages/docs/src/pages/ui-elements/divider.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import dividerConfig from '../../components/page-configs/ui-elements/va-divider/page-config'
 
 @Options({
+  name: 'DocsDivider',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/file-upload.vue
+++ b/packages/docs/src/pages/ui-elements/file-upload.vue
@@ -9,6 +9,7 @@ import fileUploadConfig
   from '../../components/page-configs/ui-elements/va-file-upload/page-config'
 
 @Options({
+  name: 'DocsFileUpload',
   components: { DocsContent },
 })
 export default class FileUpload extends Vue {

--- a/packages/docs/src/pages/ui-elements/form.vue
+++ b/packages/docs/src/pages/ui-elements/form.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import formConfig from '../../components/page-configs/ui-elements/va-form/page-config'
 
 @Options({
+  name: 'DocsForm',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/hover.vue
+++ b/packages/docs/src/pages/ui-elements/hover.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import hoverConfig from '../../components/page-configs/ui-elements/va-hover/page-config'
 
 @Options({
+  name: 'DocsHover',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/icon.vue
+++ b/packages/docs/src/pages/ui-elements/icon.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import iconConfig from '../../components/page-configs/ui-elements/va-icon/page-config'
 
 @Options({
+  name: 'DocsIcon',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/image.vue
+++ b/packages/docs/src/pages/ui-elements/image.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import imageConfig from '../../components/page-configs/ui-elements/va-image/page-config'
 
 @Options({
+  name: 'DocsImage',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/infinite-scroll.vue
+++ b/packages/docs/src/pages/ui-elements/infinite-scroll.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import infiniteScrollConfig from '../../components/page-configs/ui-elements/va-infinite-scroll/page-config'
 
 @Options({
+  name: 'DocsInfiniteScroll',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/inner-loading.vue
+++ b/packages/docs/src/pages/ui-elements/inner-loading.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import innerLoadingConfig from '../../components/page-configs/ui-elements/va-inner-loading/page-config'
 
 @Options({
+  name: 'DocsInnerLoading',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/input.vue
+++ b/packages/docs/src/pages/ui-elements/input.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import inputConfig from '../../components/page-configs/ui-elements/va-input/page-config'
 
 @Options({
+  name: 'DocsInput',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/list.vue
+++ b/packages/docs/src/pages/ui-elements/list.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import listConfig from '../../components/page-configs/ui-elements/va-list/page-config'
 
 @Options({
+  name: 'DocsList',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/modal.vue
+++ b/packages/docs/src/pages/ui-elements/modal.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import modalConfig from '../../components/page-configs/ui-elements/va-modal/page-config'
 
 @Options({
+  name: 'DocsModal',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/navbar.vue
+++ b/packages/docs/src/pages/ui-elements/navbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <docs-content :config="configComputed"/>
+  <docs-content :config="configComputed" />
 </template>
 
 <script lang="ts">
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import navbarConfig from '../../components/page-configs/ui-elements/va-navbar/page-config'
 
 @Options({
+  name: 'DocsNavbar',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/option-list.vue
+++ b/packages/docs/src/pages/ui-elements/option-list.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import optionListConfig from '../../components/page-configs/ui-elements/va-option-list/page-config'
 
 @Options({
+  name: 'DocsOptionList',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/pagination.vue
+++ b/packages/docs/src/pages/ui-elements/pagination.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import paginationConfig from '../../components/page-configs/ui-elements/va-pagination/page-config'
 
 @Options({
+  name: 'DocsPagination',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/parallax.vue
+++ b/packages/docs/src/pages/ui-elements/parallax.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import parallaxConfig from '../../components/page-configs/ui-elements/va-parallax/page-config'
 
 @Options({
+  name: 'DocsParallax',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/popover.vue
+++ b/packages/docs/src/pages/ui-elements/popover.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import popoverConfig from '../../components/page-configs/ui-elements/va-popover/page-config'
 
 @Options({
+  name: 'DocsPopover',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/progress-bar.vue
+++ b/packages/docs/src/pages/ui-elements/progress-bar.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import progressBarConfig from '../../components/page-configs/ui-elements/va-progress-bar/page-config'
 
 @Options({
+  name: 'DocsProgressBar',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/progress-circle.vue
+++ b/packages/docs/src/pages/ui-elements/progress-circle.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import progressCircleConfig from '../../components/page-configs/ui-elements/va-progress-circle/page-config'
 
 @Options({
+  name: 'DocsProgressCircle',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/radio.vue
+++ b/packages/docs/src/pages/ui-elements/radio.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import radioConfig from '../../components/page-configs/ui-elements/va-radio/page-config'
 
 @Options({
+  name: 'DocsRadio',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/rating.vue
+++ b/packages/docs/src/pages/ui-elements/rating.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import ratingConfig from '../../components/page-configs/ui-elements/va-rating/page-config'
 
 @Options({
+  name: 'DocsRating',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/select.vue
+++ b/packages/docs/src/pages/ui-elements/select.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import selectConfig from '../../components/page-configs/ui-elements/va-select/page-config'
 
 @Options({
+  name: 'DocsSelect',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/sidebar-item.vue
+++ b/packages/docs/src/pages/ui-elements/sidebar-item.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import sidebarItemConfig from '../../components/page-configs/ui-elements/va-sidebar-item/page-config'
 
 @Options({
+  name: 'DocsSidebarItem',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/sidebar.vue
+++ b/packages/docs/src/pages/ui-elements/sidebar.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import sidebarConfig from '../../components/page-configs/ui-elements/va-sidebar/page-config'
 
 @Options({
+  name: 'DocsSidebar',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/slider.vue
+++ b/packages/docs/src/pages/ui-elements/slider.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import sliderConfig from '../../components/page-configs/ui-elements/va-slider/page-config'
 
 @Options({
+  name: 'DocsSlider',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/switch.vue
+++ b/packages/docs/src/pages/ui-elements/switch.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import switchConfig from '../../components/page-configs/ui-elements/va-switch/page-config'
 
 @Options({
+  name: 'DocsSwitch',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/tabs.vue
+++ b/packages/docs/src/pages/ui-elements/tabs.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import tabsConfig from '../../components/page-configs/ui-elements/va-tabs/page-config'
 
 @Options({
+  name: 'DocsTabs',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/pages/ui-elements/toast.vue
+++ b/packages/docs/src/pages/ui-elements/toast.vue
@@ -8,6 +8,7 @@ import DocsContent from '../../components/DocsContent.vue'
 import toastConfig from '../../components/page-configs/ui-elements/va-toast/page-config'
 
 @Options({
+  name: 'DocsToast',
   components: {
     DocsContent,
   },

--- a/packages/docs/src/router/RouterLayout.vue
+++ b/packages/docs/src/router/RouterLayout.vue
@@ -6,6 +6,7 @@
 import layouts from '@/layouts'
 
 export default {
+  name: 'DocsRouterLayout',
   computed: {
     layout () {
       const layoutName = this.$route.matched.reduceRight((result, { meta }) => meta.layout ?? result, 'default')


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
close #923

Vue Devtools didn't show most of the components correctly now it is fixed, some unused imports are also removed and shortened.

Before almost all components were anonymous:
![devToolsAnonymous](https://user-images.githubusercontent.com/7745899/129611964-cf760b9e-1e90-46ec-8534-5512a6855039.png)

After update components are displayed correctly:
![vueDevtoolsFixed](https://user-images.githubusercontent.com/7745899/129611994-520a2db4-27c5-4b5b-a9c3-bd3e46290e58.png)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
