### PR TITLE
Fix #1054: GlobalConfig sizes, temporary solution

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "serve": "yarn workspace vuestic-ui serve",
     "serve:book": "yarn workspace vuestic-ui serve",
+    "serve:production": "yarn workspace vuestic-ui serve:production",
     "test": "yarn workspace vuestic-ui test",
     "lint": "yarn workspace vuestic-ui lint",
     "build": "yarn workspace vuestic-ui build",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -17,6 +17,7 @@
   ],
   "scripts": {
     "serve": "vue-cli-service serve --mode book",
+    "serve:production": "vue-cli-service serve --mode production",
     "build:dev": "tsc build/config.ts && webpack --config build/config.js --progress",
     "build": "yarn build:rollup && yarn build:types",
     "build:rollup": "rollup -c",

--- a/packages/ui/src/components/va-icon/VaIcon.vue
+++ b/packages/ui/src/components/va-icon/VaIcon.vue
@@ -70,8 +70,7 @@ export default class VaIcon extends mixins(
       transform: this.rotation && 'rotate(' + this.rotation + 'deg)',
       cursor: this.$attrs.onClick ? 'pointer' : null,
       color: this.$props.color !== undefined ? this.colorComputed : this.iconConfig.color,
-      // TODO: change this to 'fontSize: this.sizeComputed' when global config issue #1054 will be resolved
-      fontSize: this.$props.size === '' ? '24px' : this.sizeComputed,
+      fontSize: this.sizeComputed,
     }
   }
 

--- a/packages/ui/src/mixins/SizeMixin.ts
+++ b/packages/ui/src/mixins/SizeMixin.ts
@@ -1,4 +1,5 @@
 import { mixins, Vue, prop } from 'vue-class-component'
+import { getGlobalConfig } from '../services/global-config/global-config'
 
 export const sizesConfig = {
   defaultSize: 48,
@@ -41,15 +42,29 @@ class SizeProps {
 export class SizeMixin extends mixins(Vue.with(SizeProps)) {
   fontRegex = /(?<fontSize>\d+)(?<extension>px|rem)/i
 
+  get sizesConfigGlobal () {
+    const componentName: string | undefined = this.$options?.name
+    return getGlobalConfig().components?.[componentName as string]?.sizesConfig
+  }
+
   get sizeComputed (): string {
     const { defaultSize, sizes } = this.sizesConfig
+    const defaultSizeGlobal = this.sizesConfigGlobal?.defaultSize
 
     if (!this.size) {
-      return `${defaultSize}px`
+      return defaultSizeGlobal
+        ? `${defaultSizeGlobal}px`
+        : `${defaultSize}px`
     }
 
     if (typeof this.size === 'string') {
-      return this.size in sizes ? `${sizes[this.size]}px` : this.size
+      const sizeFromGlobalConfig = this.sizesConfigGlobal?.sizes?.[this.size]
+      const sizeFromSizeMixin = sizes[this.size]
+
+      if (sizeFromGlobalConfig) { return `${sizeFromGlobalConfig}px` }
+      if (sizeFromSizeMixin) { return `${sizeFromSizeMixin}px` }
+
+      return this.size
     }
 
     return `${this.size}px`


### PR DESCRIPTION
## Description
close #1054
close #1087

**Global config sizes** are applied by the sizeMixin now correctly.

This is a temporary solution because I found out that we have slightly bigger issue overall with global configs not being applied in the build version.

I've checked everything related to configs logic and it works as expected except for withConfigTransport - most likely it will be the part of a global solution.

However this issue is resolved and I will just make a new one to take care of the rest.

</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
