### PR TITLE
fix: disable mozilla focusring

### DIFF
--- a/packages/ui/src/styles/global/reset.scss
+++ b/packages/ui/src/styles/global/reset.scss
@@ -144,6 +144,13 @@ table {
   border: 0;
 }
 
+button:-moz-focusring,
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring {
+  outline: none;
+}
+
 :focus {
   outline: none;
 }


### PR DESCRIPTION
closes #1085 

## Description
Overrides the normalize.css rule for firefox. Also, we should pay attention to the `:focus-visible` pseudo-selector. It can be useful when it will be supported by all required browsers.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
