### PR TITLE
Fix#1471 Fix `VaSelect` and `VaInput`(`textarea`) readonly

### DIFF
--- a/packages/docs/src/page-configs/ui-elements/select/examples/State.vue
+++ b/packages/docs/src/page-configs/ui-elements/select/examples/State.vue
@@ -2,6 +2,13 @@
   <div style="max-width: 300px;">
     <va-select
       class="mb-4"
+      label="Readonly"
+      :options="options"
+      v-model="value"
+      readonly
+    />
+    <va-select
+      class="mb-4"
       label="Disabled"
       :options="options"
       v-model="value"

--- a/packages/ui/src/components/va-input/VaInput.demo.vue
+++ b/packages/ui/src/components/va-input/VaInput.demo.vue
@@ -481,6 +481,25 @@
         :max-rows="4"
       />
     </VbCard>
+    <VbCard title="Textarea readonly">
+      <va-input
+        id="textarea-id-example"
+        placeholder="Try to type in ..."
+        label="Readonly"
+        type="textarea"
+        readonly
+      />
+    </VbCard>
+    <VbCard title="Textarea disabled">
+      <va-input
+        name="textarea-name-example"
+        aria-label="textarea-aria-example"
+        placeholder="Try to focus"
+        label="Disabled"
+        type="textarea"
+        disabled
+      />
+    </VbCard>
     <VbCard title="Masked input">
       <va-input
         v-model="maskCreditCardValue"

--- a/packages/ui/src/components/va-input/VaInput.vue
+++ b/packages/ui/src/components/va-input/VaInput.vue
@@ -57,15 +57,16 @@
     <VaTextarea
       v-if="type === 'textarea' && !$slots.content"
       ref="input"
-      v-bind="{...textareaProps, ...inputEvents}"
+      v-bind="{ ...computedChildAttributes, ...textareaProps, ...inputEvents }"
       class="va-input__content__input"
     />
 
     <input
       v-else-if="!$slots.content"
       ref="input"
-      v-bind="{...computedInputAttributes, ...inputEvents}"
       class="va-input__content__input"
+      v-bind="{ ...computedInputAttributes, ...inputEvents }"
+      :value="computedValue"
     >
   </VaInputWrapper>
 </template>
@@ -195,17 +196,24 @@ export default defineComponent({
       onInput,
     }
 
-    const computedInputAttributes = computed(() => ({
+    const computedChildAttributes = computed(() => ({
       ariaLabel: props.label,
       ...omit(attrs, ['class', 'style']),
+    }) as InputHTMLAttributes)
+
+    const computedInputAttributes = computed(() => ({
+      ...computedChildAttributes.value,
       ...pick(props, ['type', 'tabindex', 'disabled', 'readonly', 'placeholder']),
-      value: computedValue.value,
     }) as InputHTMLAttributes)
 
     return {
       input,
       inputEvents,
+
+      computedChildAttributes,
+      computedInputAttributes,
       textareaProps: filterComponentProps(props, VaTextareaProps),
+      computedValue,
 
       // Validations
       computedError,
@@ -216,7 +224,6 @@ export default defineComponent({
       canBeCleared,
       clearIconProps,
 
-      computedInputAttributes,
       fieldListeners: createFieldListeners(emit),
       reset,
       filterSlots,

--- a/packages/ui/src/components/va-input/components/VaTextarea/VaTextarea.vue
+++ b/packages/ui/src/components/va-input/components/VaTextarea/VaTextarea.vue
@@ -2,15 +2,16 @@
   <textarea
     ref="textarea"
     class="textarea"
-    v-bind="listeners"
+    v-bind="{ ...computedProps, ...listeners }"
     :value="modelValue"
     :style="computedStyle"
-    :placeholder="placeholder"
   />
 </template>
 
 <script lang="ts">
 import { computed, defineComponent, onMounted, ref, watch, nextTick } from 'vue'
+import { pick } from 'lodash-es'
+import { useFormProps } from '../../../../composables/useForm'
 import { useTextareaRowHeight } from './useTextareaRowHeight'
 import { useEmitProxy } from '../../../../composables/useEmitProxy'
 
@@ -29,6 +30,7 @@ export default defineComponent({
   name: 'VaTextarea',
 
   props: {
+    ...useFormProps,
     modelValue: { type: [String, Number], default: '' },
     placeholder: { type: String },
     autosize: { type: Boolean, default: false },
@@ -46,7 +48,7 @@ export default defineComponent({
 
   emits: createEmits(),
 
-  setup (props, { emit, expose }) {
+  setup (props, { emit }) {
     const textarea = ref<HTMLTextAreaElement | undefined>()
     const rowHeight = ref(-1)
     const height = ref(-1)
@@ -84,6 +86,10 @@ export default defineComponent({
       resize: isResizable.value && 'none',
     }))
 
+    const computedProps = computed(() => ({
+      ...pick(props, ['disabled', 'readonly', 'placeholder']),
+    }))
+
     const focus = () => {
       textarea.value?.focus()
     }
@@ -92,19 +98,19 @@ export default defineComponent({
       textarea.value?.blur()
     }
 
-    expose({
-      focus,
-      blur,
-    })
-
     return {
       textarea,
       computedStyle,
       listeners: createListeners(emit),
+      computedProps,
+
+      // will used after fix 'useConfigTransport'
+      // focus,
+      // blur,
     }
   },
 
-  // we use this while we have problem with useConfigTransport and 'expose'
+  // we use this while we have problem with 'useConfigTransport'
   methods: {
     focus () { this.textarea?.focus() },
     blur () { this.textarea?.blur() },

--- a/packages/ui/src/components/va-select/VaSelect.demo.vue
+++ b/packages/ui/src/components/va-select/VaSelect.demo.vue
@@ -367,9 +367,19 @@
         v-model="isClearable"
       />
       <va-select
-        v-model="disabledValue"
+        v-model="defaultSingleSelect.value"
+        class="mb-4"
+        label="Readonly"
+        placeholder="Try to type in ..."
+        :options="defaultSingleSelect.options"
+        readonly
+        :clearable="isClearable"
+      />
+      <va-select
+        v-model="defaultSingleSelect.value"
         class="mb-4"
         label="Disabled"
+        placeholder="Try to focus ..."
         :options="defaultSingleSelect.options"
         disabled
         :clearable="isClearable"


### PR DESCRIPTION
## Description
close #1471 

changes:
- [x] fix readonly in `va-select`
- [x] fix readonly in `va-input` `type=textarea`
- [x] update examples in docs and demo

![chrome-capture](https://user-images.githubusercontent.com/55198465/152770680-6cb29b96-48d6-4eee-9ea3-7fbda34bf466.gif)
![chrome-capture](https://user-images.githubusercontent.com/55198465/152996462-87de7c95-9ec4-4f94-ae4c-78af2baf2165.gif)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
