### PR TITLE
Fix behavior of select dropdown when tab key pressed

### DIFF
--- a/packages/ui/src/components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/va-select/VaSelect.vue
@@ -89,8 +89,8 @@
     <va-dropdown-content
       class="va-select-dropdown__content"
       @keyup.enter.stop
-      @keydown.esc.prevent="hideAndFocus"
-      @keydown.tab="hideDropdown"
+      @keydown.esc.prevent="hideDropdown"
+      @keydown.tab.prevent="hideDropdown"
     >
       <va-input
         v-if="showSearchInput"
@@ -365,7 +365,7 @@ export default defineComponent({
 
     const selectOption = (option: any): void => {
       if (hoveredOption.value === null) {
-        hideAndFocus()
+        hideDropdown()
         return
       }
 
@@ -385,7 +385,7 @@ export default defineComponent({
         }
       } else {
         valueComputed.value = typeof option === 'string' || typeof option === 'number' ? option : { ...option }
-        hideAndFocus()
+        hideDropdown()
       }
     }
 
@@ -470,7 +470,7 @@ export default defineComponent({
 
     const toggleDropdown = () => {
       if (showDropdownContent.value) {
-        hideAndFocus()
+        hideDropdown()
       } else {
         showDropdown()
       }
@@ -489,15 +489,6 @@ export default defineComponent({
       }
 
       toggleDropdown()
-    }
-
-    const focusSelect = () => {
-      select.value?.focus()
-    }
-
-    const hideAndFocus = (): void => {
-      hideDropdown()
-      focusSelect()
     }
 
     const focusSearchBar = () => {
@@ -523,12 +514,14 @@ export default defineComponent({
         return
       }
       isFocused.value = true
+      select.value?.focus()
     }
 
     /** @public */
     const blur = (): void => {
       isFocused.value = false
       validate()
+      select.value?.blur()
     }
 
     /** @public */
@@ -615,7 +608,6 @@ export default defineComponent({
       blur,
       reset,
       onSelectClick,
-      hideAndFocus,
       searchBar,
       focusSearchBar,
       searchInput,


### PR DESCRIPTION
## Description
Changes:
- [x] - set focus to select when tab key pressed (when dropdown open)

![chrome-capture](https://user-images.githubusercontent.com/55198465/145779948-b87f5962-a61d-4ced-954c-687bd5861ab3.gif)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
