### PR TITLE
Fix#1420 Correct `VaIcon` and icons config docs

### DIFF
--- a/packages/docs/src/locales/en/en.json
+++ b/packages/docs/src/locales/en/en.json
@@ -2343,7 +2343,7 @@
   },
   "icon": {
     "title": "Icon",
-    "summaryText": "The `va-icon` component allows you to use different icon fonts. By default Vuestic UI provides [Material Icons](https://fonts.google.com/icons)[[target=_blank]].",
+    "summaryText": "The `va-icon` component allows you to use different icon fonts. By default Vuestic UI provides [Material Design Icons](https://fonts.google.com/icons)[[target=_blank]].",
     "examples": {
       "default": {
         "title": "Default",

--- a/packages/docs/src/locales/ru/ru.json
+++ b/packages/docs/src/locales/ru/ru.json
@@ -2296,7 +2296,7 @@
   },
   "icon": {
     "title": "Icon",
-    "summaryText": "Компонент `va-icon` позволяет использовать различные шрифты иконок.",
+    "summaryText": "Компонент `va-icon` позволяет использовать различные шрифты иконок. По умолчанию Vuestic UI предоставляет иконки [Material Design Icons](https://fonts.google.com/icons)[[target=_blank]].",
     "examples": {
       "default": {
         "title": "Базовое использование",

--- a/packages/docs/src/page-configs/services/icons-config/examples/font.vue
+++ b/packages/docs/src/page-configs/services/icons-config/examples/font.vue
@@ -1,13 +1,13 @@
 <template>
   <div>
     <div class="code">
-      <p> { </p>
-      <p class="tab"> name: <va-input v-model="fontName" />, </p>
+      {
+      <p class="tab"> name: <va-input v-model="iconName" />,</p>
       <p class="tab">
         resolve:
-        ({ <span class="params">{{ params }}</span> }) => { ... }
+        (<span class="params">{ {{ params }} }</span>) => ({ class: <span class="params">`{{ resolved }}`</span> })
       </p>
-      <p> } </p>
+      }
     </div>
   </div>
 </template>
@@ -25,18 +25,23 @@ const getValuesInBrackets = (s) => {
 
 export default {
   setup () {
-    const fontName = ref('fa4-{code}-{type}')
-    const iconName = ref('fa4-phone-o')
+    const iconName = ref('fa4-{code}-{type}')
+
+    const groups = computed(() => getValuesInBrackets(iconName.value))
 
     const params = computed(() => {
-      const groups = getValuesInBrackets(fontName.value)
-      return groups.reduce((acc, v) => `${acc} ${v},`, '').slice(0, -1)
+      return groups.value.reduce((acc, v) => `${acc} ${v},`, '').slice(0, -1)
+    })
+
+    const resolved = computed(() => {
+      const classes = groups.value.map((item) => 'fa-${' + `${item}` + '}')
+      return `fa ${classes.join(' ')}`
     })
 
     return {
       params,
-      fontName,
       iconName,
+      resolved,
     }
   },
 }
@@ -46,19 +51,17 @@ export default {
 .code {
   background: #f4f8fa;
   color: var(--va-dark);
-  padding: 2rem;
+  padding: 0.5rem;
 
   .tab {
-    padding-left: 2rem;
+    padding-left: 1rem;
   }
 
   .params {
-    color: #73d2de;
+    color: var(--va-primary);
   }
 
   p {
-    padding: 0.2rem 0;
-    color: var(--va-dark);
     margin: 0;
   }
 

--- a/packages/docs/src/page-configs/services/icons-config/page-config.ts
+++ b/packages/docs/src/page-configs/services/icons-config/page-config.ts
@@ -19,7 +19,7 @@ const columns: TableColumn[] = [
 const tableData: TableData = [
   ['name', 'string | RegExp', 'iconsConfig.api.name'],
   [
-    'iconClass',
+    'class',
     'string | ((...dynamicSegments: string[]) => string) | undefined',
     'iconsConfig.api.iconClass',
   ],
@@ -67,7 +67,7 @@ const config: ApiDocsBlock[] = [
 
   block.headline('iconsConfig.fonts.fontNamePattern.title'),
   block.paragraph('iconsConfig.fonts.fontNamePattern.about'),
-  block.example('font'),
+  block.example('font', { hideCode: true }),
 
   block.headline('iconsConfig.fonts.example.title'),
   block.paragraph('iconsConfig.fonts.example.about'),

--- a/packages/docs/src/page-configs/ui-elements/icon/examples/Default.vue
+++ b/packages/docs/src/page-configs/ui-elements/icon/examples/Default.vue
@@ -1,23 +1,40 @@
 <template>
   <div>
-      <p>Material Design</p>
-      <va-icon class="material-icons">home</va-icon>
-      <va-icon name="home" class="ml-4" />
+      <p>
+        Material Design Icons<br>
+        <va-icon class="material-icons">home</va-icon>
+        <va-icon name="home" />
+      </p>
 
-      <p>Font Awesome 4</p>
-      <va-icon class="fa fa-home" />
-      <va-icon name="fa4-home" class="ml-4" />
+      <p>
+        Font Awesome 4<br>
+        <va-icon class="fa fa-home" />
+        <va-icon name="fa4-home" />
+      </p>
 
-      <p>Font Awesome 5</p>
-      <va-icon class="fas fa-home" />
-      <va-icon name="fas-home" class="ml-4" />
+      <p>
+        Font Awesome 5<br>
+        <va-icon class="fas fa-home" />
+        <va-icon name="fas-home" />
+      </p>
 
-      <p>Entypo</p>
-      <va-icon class="entypo-home" />
-      <va-icon name="entypo-home" class="ml-4" />
+      <p>
+        Entypo<br>
+        <va-icon class="entypo-home" />
+        <va-icon name="entypo-home" />
+      </p>
 
-      <p>Ionic</p>
-      <va-icon class="icon ion-md-home" />
-      <va-icon name="ion-home" class="ml-4" />
+      <p>
+        Ionic<br>
+        <va-icon class="icon ion-md-home" />
+        <va-icon name="ion-home" />
+      </p>
   </div>
 </template>
+<style lang="scss">
+p {
+  i + i {
+    margin-left: 2rem;
+  }
+}
+</style>

--- a/packages/ui/src/components/va-icon/VaIcon.vue
+++ b/packages/ui/src/components/va-icon/VaIcon.vue
@@ -17,6 +17,7 @@ import { Options, mixins, prop, Vue, setup } from 'vue-class-component'
 import ColorMixin from '../../services/color-config/ColorMixin'
 import { SizeMixin } from '../../mixins/SizeMixin'
 import { useIcons } from '../../services/icon-config/icon-config'
+import { omit } from 'lodash-es'
 
 class IconProps {
   name = prop<string>({ type: String, default: '' })
@@ -53,7 +54,7 @@ export default class VaIcon extends mixins(
   }
 
   get computedAttrs () {
-    return { ...this.iconConfig.attrs, ...this.$attrs }
+    return { ...this.iconConfig.attrs, ...omit(this.$attrs, ['class']) }
   }
 
   get computedClass () {

--- a/packages/ui/src/services/icon-config/types.ts
+++ b/packages/ui/src/services/icon-config/types.ts
@@ -1,4 +1,3 @@
-
 export interface IconProps {
   attrs?: Record<string, string | ((...args: any[]) => unknown)>
 


### PR DESCRIPTION
## Description
close: #1420

changes:
- [x] - correct duplication of classes in `va-icon`
- [x] - update docs (`va-icon` and **icons config** pages)
- [x] - update locales

![image](https://user-images.githubusercontent.com/55198465/149943994-66aab69c-472b-4cbf-9b44-a04dfef25d8e.png)

![chrome-capture](https://user-images.githubusercontent.com/55198465/149944177-08ccb51e-6d14-460b-87b7-2409ef03962d.gif)

no duplication of classes:
![image](https://user-images.githubusercontent.com/55198465/149944370-2be2f7ad-d2b8-41e5-ad97-8368f196a340.png)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
