### PR TITLE
fix: CONTRIBUTING.md link pointing to localhost

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Vue.js Contributing Guide
 
-Check contribution docs [here](http://localhost:8080/en/contribution/guide).
+Check contribution docs [here](https://vuestic.dev/en/contribution/guide).


### PR DESCRIPTION
## Description
Fix CONTRIBUTING.md guide link pointing to localhost instead of docs. Updated to use same link as in /README.md

<details>

```
Check contribution docs [here](https://vuestic.dev/en/contribution/guide).
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)


(First time trying to help out OSS. Feel free to flame accordingly.)