### PR TITLE
Fix#1247 Change VaChip vertical-align

### DIFF
--- a/packages/docs/src/page-configs/ui-elements/chip/examples/Icon.vue
+++ b/packages/docs/src/page-configs/ui-elements/chip/examples/Icon.vue
@@ -6,8 +6,9 @@
         :icon="icon"
         class="mr-4"
       >
-        {{icon}}
+        {{ icon }}
       </va-chip>
+      <va-chip>without icon</va-chip>
   </div>
 </template>
 

--- a/packages/ui/src/components/va-chip/VaChip.vue
+++ b/packages/ui/src/components/va-chip/VaChip.vue
@@ -13,7 +13,7 @@
     :class="computedClass"
     :style="computedStyle"
   >
-    <div
+    <span
       class="va-chip__inner"
       v-on="SetupContext.keyboardFocusListeners"
       @focus="$emit('focus')"
@@ -37,7 +37,7 @@
         :size="iconSize"
         @click.stop="close()"
       />
-    </div>
+    </span>
   </component>
 </template>
 
@@ -188,11 +188,13 @@ export default class VaChip extends mixins(
   cursor: var(--va-chip-cursor);
   font-size: var(--va-chip-font-size);
   font-family: var(--va-font-family);
+  vertical-align: var(--va-chip-vertical-align);
 
   &__inner {
     display: var(--va-chip-inner-display);
     align-items: var(--va-chip-inner-align-items);
     width: var(--va-chip-inner-width);
+    vertical-align: inherit;
   }
 
   &:hover {

--- a/packages/ui/src/components/va-chip/_variables.scss
+++ b/packages/ui/src/components/va-chip/_variables.scss
@@ -11,7 +11,8 @@
   --va-chip-color: #ffffff;
   --va-chip-cursor: default;
   --va-chip-font-size: 1rem;
-  --va-chip-inner-display: flex;
+  --va-chip-vertical-align: middle;
+  --va-chip-inner-display: inline-flex;
   --va-chip-inner-align-items: center;
   --va-chip-inner-width: 100%;
   --va-chip-hover-opacity: 0.85;


### PR DESCRIPTION
## Description
close: #1247 

Changes:
- [x] - change va-chip: `vertical-align: middle` (from `baseline`)
- [x] - change inner container from `div` to `span`

![image](https://user-images.githubusercontent.com/55198465/142880890-3039aaa5-f3da-4ec0-b62e-255b23ebcf62.png)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
