### PR TITLE
Fix #1226 Fix VaTimeInput bug when passed text is not valid

### DIFF
--- a/packages/ui/src/components/va-time-input/VaTimeInput.vue
+++ b/packages/ui/src/components/va-time-input/VaTimeInput.vue
@@ -15,7 +15,7 @@
         :readonly="readonly || !manualInput"
         :error="!isValid || inputProps.error || computedError"
         :error-messages="computedErrorMessages"
-        @change="onInputTextChanged"
+        @change="onInputTextChanged($event.target.value)"
       >
         <template v-for="(_, name) in $slots" v-slot:[name]="bind">
           <slot :name="name" v-bind="bind"></slot>
@@ -30,7 +30,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, PropType, ref } from 'vue'
+import { computed, defineComponent, PropType, watch, ref } from 'vue'
 import VaTimePicker from '../va-time-picker/VaTimePicker.vue'
 import VaInput from '../va-input/VaInput.vue'
 import { useSyncProp } from '../../composables/useSyncProp'
@@ -127,6 +127,12 @@ export default defineComponent({
       reset,
       focus,
       blur,
+    })
+
+    watch(modelValueSync, () => {
+      if (!isValid.value && valueText.value === '') {
+        isValid.value = true
+      }
     })
 
     return {

--- a/packages/ui/src/components/va-time-input/VaTimeInput.vue
+++ b/packages/ui/src/components/va-time-input/VaTimeInput.vue
@@ -130,9 +130,7 @@ export default defineComponent({
     })
 
     watch(modelValueSync, () => {
-      if (!isValid.value && valueText.value === '') {
-        isValid.value = true
-      }
+      isValid.value = true
     })
 
     return {

--- a/packages/ui/src/components/va-time-input/hooks/time-text-parser.ts
+++ b/packages/ui/src/components/va-time-input/hooks/time-text-parser.ts
@@ -9,7 +9,7 @@ const parse = (text: string) => {
 }
 
 const parsePeriod = (text: string) => {
-  const m = text.match(/PM|pm|Am|am/)
+  const m = text.match(/pm|am/i)
 
   if (!m) { return null }
 


### PR DESCRIPTION
## Description
close: #1226 

Changes:
- [x] - fix `va-time-input` bug when passed text (prop `manual-input` enable) is not valid
- [x] - tweak regexp in `useTimeParser` hook

![chrome-capture](https://user-images.githubusercontent.com/55198465/145047757-46daff89-6af8-49dc-87b7-89d03c65929b.gif)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
