### PR TITLE
Fix #1083. Move toggle active button styles to props.

### DIFF
--- a/packages/docs/src/locales/en/en.json
+++ b/packages/docs/src/locales/en/en.json
@@ -953,7 +953,7 @@
         "value": "Current toggle state",
         "size": "Specify size for component. \"small\", \"medium\", \"large\" sizes are available",
         "toggleColor": "Color of the toggle button",
-        "activeButtonTextColor": "Цвет текста кнопки с выбранным значением"
+        "activeButtonTextColor": "The color of the button text with the selected value"
       },
       "events": {
         "input": "Emits when toggling to the different button"

--- a/packages/ui/src/components/va-button-group/VaButtonGroup.vue
+++ b/packages/ui/src/components/va-button-group/VaButtonGroup.vue
@@ -120,6 +120,15 @@ export default class VaButtonGroup extends Vue.with(Props) {
     border-bottom-right-radius: 0;
     padding-right: 0.5rem;
     border-right: 0;
+
+    .va-button__content {
+      /**
+        We need to prevent minus margin because we had:
+          border-right: 2px;
+          maring-right: -2px;
+      */
+      margin-right: 0;
+    }
   }
 
   & > .va-button + .va-button {
@@ -127,6 +136,15 @@ export default class VaButtonGroup extends Vue.with(Props) {
     border-bottom-left-radius: 0;
     padding-left: 0.5rem;
     border-left: 0;
+
+    .va-button__content {
+      /**
+        We need to prevent minus margin because we had:
+          border-left: 2px;
+          maring-left: -2px;
+      */
+      margin-left: 0;
+    }
   }
 }
 </style>

--- a/packages/ui/src/components/va-button-toggle/VaButtonToggle.vue
+++ b/packages/ui/src/components/va-button-toggle/VaButtonToggle.vue
@@ -10,8 +10,8 @@
     >
       <va-button
         v-for="option in options"
+        v-bind="buttonProps(option.value)"
         :key="option.value"
-        :style="buttonStyle(option.value)"
         :disabled="disabled"
         :size="size"
         :class="buttonClass(option.value)"
@@ -74,18 +74,19 @@ export default class VaButtonToggle extends mixins(
     return buttonValue === this.modelValue && this.toggleColor ? this.toggleColor : this.color
   }
 
-  buttonStyle (buttonValue: any) {
-    if (buttonValue === this.modelValue) {
-      let color = this.activeButtonTextColor ? this.activeButtonTextColor : getTextColor(this.colorComputed)
-      let background = this.toggleColor ? this.theme.getColor(this.toggleColor) : shiftHSLAColor(this.colorComputed, { l: -6 })
-      if (this.outline || this.flat) {
-        background = this.toggleColor ? this.theme.getColor(this.toggleColor) : this.colorComputed
-        color = this.activeButtonTextColor
-      }
+  buttonProps (buttonValue: any) {
+    if (buttonValue !== this.modelValue) { return }
+
+    if (this.outline || this.flat) {
       return {
-        background: background,
-        color: color,
+        textColor: this.activeButtonTextColor,
+        color: this.toggleColor ? this.theme.getColor(this.toggleColor) : this.colorComputed,
       }
+    }
+
+    return {
+      textColor: this.activeButtonTextColor ? this.activeButtonTextColor : getTextColor(this.colorComputed),
+      color: this.toggleColor ? this.theme.getColor(this.toggleColor) : shiftHSLAColor(this.colorComputed, { l: -6 }),
     }
   }
 

--- a/packages/ui/src/components/va-button-toggle/VaButtonToggle.vue
+++ b/packages/ui/src/components/va-button-toggle/VaButtonToggle.vue
@@ -81,6 +81,8 @@ export default class VaButtonToggle extends mixins(
       return {
         textColor: this.activeButtonTextColor,
         color: this.toggleColor ? this.theme.getColor(this.toggleColor) : this.colorComputed,
+        outline: false,
+        flat: false,
       }
     }
 

--- a/packages/ui/src/components/va-button/_variables.scss
+++ b/packages/ui/src/components/va-button/_variables.scss
@@ -9,7 +9,7 @@
   --va-button-border: 0;
   --va-button-font-family: 'Source Sans Pro', sans-serif;
   --va-button-font-weight: 600;
-  --va-button-transition: 0.3s cubic-bezier(0.25, 0.8, 0.5, 1);
+  --va-button-transition: background 0.3s cubic-bezier(0.25, 0.8, 0.5, 1);
   --va-button-background-color: #ffffff;
   --va-button-icon-color: #ffffff;
   --va-button-size: 2.25rem;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description

First of all, there was an issue with background passed as style in VaButtonToggle, because of that this style was ignored after switching the active button in VaButtonToggle. Also, It required to remove transition for the border (it does not work anyway). So I made the transition only for background what looks good. 

Next, I fixed the issue with different outlined, flat and default buttons.

<table>
<tr>
	<td>Before</td>
	<td>After</td>
</tr>
<tr>
	<td>
	<img src="https://user-images.githubusercontent.com/23530004/132842574-786a28f1-f80f-4491-89c7-05a206f2137c.png" /> 
</td>
	<td>
<img src="https://user-images.githubusercontent.com/23530004/132842902-f3597c40-a118-4484-b307-98dd531a6c20.png" />
</td>
<tr/>
</table>

closes #1070
closes #1083

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
