### PR TITLE
Fix#1204 Add VaDataTable events

### DIFF
--- a/packages/docs/src/locales/en/en.json
+++ b/packages/docs/src/locales/en/en.json
@@ -854,6 +854,7 @@
         "sortBy": "Sets the column to sort by. Works through the `v-model`",
         "sortingOrder": "Sets the sorting order. Works through the `v-model`",
         "selectable": "Sets whether the `va-data-table` should have selectable rows or not",
+        "clickable": "Sets whether the `va-data-table` should have clickable (the click events will be emitted) rows or not",
         "selectMode": "Sets the select mode. `'single'` selection allows for only a single row to be selected at a time, while `'multiple'` mode allows to select multiple rows by clicking on checkboxes or using the **ctrl**/**shift** keys when clicking rows",
         "selectedColor": "Sets the highlighting color of the selected row",
         "perPage": "Sets the maximum number of rows displayed in the table's `<tbody>`",
@@ -874,6 +875,9 @@
         "updateSortingOrder": "Emits when `sorting-order` changed",
         "filtered": "`va-data-table` emits the `filtered` event each time filtering is applied (and when the filter is cleared), with the following param: \n &#123;\n &nbsp; `items: ITableItem[]`,\n &nbsp; `itemsIndexes: number[]`\n &#125;",
         "sorted": "Each time the table's sorting changes, the `sorted` event is thrown, with the following param: \n &#123;\n &nbsp; `sortBy: string`,\n &nbsp; `sortingOrder: TSortingOrder`,\n &nbsp; `items: ITableItem[]`,\n &nbsp; `itemsIndexes: number[]`\n &#125;",
+        "rowClick": "When row clicked the event is thrown with the following param (`RowClickEvent`): \n &#123;\n &nbsp; `event: Event`,\n &nbsp; `item: ITableItem`,\n &nbsp; `itemIndex: number`\n &#125;",
+        "rowDblclick": "Double-clicking a row raises an event with the `RowClickEvent` param",
+        "rowContextmenu": "When the context menu is clicked on a row, an event is raised with the `RowClickEvent` param",
         "selectionChange": "The `selectionChange` event is thrown each time the selection changes. It provides the following object: \n&#123;\n &nbsp; `currentSelectedItems: ITableItem[]`,\n &nbsp; `previousSelectedItems: ITableItem[]`\n &#125;"
       },
       "methods": {},

--- a/packages/docs/src/locales/en/en.json
+++ b/packages/docs/src/locales/en/en.json
@@ -866,14 +866,14 @@
         "footerClone": "Sets whether to clone the `<thead>` columns into the `<tfoot>`. Has no effect if the default `<thead>` is hidden with the `hide-default-header` prop",
         "allowFooterSorting": "Allows clicks on `<tfoot>` column headers to sort (and to display the sorting status) the rows",
         "striped": "Sets the striped style to the `<tbody>` rows (highlights each 2nd row)",
-        "hoverable": "Allows the a hover state on table rows within a `<tbody>`. The highlighting color of the hover state takes from `selected-color` prop",
+        "hoverable": "Allows the hover state on table rows within a `<tbody>`. The highlighting color of the hover state takes from `selected-color` prop",
         "animated": "Sets css `transition` to table rows"
       },
       "events": {
         "updateSortBy": "Emits when `sort-by` changed",
         "updateSortingOrder": "Emits when `sorting-order` changed",
-        "filtered": "`va-data-table` emits the `filtered` event each time filtering is applied (and when the filter is cleared), passing the array of sources of filtered items",
-        "sorted": "Each time the table's sorting changes, the `sorted` event is thrown, with the following param: \n &#123;\n &nbsp; `sortBy: string`,\n &nbsp; `sortingOrder: TSortingOrder`\n &#125;",
+        "filtered": "`va-data-table` emits the `filtered` event each time filtering is applied (and when the filter is cleared), with the following param: \n &#123;\n &nbsp; `items: ITableItem[]`,\n &nbsp; `itemsIndexes: number[]`\n &#125;",
+        "sorted": "Each time the table's sorting changes, the `sorted` event is thrown, with the following param: \n &#123;\n &nbsp; `sortBy: string`,\n &nbsp; `sortingOrder: TSortingOrder`,\n &nbsp; `items: ITableItem[]`,\n &nbsp; `itemsIndexes: number[]`\n &#125;",
         "selectionChange": "The `selectionChange` event is thrown each time the selection changes. It provides the following object: \n&#123;\n &nbsp; `currentSelectedItems: ITableItem[]`,\n &nbsp; `previousSelectedItems: ITableItem[]`\n &#125;"
       },
       "methods": {},

--- a/packages/docs/src/locales/en/en.json
+++ b/packages/docs/src/locales/en/en.json
@@ -873,12 +873,12 @@
       "events": {
         "updateSortBy": "Emits when `sort-by` changed",
         "updateSortingOrder": "Emits when `sorting-order` changed",
-        "filtered": "`va-data-table` emits the `filtered` event each time filtering is applied (and when the filter is cleared), with the following param: \n &#123;\n &nbsp; `items: ITableItem[]`,\n &nbsp; `itemsIndexes: number[]`\n &#125;",
-        "sorted": "Each time the table's sorting changes, the `sorted` event is thrown, with the following param: \n &#123;\n &nbsp; `sortBy: string`,\n &nbsp; `sortingOrder: TSortingOrder`,\n &nbsp; `items: ITableItem[]`,\n &nbsp; `itemsIndexes: number[]`\n &#125;",
-        "rowClick": "When row clicked the event is thrown with the following param (`RowClickEvent`): \n &#123;\n &nbsp; `event: Event`,\n &nbsp; `item: ITableItem`,\n &nbsp; `itemIndex: number`\n &#125;",
-        "rowDblclick": "Double-clicking a row raises an event with the `RowClickEvent` param",
-        "rowContextmenu": "When the context menu is clicked on a row, an event is raised with the `RowClickEvent` param",
-        "selectionChange": "The `selectionChange` event is thrown each time the selection changes. It provides the following object: \n&#123;\n &nbsp; `currentSelectedItems: ITableItem[]`,\n &nbsp; `previousSelectedItems: ITableItem[]`\n &#125;"
+        "filtered": "`va-data-table` emits the `filtered` event each time filtering is applied (and when the filter is cleared), with the following param: `FilteredEmit` = \n &#123;\n &nbsp; `items: ITableItem[]`,\n &nbsp; `itemsIndexes: number[]`\n &#125;",
+        "sorted": "Each time the table's sorting changes, the `sorted` event is thrown, with the following param: `SortedEmit` = \n &#123;\n &nbsp; `sortBy: string`,\n &nbsp; `sortingOrder: TSortingOrder`,\n &nbsp; `items: ITableItem[]`,\n &nbsp; `itemsIndexes: number[]`\n &#125;",
+        "rowClick": "When row clicked the event is thrown with the following param: `RowClickEmit` = \n &#123;\n &nbsp; `event: Event`,\n &nbsp; `item: ITableItem`,\n &nbsp; `itemIndex: number`\n &#125;",
+        "rowDblclick": "Double-clicking a row raises an event with the `RowClickEmit` param",
+        "rowContextmenu": "When the context menu is clicked on a row, an event is raised with the `RowClickEmit` param",
+        "selectionChange": "The `selectionChange` event is thrown each time the selection changes. It provides the following object: `SelectionChangeEmit` = \n&#123;\n &nbsp; `currentSelectedItems: ITableItem[]`,\n &nbsp; `previousSelectedItems: ITableItem[]`\n &#125;"
       },
       "methods": {},
       "slots": {

--- a/packages/docs/src/locales/ru/ru.json
+++ b/packages/docs/src/locales/ru/ru.json
@@ -873,12 +873,12 @@
       "events": {
         "updateSortBy": "Событие генерируется при изменении `sort-by`",
         "updateSortingOrder": "Событие генерируется при изменении `sorting-order`",
-        "filtered": "`va-data-table` генерирует событие `filtered` каждый раз, когда применяется фильтрация (и когда фильтр очищается), со следующим параметром: \n &#123;\n &nbsp; `items: ITableItem[]`,\n &nbsp; `itemsIndexes: number[]`\n &#125;",
-        "sorted": "Каждый раз, когда сортировка таблицы изменяется, генерируется событие `sorted` со следующим параметром: \n &#123;\n &nbsp; `sortBy: string`,\n &nbsp; `sortingOrder: TSortingOrder`,\n &nbsp; `items: ITableItem[]`,\n &nbsp; `itemsIndexes: number[]`\n &#125;",
-        "rowClick": "При щелчке по строке возникает событие со следующим параметром (`RowClickEvent`): \n &#123;\n &nbsp; `event: Event`,\n &nbsp; `item: ITableItem`,\n &nbsp; `itemIndex: number`\n &#125;",
-        "rowDblclick": "Двойной щелчок по строке вызывает событие с параметром `RowClickEvent`",
-        "rowContextmenu": "При щелчке контекстного меню по строке возникает событие с параметром `RowClickEvent`",
-        "selectionChange": "Событие `selectionChange` генерируется каждый раз при изменении выделения строк. Он предоставляет следующий объект: \n&#123;\n &nbsp; `currentSelectedItems: ITableItem[]`,\n &nbsp; `previousSelectedItems: ITableItem[]`\n &#125;"
+        "filtered": "`va-data-table` генерирует событие `filtered` каждый раз, когда применяется фильтрация (и когда фильтр очищается), со следующим параметром: `FilteredEmit` = \n &#123;\n &nbsp; `items: ITableItem[]`,\n &nbsp; `itemsIndexes: number[]`\n &#125;",
+        "sorted": "Каждый раз, когда сортировка таблицы изменяется, генерируется событие `sorted` со следующим параметром: `SortedEmit` = \n &#123;\n &nbsp; `sortBy: string`,\n &nbsp; `sortingOrder: TSortingOrder`,\n &nbsp; `items: ITableItem[]`,\n &nbsp; `itemsIndexes: number[]`\n &#125;",
+        "rowClick": "При щелчке по строке возникает событие со следующим параметром: `RowClickEmit` = \n &#123;\n &nbsp; `event: Event`,\n &nbsp; `item: ITableItem`,\n &nbsp; `itemIndex: number`\n &#125;",
+        "rowDblclick": "Двойной щелчок по строке вызывает событие с параметром `RowClickEmit`",
+        "rowContextmenu": "При щелчке контекстного меню по строке возникает событие с параметром `RowClickEmit`",
+        "selectionChange": "Событие `selectionChange` генерируется каждый раз при изменении выделения строк. Он предоставляет следующий объект: `SelectionChangeEmit` = \n&#123;\n &nbsp; `currentSelectedItems: ITableItem[]`,\n &nbsp; `previousSelectedItems: ITableItem[]`\n &#125;"
       },
       "methods": {},
       "slots": {

--- a/packages/docs/src/locales/ru/ru.json
+++ b/packages/docs/src/locales/ru/ru.json
@@ -872,8 +872,8 @@
       "events": {
         "updateSortBy": "Событие генерируется при изменении `sort-by`",
         "updateSortingOrder": "Событие генерируется при изменении `sorting-order`",
-        "filtered": "`va-data-table` генерирует событие `filtered` каждый раз, когда применяется фильтрация (и когда фильтр очищается), передавая массив с исходными данными отфильтрованных элементов",
-        "sorted": "Каждый раз, когда сортировка таблицы изменяется, генерируется событие `sorted` со следующим параметром: \n &#123;\n &nbsp; `sortBy: string`,\n &nbsp; `sortingOrder: TSortingOrder`\n &#125;",
+        "filtered": "`va-data-table` генерирует событие `filtered` каждый раз, когда применяется фильтрация (и когда фильтр очищается), со следующим параметром: \n &#123;\n &nbsp; `items: ITableItem[]`,\n &nbsp; `itemsIndexes: number[]`\n &#125;",
+        "sorted": "Каждый раз, когда сортировка таблицы изменяется, генерируется событие `sorted` со следующим параметром: \n &#123;\n &nbsp; `sortBy: string`,\n &nbsp; `sortingOrder: TSortingOrder`,\n &nbsp; `items: ITableItem[]`,\n &nbsp; `itemsIndexes: number[]`\n &#125;",
         "selectionChange": "Событие `selectionChange` генерируется каждый раз при изменении выделения строк. Он предоставляет следующий объект: \n&#123;\n &nbsp; `currentSelectedItems: ITableItem[]`,\n &nbsp; `previousSelectedItems: ITableItem[]`\n &#125;"
       },
       "methods": {},

--- a/packages/docs/src/locales/ru/ru.json
+++ b/packages/docs/src/locales/ru/ru.json
@@ -854,6 +854,7 @@
         "sortBy": "Устанавливает столбец, по которому выполнять сортировку. Работает через `v-model`",
         "sortingOrder": "Устанавливает направление сортировки. Работает через `v-model`",
         "selectable": "Устанавливает, должна ли `va-data-table` иметь выбираемые строки или нет",
+        "clickable": "Устанавливает, должна ли таблица `va-data-table` иметь интерактивные (будут генерироваться события щелчка) строки или нет",
         "selectMode": "Устанавливает режим выбора. Режим `'single'` позволяет выбирать только одну строку за раз, в то время как режим `'multiple'` позволяет выбирать несколько строк, выбирая чекбоксы или используя клавиши **ctrl**/**shift** при щелчке по строкам",
         "selectedColor": "Устанавливает цвет выделенной строки",
         "perPage": "Устанавливает максимальное количество строк, отображаемых в `<tbody>` таблицы",
@@ -874,6 +875,9 @@
         "updateSortingOrder": "Событие генерируется при изменении `sorting-order`",
         "filtered": "`va-data-table` генерирует событие `filtered` каждый раз, когда применяется фильтрация (и когда фильтр очищается), со следующим параметром: \n &#123;\n &nbsp; `items: ITableItem[]`,\n &nbsp; `itemsIndexes: number[]`\n &#125;",
         "sorted": "Каждый раз, когда сортировка таблицы изменяется, генерируется событие `sorted` со следующим параметром: \n &#123;\n &nbsp; `sortBy: string`,\n &nbsp; `sortingOrder: TSortingOrder`,\n &nbsp; `items: ITableItem[]`,\n &nbsp; `itemsIndexes: number[]`\n &#125;",
+        "rowClick": "При щелчке по строке возникает событие со следующим параметром (`RowClickEvent`): \n &#123;\n &nbsp; `event: Event`,\n &nbsp; `item: ITableItem`,\n &nbsp; `itemIndex: number`\n &#125;",
+        "rowDblclick": "Двойной щелчок по строке вызывает событие с параметром `RowClickEvent`",
+        "rowContextmenu": "При щелчке контекстного меню по строке возникает событие с параметром `RowClickEvent`",
         "selectionChange": "Событие `selectionChange` генерируется каждый раз при изменении выделения строк. Он предоставляет следующий объект: \n&#123;\n &nbsp; `currentSelectedItems: ITableItem[]`,\n &nbsp; `previousSelectedItems: ITableItem[]`\n &#125;"
       },
       "methods": {},

--- a/packages/docs/src/page-configs/ui-elements/data-table/api-options.ts
+++ b/packages/docs/src/page-configs/ui-elements/data-table/api-options.ts
@@ -34,6 +34,15 @@ export default defineManualApi({
     'update:sortingOrder': {
       types: '`() => TSortingOrder`',
     },
+    'row:click': {
+      types: '`() => RowClickEvent`',
+    },
+    'row:contextmenu': {
+      types: '`() => RowClickEvent`',
+    },
+    'row:dblclick': {
+      types: '`() => RowClickEvent`',
+    },
   },
   slots: {
     colgroup: {},

--- a/packages/docs/src/page-configs/ui-elements/data-table/api-options.ts
+++ b/packages/docs/src/page-configs/ui-elements/data-table/api-options.ts
@@ -20,13 +20,13 @@ export default defineManualApi({
   },
   events: {
     filtered: {
-      types: '`() => Object`',
+      types: '`() => FilteredEmit`',
     },
     selectionChange: {
-      types: '`() => Object`',
+      types: '`() => SelectionChangeEmit`',
     },
     sorted: {
-      types: '`() => Object`',
+      types: '`() => SortedEmit`',
     },
     'update:sortBy': {
       types: '`() => String`',
@@ -35,13 +35,13 @@ export default defineManualApi({
       types: '`() => TSortingOrder`',
     },
     'row:click': {
-      types: '`() => RowClickEvent`',
+      types: '`() => RowClickEmit`',
     },
     'row:contextmenu': {
-      types: '`() => RowClickEvent`',
+      types: '`() => RowClickEmit`',
     },
     'row:dblclick': {
-      types: '`() => RowClickEvent`',
+      types: '`() => RowClickEmit`',
     },
   },
   slots: {

--- a/packages/docs/src/page-configs/ui-elements/data-table/api-options.ts
+++ b/packages/docs/src/page-configs/ui-elements/data-table/api-options.ts
@@ -20,7 +20,7 @@ export default defineManualApi({
   },
   events: {
     filtered: {
-      types: '`() => Number`',
+      types: '`() => Object`',
     },
     selectionChange: {
       types: '`() => Object`',

--- a/packages/docs/src/page-configs/ui-elements/data-table/examples/Filtering.vue
+++ b/packages/docs/src/page-configs/ui-elements/data-table/examples/Filtering.vue
@@ -18,7 +18,7 @@
     :columns="columns"
     :filter="filter"
     :filter-method="customFilteringFn"
-    @filtered="filteredCount = $event.length"
+    @filtered="filteredCount = $event.items.length"
   />
 
   <va-alert class="mt-3" border="left">

--- a/packages/docs/src/page-configs/ui-elements/data-table/examples/Other.vue
+++ b/packages/docs/src/page-configs/ui-elements/data-table/examples/Other.vue
@@ -21,6 +21,13 @@
         size="small"
         v-model="animated"
       />
+      <br />
+      <va-switch
+        class="mt-2"
+        label="Clickable rows"
+        size="small"
+        v-model="isTableRowsClickable"
+      />
     </div>
 
     <div class="flex lg4 mb-2">
@@ -77,11 +84,16 @@
     :columns="columns"
     :striped="isTableStriped"
     :hoverable="isTableHoverable"
+    :selectable="true"
+    :clickable="isTableRowsClickable"
     :loading="isTableLoading"
     :hide-default-header="hideDefaultHeader"
     :footer-clone="footerClone"
     :allow-footer-sorting="footerSorting"
     :animated="animated"
+    @row:click="rowEventType = $event.event.type, rowId = $event.item.id"
+    @row:dblclick="rowEventType = $event.event.type, rowId = $event.item.id"
+    @row:contextmenu="rowEventType = $event.event.type, rowId = $event.item.id"
   >
     <template #headerPrepend v-if="prependSlot">
       <tr><th colspan="8">Custom cell which span 8 cells (headPrepend slot)</th></tr>
@@ -104,6 +116,15 @@
       <tr><th colspan="8">Custom cell which span 8 cells (footAppend slot)</th></tr>
     </template>
   </va-data-table>
+
+  <va-alert v-if="isTableRowsClickable" class="mt-3" border="left">
+    <span>
+      Last row click event (id, event type):
+      <va-chip v-if="rowId">{{ rowId }}</va-chip>
+      <va-chip v-if="rowEventType">{{ rowEventType }}</va-chip>
+    </span>
+  </va-alert>
+
 </template>
 
 <script>
@@ -163,13 +184,25 @@ export default defineComponent({
       isTableLoading: false,
       isTableStriped: true,
       isTableHoverable: true,
+      isTableRowsClickable: false,
       hideDefaultHeader: false,
       footerClone: true,
       footerSorting: true,
       prependSlot: false,
       appendSlot: false,
       animated: true,
+      rowEventType: '',
+      rowId: '',
     }
+  },
+
+  watch: {
+    isTableRowsClickable (value) {
+      if (!value) {
+        this.rowEventType = ''
+        this.rowId = ''
+      }
+    },
   },
 })
 </script>

--- a/packages/docs/src/page-configs/ui-elements/data-table/examples/Pagination.vue
+++ b/packages/docs/src/page-configs/ui-elements/data-table/examples/Pagination.vue
@@ -28,10 +28,9 @@
     :columns="columns"
     :per-page="perPage"
     :current-page="currentPage"
-    :selectable="selectable"
-    :select-mode="selectMode"
+    :selectable="true"
     :filter="filter"
-    @filtered="filtered = $event"
+    @filtered="filtered = $event.items"
   >
     <template #bodyAppend>
       <tr><td colspan="8" class="table-example--pagination">
@@ -107,8 +106,6 @@ export default defineComponent({
       columns,
       perPage: 3,
       currentPage: 1,
-      selectable: true,
-      selectMode: 'multiple',
       filter: '',
       filtered: users,
     }
@@ -116,7 +113,7 @@ export default defineComponent({
 
   computed: {
     pages () {
-      return (this.perPage && this.perPage !== '0')
+      return (this.perPage && this.perPage !== 0)
         ? Math.ceil(this.filtered.length / this.perPage)
         : this.filtered.length
     },

--- a/packages/docs/src/page-configs/ui-elements/data-table/examples/Sorting.vue
+++ b/packages/docs/src/page-configs/ui-elements/data-table/examples/Sorting.vue
@@ -23,7 +23,7 @@
     v-model:sort-by="sortBy"
     v-model:sorting-order="sortingOrder"
     @sorted="
-      sortedRowsEmitted = $event.sortedRows.map(row => row.id),
+      sortedRowsEmitted = $event.items.map(row => row.id),
       sortingOrderEmitted = $event.sortingOrder,
       sortByEmitted = $event.sortBy
     "

--- a/packages/ui/src/components/va-data-table/VaDataTable.new.demo.vue
+++ b/packages/ui/src/components/va-data-table/VaDataTable.new.demo.vue
@@ -2,7 +2,20 @@
   <VbDemo>
     <VbCard title="Reactive data">
       <button @click="shuffleItems">Shuffle</button>
-      <va-data-table :items="items" />
+      <va-data-table
+        :items="items"
+        :clickable="true"
+        @row:click="rowEventType = $event.event.type, rowId = $event.item.id"
+        @row:dblclick="rowEventType = $event.event.type, rowId = $event.item.id"
+        @row:contextmenu="rowEventType = $event.event.type, rowId = $event.item.id"
+      />
+      <va-alert class="mt-3" border="left">
+        <span>
+          Last row click event (id, event type):
+          <va-chip v-if="rowId">{{ rowId }}</va-chip>
+          <va-chip v-if="rowEventType">{{ rowEventType }}</va-chip>
+        </span>
+      </va-alert>
     </VbCard>
 
     <VbCard title="Use custom slots for address and company">
@@ -299,6 +312,9 @@ export default defineComponent({
 
       perPage: 2,
       currentPage: 1,
+
+      rowEventType: '',
+      rowId: '',
     }
   },
 

--- a/packages/ui/src/components/va-data-table/hooks/useFilterable.ts
+++ b/packages/ui/src/components/va-data-table/hooks/useFilterable.ts
@@ -2,7 +2,8 @@ import { Ref, watch, computed } from 'vue'
 import { TableRow, ITableItem } from './useRows'
 
 export type TFilterMethod = (source: any) => boolean
-export type TFilterableEmits = (event: 'filtered', arg: ITableItem[]) => void
+export type TFilteredArgs = { items: ITableItem[], itemsIndexes: number[] }
+export type TFilterableEmits = (event: 'filtered', arg: TFilteredArgs) => void
 
 export default function useFilterable (
   rawRows: Ref<TableRow[]>,
@@ -23,7 +24,10 @@ export default function useFilterable (
   })
 
   watch(filteredRows, () => {
-    emit('filtered', filteredRows.value.map(row => row.source))
+    emit('filtered', {
+      items: filteredRows.value.map(row => row.source),
+      itemsIndexes: filteredRows.value.map(row => row.initialIndex),
+    })
   })
 
   return {

--- a/packages/ui/src/components/va-data-table/hooks/useFilterable.ts
+++ b/packages/ui/src/components/va-data-table/hooks/useFilterable.ts
@@ -12,6 +12,10 @@ export default function useFilterable (
   emit: TFilterableEmits,
 ) {
   const filteredRows = computed<TableRow[]>(() => {
+    if (!rawRows.value.length) {
+      return rawRows.value
+    }
+
     if (filter.value === '' && !filterMethod.value) {
       return rawRows.value
     }

--- a/packages/ui/src/components/va-data-table/hooks/useSelectable.ts
+++ b/packages/ui/src/components/va-data-table/hooks/useSelectable.ts
@@ -3,7 +3,10 @@ import { TableRow, ITableItem } from './useRows'
 
 export type TSelectMode = 'single' | 'multiple'
 export type TEmits = 'update:modelValue' | 'selectionChange'
-export type TSelectionChange = { currentSelectedItems: ITableItem[], previousSelectedItems: ITableItem[] }
+export type TSelectionChange = {
+  currentSelectedItems: ITableItem[],
+  previousSelectedItems: ITableItem[],
+}
 export type TSelectableEmits = (event: TEmits, arg: ITableItem[] | TSelectionChange) => void
 
 export default function useSelectable (

--- a/packages/ui/src/components/va-data-table/hooks/useSortable.ts
+++ b/packages/ui/src/components/va-data-table/hooks/useSortable.ts
@@ -58,6 +58,10 @@ export default function useSortable (
   // provided. Otherwise uses that very sortingFn. If sortingOrder is `null` then restores the initial sorting order of
   // the rows.
   const sortedRows = computed(() => {
+    if (filteredRows.value.length <= 1) {
+      return filteredRows.value
+    }
+
     const column = columns.value.find(column => column.key === sortByProxy.value)
 
     if (!column || !column.sortable) {

--- a/packages/ui/src/components/va-data-table/hooks/useSortable.ts
+++ b/packages/ui/src/components/va-data-table/hooks/useSortable.ts
@@ -3,9 +3,10 @@ import { computed, ref, Ref, watch } from 'vue'
 import { TableRow, ITableItem } from './useRows'
 
 export type TSortingOrder = 'asc' | 'desc' | null
+export type TSortedArgs = { sortBy: string, sortingOrder: TSortingOrder, items: ITableItem[], itemsIndexes: number[] }
 export type TSortableEmits = (
   event: 'update:sortBy' | 'update:sortingOrder' | 'sorted',
-  args: string | TSortingOrder | { sortBy: string, sortingOrder: TSortingOrder, sortedRows: ITableItem[] },
+  args: string | TSortingOrder | TSortedArgs,
 ) => void
 
 export default function useSortable (
@@ -91,7 +92,8 @@ export default function useSortable (
     emit('sorted', {
       sortBy: sortByProxy.value,
       sortingOrder: sortingOrderProxy.value,
-      sortedRows: sortedRows.value.map(row => row.source),
+      items: sortedRows.value.map(row => row.source),
+      itemsIndexes: sortedRows.value.map(row => row.initialIndex),
     })
   })
 

--- a/packages/ui/src/components/va-data-table/hooks/useStyleable.ts
+++ b/packages/ui/src/components/va-data-table/hooks/useStyleable.ts
@@ -5,7 +5,6 @@ import { computed, Ref } from 'vue'
 import { TableColumn } from './useColumns'
 
 export default function useStyleable (
-  hoverable: Ref<boolean>,
   selectable: Ref<boolean>,
   selectedColor: Ref<string>,
   allowFooterSorting: Ref<boolean>,
@@ -19,20 +18,15 @@ export default function useStyleable (
   }
 
   const rowCSSVariables = computed(() => {
+    const styles: Record<string, any> = {
+      '--hover-color': getHoverColor(getColor(selectedColor.value)),
+    }
+
     if (selectable.value) {
-      return {
-        '--hover-color': getHoverColor(getColor(selectedColor.value)),
-        '--selected-color': getFocusColor(getColor(selectedColor.value)),
-      }
+      styles['--selected-color'] = getFocusColor(getColor(selectedColor.value))
     }
 
-    if (hoverable.value) {
-      return {
-        '--hover-color': getHoverColor(getColor(selectedColor.value)),
-      }
-    }
-
-    return {}
+    return styles
   })
 
   function getCellCSSVariables (cell: TableCell) {


### PR DESCRIPTION
## Description
close #1204 

Changes:
- [x] - add `clickable` prop
- [x] - add table row events: `click`, `dblclick`, `contextmenu`
- [x] - update `sorted` and `filtered` emit arguments (add array of items initial indexes)

![chrome-capture](https://user-images.githubusercontent.com/55198465/143417461-cea73ab0-8cc7-4712-b58c-9e95485e934b.gif)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
