### PR TITLE
Fix#1192 Fix VaModal, VaDropdown and VaToast z-index

### DIFF
--- a/packages/docs/src/examples/va-modal/NestedModals.vue
+++ b/packages/docs/src/examples/va-modal/NestedModals.vue
@@ -1,14 +1,26 @@
 <template>
   <p>
-    <va-button @click="showFirstModal = !showFirstModal">
+    <va-button class="mb-4" @click="showFirstModal = !showFirstModal">
       Show first modal
     </va-button>
+
     <va-modal v-model="showFirstModal" :message="firstMessage" hide-default-actions>
       <slot>
-        <va-button @click="showSecondModal = !showSecondModal">
+        <va-button class="mr-2" @click="$vaToast.init('Hello')">Basic notification</va-button>
+        <va-popover message="Popover text"><va-button>Hover me</va-button></va-popover>
+        <va-date-input class="mt-2" />
+
+        <va-button class="mt-5" @click="showSecondModal = !showSecondModal" color="secondary">
           Show second modal
         </va-button>
-        <va-modal v-model="showSecondModal" :message="secondMessage" />
+
+        <va-modal v-model="showSecondModal" :message="secondMessage">
+          <slot>
+            <va-button class="mr-2" @click="$vaToast.init('Hello')">Show notification</va-button>
+            <va-popover message="Popover text"><va-button>Hover me</va-button></va-popover>
+            <va-select class="mt-2" v-model="value" :options="options" />
+          </slot>
+        </va-modal>
       </slot>
     </va-modal>
   </p>
@@ -21,6 +33,8 @@ export default {
       showSecondModal: false,
       firstMessage: 'First modal message',
       secondMessage: 'Second modal message',
+      value: '',
+      options: ['one', 'two', 'three'],
     }
   },
 }

--- a/packages/ui/src/components/va-data-table/_variables.scss
+++ b/packages/ui/src/components/va-data-table/_variables.scss
@@ -1,6 +1,5 @@
 :root {
   --va-data-table-cell-padding: 0.625rem;
-
   --va-data-table-thead-line-height: 1.6;
   --va-data-table-thead-font-size: 0.625rem;
   --va-data-table-thead-font-weight: 700;

--- a/packages/ui/src/components/va-dropdown/_variables.scss
+++ b/packages/ui/src/components/va-dropdown/_variables.scss
@@ -1,4 +1,4 @@
 :root {
   --va-dropdown-line-height: 1;
-  --va-dropdown-content-wrapper-z-index: 100;
+  --va-dropdown-content-wrapper-z-index: var(--va-z-index-teleport-overlay);
 }

--- a/packages/ui/src/components/va-modal/_variables.scss
+++ b/packages/ui/src/components/va-modal/_variables.scss
@@ -10,8 +10,8 @@
   --va-modal-justify-content: center;
   --va-modal-overflow: hidden;
   --va-modal-outline: 0;
-  --va-modal-z-index: 99999;
-  --va-modal-container-z-index: 1050;
+  --va-modal-z-index: var(--va-z-index-teleport-overlay);
+  --va-modal-container-z-index: 100;
 
   /* Dialog */
   --va-modal-dialog-background: #ffffff;

--- a/packages/ui/src/components/va-toast/VaToast.vue
+++ b/packages/ui/src/components/va-toast/VaToast.vue
@@ -185,6 +185,7 @@ export default class VaToast extends mixins(
   box-shadow: $toast-shadow;
   transition: opacity 0.3s, transform 0.3s, left 0.3s, right 0.3s, top 0.4s, bottom 0.3s;
   overflow: hidden;
+  z-index: var(--va-toast-z-index);
 
   &--multiline {
     min-height: 70px;

--- a/packages/ui/src/components/va-toast/_variables.scss
+++ b/packages/ui/src/components/va-toast/_variables.scss
@@ -12,6 +12,7 @@
   --va-toast-box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
   --va-toast-transition: opacity 0.3s, transform 0.3s, left 0.3s, right 0.3s, top 0.4s, bottom 0.3s;
   --va-toast-overflow: hidden;
+  --va-toast-z-index: calc(var(--va-z-index-teleport-overlay) + 100);
 
   /* Group */
   --va-toast-group-margin-left: 13px;

--- a/packages/ui/src/components/va-toast/index.ts
+++ b/packages/ui/src/components/va-toast/index.ts
@@ -1,8 +1,7 @@
 import VaToast from './VaToast'
 import { NotificationOptions } from './types'
-import { VNode, App, createVNode, render, cloneVNode } from 'vue'
+import { VNode, App, createVNode, render } from 'vue'
 
-const Z_INDEX = 100
 const GAP = 5
 let seed = 1
 
@@ -160,12 +159,11 @@ const createToastInstance = (customProps: NotificationOptions, app: App): VNode 
   const nodeProps = getNodeProps(vNode)
 
   if (el && vNode.el && nodeProps) {
-    document.body.appendChild(el)
+    document.body.appendChild(el.childNodes[0])
     const { offsetX, offsetY, position } = nodeProps
 
     vNode.el.style.display = 'flex'
     vNode.el.id = 'notification_' + seed
-    vNode.el.style.zIndex = Z_INDEX + ''
 
     let transformY = 0
     toastInstances.filter(item => {

--- a/packages/ui/src/styles/global/css-variables.scss
+++ b/packages/ui/src/styles/global/css-variables.scss
@@ -91,4 +91,7 @@
 
   /* Shadows */
   --va-box-shadow: 0 0.25rem 0.5rem 0 rgba(59, 63, 73, 0.15);
+
+  /* Z-indexes */
+  --va-z-index-teleport-overlay: 1000;
 }


### PR DESCRIPTION
## Description
close: #1192

Changes:
- [x] - add global css variable: `--va-z-index-teleport-overlay: 1000`
- [x] - fix va-modal and va-dropdown z-index. They equal `--va-z-index-teleport-overlay`
- [x] - fix va-toast z-index. It equals `--va-z-index-teleport-overlay + 100`. Removed the extra notification wrapper ('div')
- [x] - update nested modal example
![image](https://user-images.githubusercontent.com/55198465/140507274-a462cd1d-5e75-4c8a-8877-659ad7db7229.png)
![image](https://user-images.githubusercontent.com/55198465/140507220-09fe86d8-15f4-429f-b069-5f775ebab9a7.png)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
