### PR TITLE
Fix#1258 Fix VaSelect dropdown width

### DIFF
--- a/packages/docs/src/page-configs/ui-elements/input/examples/Hint.vue
+++ b/packages/docs/src/page-configs/ui-elements/input/examples/Hint.vue
@@ -24,6 +24,7 @@ export default {
     return {
       message: 'Required field',
       messages: ['Required field', 'Tap to start typing'],
+      value: '',
     }
   },
 }

--- a/packages/docs/src/page-configs/ui-elements/select/examples/Decorators.vue
+++ b/packages/docs/src/page-configs/ui-elements/select/examples/Decorators.vue
@@ -52,7 +52,7 @@
       :options="options"
       v-model="value"
       clearable
-      clearIcon="cancel"
+      clearableIcon="cancel"
     />
     <va-select
       class="mb-4"
@@ -91,10 +91,10 @@
     />
     <va-select
       class="mb-4"
-      label="Custom select width (50%)"
+      label="Custom select width (75%)"
       :options="options"
       v-model="value"
-      width="50%"
+      width="75%"
     />
   </div>
 </template>

--- a/packages/docs/src/page-configs/ui-elements/select/examples/Slots.vue
+++ b/packages/docs/src/page-configs/ui-elements/select/examples/Slots.vue
@@ -5,6 +5,7 @@
       label="Prepend slot"
       :options="options"
       v-model="value"
+      bordered
     >
       <template #prepend>
         <va-icon
@@ -17,6 +18,7 @@
       label="Prepend inner slot"
       :options="options"
       v-model="value"
+      bordered
     >
       <template #prependInner>
         <va-icon

--- a/packages/docs/src/page-configs/ui-elements/select/examples/Slots.vue
+++ b/packages/docs/src/page-configs/ui-elements/select/examples/Slots.vue
@@ -5,7 +5,6 @@
       label="Prepend slot"
       :options="options"
       v-model="value"
-      bordered
     >
       <template #prepend>
         <va-icon
@@ -18,7 +17,6 @@
       label="Prepend inner slot"
       :options="options"
       v-model="value"
-      bordered
     >
       <template #prependInner>
         <va-icon

--- a/packages/docs/src/page-configs/ui-elements/select/examples/Variations.vue
+++ b/packages/docs/src/page-configs/ui-elements/select/examples/Variations.vue
@@ -19,7 +19,7 @@
       :options="options"
       v-model="valueMultipleMax"
       multiple
-      max-selections=2
+      :max-selections="2"
     />
   </div>
 </template>

--- a/packages/docs/src/page-configs/ui-elements/select/examples/Variations.vue
+++ b/packages/docs/src/page-configs/ui-elements/select/examples/Variations.vue
@@ -19,7 +19,7 @@
       :options="options"
       v-model="valueMultipleMax"
       multiple
-      :max-selections="2"
+      max-selections="2"
     />
   </div>
 </template>

--- a/packages/ui/src/components/va-input/VaInput.vue
+++ b/packages/ui/src/components/va-input/VaInput.vue
@@ -136,7 +136,9 @@ export default defineComponent({
       return 'grey'
     })
 
-    const { computedValue, onInput } = useCleave(props.type === 'textarea' ? ref(undefined) : input, props, emit)
+    /** Use cleave only if this component is input, because it will break. */
+    const computedCleaveTarget = computed(() => props.type === 'textarea' ? undefined : input.value)
+    const { computedValue, onInput } = useCleave(computedCleaveTarget, props, emit)
 
     const computedInputAttributes = computed(() => ({
       ...omit(attrs, ['class', 'style']),

--- a/packages/ui/src/components/va-input/VaInput.vue
+++ b/packages/ui/src/components/va-input/VaInput.vue
@@ -44,6 +44,7 @@
 
     <VaTextarea
       v-if="type === 'textarea'"
+      ref="textarea"
       v-bind="textareaProps"
       class="va-input__content__input"
       @input="onInput"
@@ -115,6 +116,7 @@ export default defineComponent({
 
   setup (props, { emit, attrs }) {
     const input = ref<HTMLInputElement>()
+    const textarea = ref<HTMLTextAreaElement>()
 
     const {
       isFocused,
@@ -157,6 +159,7 @@ export default defineComponent({
 
     return {
       input,
+      textarea,
       textareaProps: filterComponentProps(props, VaTextareaProps),
 
       // Validations
@@ -175,6 +178,24 @@ export default defineComponent({
       fieldListeners: createFieldListeners(emit),
       reset,
     }
+  },
+
+  methods: {
+    focus () {
+      if (this.input) {
+        this.input.focus()
+      } else if (this.textarea) {
+        this.textarea.focus()
+      }
+    },
+
+    blur () {
+      if (this.input) {
+        this.input.blur()
+      } else if (this.textarea) {
+        this.textarea.blur()
+      }
+    },
   },
 })
 </script>

--- a/packages/ui/src/components/va-input/VaInput.vue
+++ b/packages/ui/src/components/va-input/VaInput.vue
@@ -43,8 +43,8 @@
     </template>
 
     <VaTextarea
-      v-bind="textareaProps"
       v-if="type === 'textarea'"
+      v-bind="textareaProps"
       class="va-input__content__input"
       @input="onInput"
     />
@@ -115,6 +115,7 @@ export default defineComponent({
 
   setup (props, { emit, attrs }) {
     const input = ref<HTMLInputElement>()
+
     const {
       isFocused,
       listeners: validationListeners,

--- a/packages/ui/src/components/va-input/VaInput.vue
+++ b/packages/ui/src/components/va-input/VaInput.vue
@@ -44,7 +44,7 @@
 
     <VaTextarea
       v-if="type === 'textarea'"
-      ref="textarea"
+      ref="input"
       v-bind="textareaProps"
       class="va-input__content__input"
       @input="onInput"
@@ -115,8 +115,7 @@ export default defineComponent({
   inheritAttrs: false,
 
   setup (props, { emit, attrs }) {
-    const input = ref<HTMLInputElement>()
-    const textarea = ref<HTMLTextAreaElement>()
+    const input = ref<HTMLInputElement | HTMLTextAreaElement>()
 
     const {
       isFocused,
@@ -137,7 +136,7 @@ export default defineComponent({
       return 'grey'
     })
 
-    const { computedValue, onInput } = useCleave(input, props, emit)
+    const { computedValue, onInput } = useCleave(props.type === 'textarea' ? ref(undefined) : input, props, emit)
 
     const computedInputAttributes = computed(() => ({
       ...omit(attrs, ['class', 'style']),
@@ -159,7 +158,6 @@ export default defineComponent({
 
     return {
       input,
-      textarea,
       textareaProps: filterComponentProps(props, VaTextareaProps),
 
       // Validations
@@ -181,21 +179,8 @@ export default defineComponent({
   },
 
   methods: {
-    focus () {
-      if (this.input) {
-        this.input.focus()
-      } else if (this.textarea) {
-        this.textarea.focus()
-      }
-    },
-
-    blur () {
-      if (this.input) {
-        this.input.blur()
-      } else if (this.textarea) {
-        this.textarea.blur()
-      }
-    },
+    focus () { this.input?.focus() },
+    blur () { this.input?.blur() },
   },
 })
 </script>

--- a/packages/ui/src/components/va-input/components/VaInputField.vue
+++ b/packages/ui/src/components/va-input/components/VaInputField.vue
@@ -201,6 +201,15 @@ export default defineComponent({
     position: relative;
   }
 
+  &-wrapper__prepend-inner,
+  &-wrapper__append-inner,
+  &__prepend-inner,
+  &__append-inner {
+    display: flex;
+    justify-content: center;
+    align-content: center;
+  }
+
   &__content-wrapper {
     display: flex;
     align-items: center;

--- a/packages/ui/src/components/va-input/components/VaInputField.vue
+++ b/packages/ui/src/components/va-input/components/VaInputField.vue
@@ -40,6 +40,7 @@
             <div v-if="$slots.content" class="va-input__content__input">
               <slot name="content" />
             </div>
+
             <slot></slot>
           </div>
         </div>
@@ -194,6 +195,10 @@ export default defineComponent({
         padding-right: 0;
       }
     }
+  }
+
+  &-wrapper__content {
+    position: relative;
   }
 
   &__content-wrapper {

--- a/packages/ui/src/components/va-input/components/VaTextarea/VaTextarea.vue
+++ b/packages/ui/src/components/va-input/components/VaTextarea/VaTextarea.vue
@@ -78,6 +78,11 @@ export default defineComponent({
       listeners: createListeners(emit),
     }
   },
+
+  methods: {
+    focus () { this.textarea?.focus() },
+    blur () { this.textarea?.blur() },
+  },
 })
 </script>
 

--- a/packages/ui/src/components/va-input/components/VaTextarea/VaTextarea.vue
+++ b/packages/ui/src/components/va-input/components/VaTextarea/VaTextarea.vue
@@ -2,6 +2,7 @@
   <textarea
     ref="textarea"
     v-bind="listeners"
+    :value="modelValue"
     :style="{ ...computedHeight }"
   />
 </template>
@@ -19,7 +20,7 @@ const positiveNumberValidator = (val: number) => {
 }
 
 const { createEmits, createListeners } = useEmitProxy([
-  'input', 'change', 'click',
+  'input', 'change', 'click', 'update:modelValue',
 ])
 
 export default defineComponent({

--- a/packages/ui/src/components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/va-select/VaSelect.vue
@@ -652,10 +652,6 @@ export default defineComponent({
   .va-input {
     cursor: var(--va-select-cursor);
   }
-
-  .va-input-wrapper__content {
-    flex-grow: 1;
-  }
 }
 
 .va-select-dropdown {
@@ -671,12 +667,6 @@ export default defineComponent({
     border-top-left-radius: 0;
     box-shadow: var(--va-select-box-shadow);
     padding: 0;
-
-    .va-input {
-      .va-input-wrapper__content {
-        flex-grow: 1;
-      }
-    }
   }
 
   &__options-wrapper {
@@ -686,4 +676,12 @@ export default defineComponent({
     @include va-scroll(var(--va-select-scroll-color));
   }
 }
+
+.va-select,
+.va-select-dropdown__content {
+  .va-input-wrapper__content {
+    flex-grow: 1;
+  }
+}
+
 </style>

--- a/packages/ui/src/components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/va-select/VaSelect.vue
@@ -659,6 +659,10 @@ export default defineComponent({
     justify-content: center;
     align-content: center;
   }
+
+  .va-input-wrapper__content {
+    flex-grow: 1;
+  }
 }
 
 .va-select-dropdown {

--- a/packages/ui/src/components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/va-select/VaSelect.vue
@@ -26,6 +26,7 @@
       >
         <!-- We show messages outside of dropdown to draw dropdown content under the input -->
         <va-input
+          :style="{ width: $props.width }"
           :model-value="valueComputedString"
           :success="$props.success"
           :error="computedError"
@@ -678,6 +679,12 @@ export default defineComponent({
     border-top-left-radius: 0;
     box-shadow: var(--va-select-box-shadow);
     padding: 0;
+
+    .va-input {
+      .va-input-wrapper__content {
+        flex-grow: 1;
+      }
+    }
   }
 
   &__options-wrapper {

--- a/packages/ui/src/components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/va-select/VaSelect.vue
@@ -68,16 +68,14 @@
           </template>
 
           <template #appendInner>
-            <div class="va-input__append">
-              <slot
-                v-if="$slots.appendInner"
-                name="appendInner"
-              />
-              <va-icon
-                :color="colorComputed"
-                :name="toggleIcon"
-              />
-            </div>
+            <slot
+              v-if="$slots.appendInner"
+              name="appendInner"
+            />
+            <va-icon
+              :color="colorComputed"
+              :name="toggleIcon"
+            />
           </template>
 
           <template v-if="$slots.content" #content="{ value, focus }">
@@ -653,12 +651,6 @@ export default defineComponent({
 
   .va-input {
     cursor: var(--va-select-cursor);
-  }
-
-  .va-input__append {
-    display: flex;
-    justify-content: center;
-    align-content: center;
   }
 
   .va-input-wrapper__content {

--- a/packages/ui/src/components/va-select/VaSelectOptionList/VaSelectOptionList.vue
+++ b/packages/ui/src/components/va-select/VaSelectOptionList/VaSelectOptionList.vue
@@ -213,7 +213,9 @@ export default class VaSelectOptionList extends mixins(
   scrollToOption (option: any) {
     const element: HTMLElement = this.itemRefs[(this.$props.getTrackBy as Function)(option)]
 
-    scrollToElement(element)
+    if (element) {
+      scrollToElement(element)
+    }
   }
 
   public focus () {

--- a/packages/ui/src/composables/useMaxSelections.ts
+++ b/packages/ui/src/composables/useMaxSelections.ts
@@ -8,14 +8,18 @@ import { PropType, Ref } from 'vue'
  */
 export const useMaxSelectionsProps = {
   maxSelections: {
-    type: Number as PropType<number>,
+    type: [Number, String] as PropType<number | string>,
     default: undefined,
   },
 }
 
-export function useMaxSelections (selections: Ref<any[]>, maxSelections: Ref<number | undefined>, emit: (event: 'update:modelValue', ...args: any[]) => void) {
+export function useMaxSelections (
+  selections: Ref<any[]>,
+  maxSelections: Ref<number | string | undefined>,
+  emit: (event: 'update:modelValue', ...args: any[]) => void,
+) {
   const exceedsMaxSelections = (): boolean => {
-    if (maxSelections.value === undefined) { return false }
+    if (maxSelections.value === undefined || isNaN(+maxSelections.value)) { return false }
     return selections.value.length >= maxSelections.value
   }
 


### PR DESCRIPTION
## Description
close: #1258 
close: #1286 

Changes:
- [x] - fix border width in `va-input`
- [x] - fix width `va-input` in `va-select`
- [x] - add `focus` and `blur` exposed methods to `va-input` and `va-textarea` 
- [x] - fix errors in components (`va-input`, `va-select`) docs examples

![chrome-capture](https://user-images.githubusercontent.com/55198465/143570482-67e6490d-7701-41b8-9213-dcb95057f26c.gif)

![chrome-capture](https://user-images.githubusercontent.com/55198465/144443238-32ce87c1-43ab-408d-a6d5-b238977ce231.gif)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
