### PR TITLE
Fix #1261 Add round style to va-button-dropdown without label prop

### DIFF
--- a/packages/docs/src/page-configs/ui-elements/button-dropdown/examples/Default.vue
+++ b/packages/docs/src/page-configs/ui-elements/button-dropdown/examples/Default.vue
@@ -2,4 +2,8 @@
   <va-button-dropdown label="label">
     Content
   </va-button-dropdown>
+
+  <va-button-dropdown class="ml-2">
+    Button without label
+  </va-button-dropdown>
 </template>

--- a/packages/ui/src/components/va-button-dropdown/VaButtonDropdown.demo.vue
+++ b/packages/ui/src/components/va-button-dropdown/VaButtonDropdown.demo.vue
@@ -5,6 +5,11 @@
         Content
       </va-button-dropdown>
     </VbCard>
+    <VbCard title="without label">
+      <va-button-dropdown>
+        Content
+      </va-button-dropdown>
+    </VbCard>
     <VbCard title="label slot">
       <va-button-dropdown>
         <template #label>

--- a/packages/ui/src/components/va-button-dropdown/VaButtonDropdown.vue
+++ b/packages/ui/src/components/va-button-dropdown/VaButtonDropdown.vue
@@ -17,11 +17,11 @@
           :outline="outline"
           :disabled="disabled"
           :color="color"
-          v-bind="{ [label ? 'icon-right' : 'icon']: computedIcon }"
-          :round="!label"
+          v-bind="{ [label || $slots.label ? 'icon-right' : 'icon']: computedIcon }"
+          :round="!label && !$slots.label"
           @click="click"
         >
-          <slot v-if="label" name="label">
+          <slot name="label">
             {{ label }}
           </slot>
         </va-button>

--- a/packages/ui/src/components/va-button-dropdown/VaButtonDropdown.vue
+++ b/packages/ui/src/components/va-button-dropdown/VaButtonDropdown.vue
@@ -17,10 +17,11 @@
           :outline="outline"
           :disabled="disabled"
           :color="color"
-          :icon-right="computedIcon"
+          v-bind="{ [label ? 'icon-right' : 'icon']: computedIcon }"
+          :round="!label"
           @click="click"
         >
-          <slot name="label">
+          <slot v-if="label" name="label">
             {{ label }}
           </slot>
         </va-button>


### PR DESCRIPTION
## Description
close: #1261

Changes:
- [x] - add round style to `va-button-dropdown` when only icon is set

![chrome-capture](https://user-images.githubusercontent.com/55198465/143867869-c7cae5a3-6fd5-4f0a-875a-3aec281dd366.gif)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
