### PR TITLE
Fix#1401 Set `display: none` to tabs slider when hideSlider=true

### DIFF
--- a/packages/ui/src/components/va-tabs/VaTabs.vue
+++ b/packages/ui/src/components/va-tabs/VaTabs.vue
@@ -202,7 +202,7 @@ export default class VaTabs extends mixins(
 
   get sliderStyles () {
     if (this.$props.hideSlider) {
-      return {}
+      return { display: 'none' }
     }
     const transition = this.animationIncluded ? 'var(--va-tabs-slider-wrapper-transition)' : ''
     if (this.$props.vertical) {


### PR DESCRIPTION
## Description
close: #1401

changes:
- [x] - set `display: none` to tabs slider when `hideSlider`=`true`

![image](https://user-images.githubusercontent.com/55198465/148905548-91c35414-e525-41ce-bd8f-c4746839194b.png)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
