### PR TITLE
Fix#1243: Set tabindex for disabled VaTimePicker columns

### DIFF
--- a/packages/ui/src/components/va-time-picker/VaTimePicker.vue
+++ b/packages/ui/src/components/va-time-picker/VaTimePicker.vue
@@ -4,6 +4,7 @@
       v-for="(column, idx) in columns" :key="idx"
       v-model:activeItemIndex="column.activeItem.value"
       :items="column.items"
+      :tabindex="disabled ? -1 : 0"
     />
   </div>
 </template>
@@ -26,8 +27,7 @@ export default defineComponent({
     modelValue: { type: Date, required: false },
     ampm: { type: Boolean, default: false },
     hidePeriodSwitch: { type: Boolean, default: false },
-    // Update model value when switching period automatically.
-    periodUpdatesModelValue: { type: Boolean, default: true },
+    periodUpdatesModelValue: { type: Boolean, default: true }, // Update model value when switching period automatically
     view: { type: String as PropType<'hours' | 'minutes' | 'seconds'>, default: 'minutes' },
     hoursFilter: { type: Function as PropType<(h: number) => boolean> },
     minutesFilter: { type: Function as PropType<(h: number) => boolean> },

--- a/packages/ui/src/components/va-time-picker/components/VaTimePickerColumn.vue
+++ b/packages/ui/src/components/va-time-picker/components/VaTimePickerColumn.vue
@@ -47,9 +47,9 @@ export default defineComponent({
 
     const scrollTo = (index: number, animate = true) => {
       nextTick(() => {
-        const childs = rootElement.value!.children
+        const children = rootElement.value!.children
 
-        const element = childs[index] as HTMLElement
+        const element = children[index] as HTMLElement
 
         if (!element) {
           rootElement.value?.scrollTo({


### PR DESCRIPTION
## Description
close: #1243

Changes:
- [x] - set columns `tabindex = -1` when passed `disabled` prop

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
