### PR TITLE
Fix #1042: Global & local configs

### DIFF
--- a/packages/ui/src/services/config-transport/withConfigTransport.ts
+++ b/packages/ui/src/services/config-transport/withConfigTransport.ts
@@ -118,7 +118,8 @@ const withConfigTransport = (component: any): any => {
   const methods: { [key: string]: (...args: any[]) => any } = { ...options.methods }
   const optionsWithoutDefaults = Object.keys(propsOptions)
 
-  const componentName = upperFirst(camelCase(component.name))
+  const vueClassComponent = component.__vccOpts
+  const componentName = upperFirst(camelCase(vueClassComponent ? vueClassComponent.name : component.name))
 
   return {
     name: `WithConfigTransport${componentName || 'Component'}`,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Global and local configs were not working completely after the build.

It was caused by `vue-class-component` logic wrapping our code.

The only reason it worked in `dev` is because constructor name was the same as component name here unlike the bundled version.
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
