### PR TITLE
VaSelect on scroll bottom event

### DIFF
--- a/packages/docs/src/locales/en/en.json
+++ b/packages/docs/src/locales/en/en.json
@@ -761,7 +761,8 @@
       "events": {
         "clear": "Emitted if select value has been cleared",
         "updateSearch": "Emitted if search value has changed",
-        "createNew": "Emitted if search input has created new option"
+        "createNew": "Emitted if search input has created new option",
+        "scrollBottom": "Emitted once the scroll position of options has reached the bottom"
       },
       "methods": {
         "reset": "Clearing select value"

--- a/packages/docs/src/page-configs/ui-elements/select/api-options.ts
+++ b/packages/docs/src/page-configs/ui-elements/select/api-options.ts
@@ -11,6 +11,9 @@ export default defineManualApi({
     updateSearch: {
       types: 'any',
     },
+    scrollBottom: {
+      types: 'any',
+    },
   },
   methods: {
     reset: {

--- a/packages/ui/src/components/va-select/VaSelect.demo.vue
+++ b/packages/ui/src/components/va-select/VaSelect.demo.vue
@@ -493,6 +493,16 @@
       />
     </VbCard>
     <VbCard
+      title="scroll-bottom event"
+      style="width: 400px;"
+    >
+      <va-select
+        v-model="preloadable.value"
+        :options="preloadable.options"
+        @scrollBottom="onLoadMore()"
+      />
+    </VbCard>
+    <VbCard
       title="Validation rules (on blur)"
       style="width: 400px;"
     >
@@ -532,6 +542,8 @@ import VaSelect from './index'
 
 const positions = ['top', 'bottom']
 
+const random = () => Math.ceil(Math.random() * 10000) + ''
+
 export default {
   components: { VaSelect, VaIcon },
   data () {
@@ -546,6 +558,10 @@ export default {
       defaultMultiSelect: {
         options: ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine'],
         value: [],
+      },
+      preloadable: {
+        options: [random(), random(), random(), random(), random()],
+        value: '',
       },
       allowCreateSelect: {
         options: [
@@ -600,6 +616,9 @@ export default {
     }
   },
   methods: {
+    onLoadMore () {
+      this.preloadable.options.push(random(), random(), random())
+    },
     updateSearch (val) {
       this.isLoading = true
       setTimeout(() => {

--- a/packages/ui/src/components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/va-select/VaSelect.vue
@@ -131,6 +131,7 @@
           @keydown.enter.stop.prevent="selectHoveredOption()"
           @keydown.space.stop.prevent="selectHoveredOption()"
           @keydown="onHintedSearch"
+          @scroll-bottom="onScrollBottom"
         />
       </div>
     </va-dropdown-content>
@@ -167,7 +168,7 @@ export default defineComponent({
     VaDropdownContent,
     VaInput,
   },
-  emits: ['update-search', 'update:modelValue', 'clear', 'create-new', ...useValidationEmits],
+  emits: ['update-search', 'update:modelValue', 'clear', 'create-new', 'scroll-bottom', ...useValidationEmits],
   props: {
     ...useSelectableListProps,
     ...useValidationProps,
@@ -248,6 +249,10 @@ export default defineComponent({
     } = useValidation(props, emit, () => reset(), () => focus(), () => blur())
 
     const { colorComputed } = useColor(props)
+
+    const onScrollBottom = () => {
+      emit('scroll-bottom')
+    }
 
     const searchInput = ref('')
     const showSearchInput = computed(() => {
@@ -640,6 +645,7 @@ export default defineComponent({
       onHintedSearch,
       getText,
       getTrackBy,
+      onScrollBottom,
     }
   },
 })

--- a/packages/ui/src/components/va-select/VaSelectOptionList/VaSelectOptionList.vue
+++ b/packages/ui/src/components/va-select/VaSelectOptionList/VaSelectOptionList.vue
@@ -92,6 +92,7 @@ const SelectOptionListPropsMixin = Vue.with(SelectOptionListProps)
     'select-option',
     'update:hoveredOption',
     'no-previous-option-to-hover',
+    'scroll-bottom',
   ],
 })
 export default class VaSelectOptionList extends mixins(
@@ -106,6 +107,21 @@ export default class VaSelectOptionList extends mixins(
         this.scrollToOption(newOption)
       }
     })
+  }
+
+  onScroll () {
+    const el = this.$refs.el as HTMLDivElement
+    if (el.scrollTop + el.clientHeight === el.scrollHeight) { this.$emit('scroll-bottom') }
+  }
+
+  mounted () {
+    const el = this.$refs.el as HTMLDivElement
+    el.addEventListener('scroll', () => this.onScroll())
+  }
+
+  beforeUnmount () {
+    const el = this.$refs.el as HTMLDivElement
+    el.removeEventListener('scroll', this.onScroll)
   }
 
   beforeUpdate () {


### PR DESCRIPTION
closes #1380 

## Description

Added the event scroll-bottom for the VaSelect component. It should be working as expected. If you scroll at bottom of the options, the new scroll-bottom event is emitted. The new feature was also added to the documentation (only for English).

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
