### PR TITLE
Fix#1499 Fix `VaSelectOptionList` font-family

### DIFF
--- a/packages/ui/src/components/va-button-toggle/VaButtonToggle.vue
+++ b/packages/ui/src/components/va-button-toggle/VaButtonToggle.vue
@@ -30,7 +30,6 @@ import { getTextColor, shiftHSLAColor } from '../../services/color-config/color-
 import { useColors } from '../../composables/useColor'
 import VaButton from '../va-button'
 import VaButtonGroup from '../va-button-group'
-import { getColor } from 'src/main'
 
 export default defineComponent({
   name: 'VaButtonToggle',

--- a/packages/ui/src/components/va-dropdown/VaDropdownContent/VaDropdownContent.vue
+++ b/packages/ui/src/components/va-dropdown/VaDropdownContent/VaDropdownContent.vue
@@ -24,6 +24,7 @@ export default defineComponent({
       padding: var(--va-dropdown-content-padding);
       box-shadow: var(--va-dropdown-content-box-shadow);
       border-radius: var(--va-dropdown-content-border-radius);
+      font-family: var(--va-font-family);
     }
   }
 </style>

--- a/packages/ui/src/components/va-select/VaSelectOptionList/VaSelectOptionList.vue
+++ b/packages/ui/src/components/va-select/VaSelectOptionList/VaSelectOptionList.vue
@@ -234,14 +234,15 @@ export default class VaSelectOptionList extends mixins(
 </script>
 <style lang="scss">
 @import "../../../styles/resources";
-@import 'variables';
+@import "variables";
 
 .va-select-option-list {
   display: var(--va-select-option-list-display);
   flex-direction: var(--va-select-option-list-flex-direction);
   width: var(--va-select-option-list-width);
   list-style: var(--va-select-option-list-list-style);
-  max-height: 200px;
+  max-height: var(--va-select-option-list-max-height);
+  font-family: var(--va-font-family);
   overflow: auto;
 
   @include va-scroll();

--- a/packages/ui/src/components/va-select/VaSelectOptionList/_variables.scss
+++ b/packages/ui/src/components/va-select/VaSelectOptionList/_variables.scss
@@ -3,6 +3,7 @@
   --va-select-option-list-flex-direction: column;
   --va-select-option-list-width: 100%;
   --va-select-option-list-list-style: none;
+  --va-select-option-list-max-height: 200px;
 
   /* Option */
   --va-select-option-list-option-cursor: pointer;


### PR DESCRIPTION
## Description
close #1499 

changes:
- [x] add `font-family: var(--va-font-family);` to `VaSelectOptionList` and to `VaDropdownContent`

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
