### PR TITLE
Fix vite SSR build

### DIFF
--- a/packages/bundlers-tests/package.json
+++ b/packages/bundlers-tests/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@vue/cli-service": "^4.5.13",
     "jest": "^27.0.6",
+    "rollup-plugin-visualizer": "^5.5.4",
     "ts-node": "^10.1.0",
     "vue": "^3.0.5"
   },

--- a/packages/bundlers-tests/vite.config.ts
+++ b/packages/bundlers-tests/vite.config.ts
@@ -1,17 +1,33 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import { visualizer } from 'rollup-plugin-visualizer'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [
+    vue(),
+    visualizer({
+      filename: './dist/stats.html',
+      title: 'Vuestic Test App',
+      template: 'sunburst',
+      sourcemap: true,
+    })
+  ],
   build: {
+    sourcemap: true,
     outDir: 'dist/vite',
     rollupOptions: {
       output: {
         entryFileNames: `assets/[name].js`,
         chunkFileNames: `assets/[name].js`,
         assetFileNames: `assets/[name].[ext]`
-      }
+      },
     },
-  }
+  },
+  esbuild: {
+    keepNames: true
+  },
+  optimizeDeps: {
+    exclude: ['vuestic-ui']
+  }, 
 })

--- a/packages/docs/src/page-configs/ui-elements/data-table/examples/Sorting.vue
+++ b/packages/docs/src/page-configs/ui-elements/data-table/examples/Sorting.vue
@@ -45,7 +45,7 @@
 
 <script>
 import { defineComponent } from 'vue'
-import { shuffle } from 'lodash-es'
+import shuffle from 'lodash/shuffle'
 
 export default defineComponent({
   data () {

--- a/packages/ui/jest.config.js
+++ b/packages/ui/jest.config.js
@@ -17,7 +17,7 @@ module.exports = {
     '^.+\\.vue$': 'vue-jest',
     '^.+\\js$': 'babel-jest',
   },
-  transformIgnorePatterns: ['<rootDir>/node_modules/', '/!node_modules\\/lodash-es/'],
+  transformIgnorePatterns: ['<rootDir>/node_modules/', '/!node_modules\\/lodash/'],
   moduleFileExtensions: ['vue', 'js', 'json', 'jsx', 'ts', 'tsx', 'node'],
   globals: {
     'ts-jest': {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -52,7 +52,7 @@
     "colortranslator": "^1.7.1",
     "detect-browser": "^5.2.0",
     "element-resize-detector": "^1.2.1",
-    "lodash-es": "^4.17.21",
+    "lodash": "^4.17.21",
     "normalize.css": "^8.0.1",
     "tslib": "^2.2.0"
   },
@@ -69,7 +69,6 @@
     "@types/cleave.js": "^1.4.3",
     "@types/jest": "^26.0.20",
     "@types/lodash": "^4.14.161",
-    "@types/lodash-es": "^4.17.3",
     "@types/mini-css-extract-plugin": "^1.2.1",
     "@types/semver": "^7.3.6",
     "@types/webpack": "^5",

--- a/packages/ui/src/components/va-affix/VaAffix-utils.ts
+++ b/packages/ui/src/components/va-affix/VaAffix-utils.ts
@@ -1,4 +1,4 @@
-import { throttle } from 'lodash-es'
+import throttle from 'lodash/throttle'
 import { Vue } from 'vue-class-component'
 
 export type State = {

--- a/packages/ui/src/components/va-affix/VaAffix.vue
+++ b/packages/ui/src/components/va-affix/VaAffix.vue
@@ -17,7 +17,7 @@
 </template>
 <script lang="ts">
 import { defineComponent, computed, PropType, ref, Ref, nextTick, onMounted, onBeforeUnmount } from 'vue'
-import { noop } from 'lodash-es'
+import noop from 'lodash/noop'
 
 import {
   handleThrottledEvent,

--- a/packages/ui/src/components/va-button-dropdown/VaButtonDropdown.vue
+++ b/packages/ui/src/components/va-button-dropdown/VaButtonDropdown.vue
@@ -79,7 +79,7 @@
 
 <script lang="ts">
 import { computed, defineComponent, PropType } from 'vue'
-import { pick } from 'lodash-es'
+import pick from 'lodash/pick'
 
 import { useStatefulProps, useStateful } from '../../composables/useStateful'
 import { useEmitProxy } from '../../composables/useEmitProxy'

--- a/packages/ui/src/components/va-data-table/VaDataTable.demo.vue
+++ b/packages/ui/src/components/va-data-table/VaDataTable.demo.vue
@@ -493,7 +493,8 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 import VaDataTable from './'
-import { cloneDeep, shuffle } from 'lodash-es'
+import cloneDeep from 'lodash/cloneDeep'
+import shuffle from 'lodash/shuffle'
 
 interface EvenItems {
     id?: number;

--- a/packages/ui/src/components/va-data-table/VaDataTable.new.demo.vue
+++ b/packages/ui/src/components/va-data-table/VaDataTable.new.demo.vue
@@ -159,7 +159,8 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 import VaDataTable from './'
-import { cloneDeep, shuffle } from 'lodash-es'
+import shuffle from 'lodash/shuffle'
+import cloneDeep from 'lodash/cloneDeep'
 
 export default defineComponent({
   name: 'VaDataTableNewDemo',

--- a/packages/ui/src/components/va-data-table/hooks/useColumns.ts
+++ b/packages/ui/src/components/va-data-table/hooks/useColumns.ts
@@ -1,6 +1,7 @@
 import { computed, Ref } from 'vue'
 import { ITableItem } from './useRows'
-import { merge, startCase } from 'lodash-es'
+import startCase from 'lodash/startCase'
+import merge from 'lodash/merge'
 
 export type TAlignOptions = 'left' | 'center' | 'right';
 export type TVerticalAlignOptions = 'top' | 'middle' | 'bottom';

--- a/packages/ui/src/components/va-icon/VaIcon.vue
+++ b/packages/ui/src/components/va-icon/VaIcon.vue
@@ -17,7 +17,7 @@ import { Options, mixins, prop, Vue, setup } from 'vue-class-component'
 import ColorMixin from '../../services/color-config/ColorMixin'
 import { SizeMixin } from '../../mixins/SizeMixin'
 import { useIcons } from '../../services/icon-config/icon-config'
-import { omit } from 'lodash-es'
+import omit from 'lodash/omit'
 
 class IconProps {
   name = prop<string>({ type: String, default: '' })

--- a/packages/ui/src/components/va-infinite-scroll/VaInfiniteScroll.vue
+++ b/packages/ui/src/components/va-infinite-scroll/VaInfiniteScroll.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script lang="ts">
-import { debounce } from 'lodash-es'
+import debounce from 'lodash/debounce'
 import { computed, defineComponent, ref, watch } from 'vue'
 
 import { sleep } from '../../services/utils'

--- a/packages/ui/src/components/va-input/VaInput.vue
+++ b/packages/ui/src/components/va-input/VaInput.vue
@@ -82,7 +82,8 @@ import { useClearableProps, useClearable, useClearableEmits } from '../../compos
 import VaTextarea from './components/VaTextarea/VaTextarea.vue'
 import VaIcon from '../va-icon/VaIcon.vue'
 import { extractComponentProps, filterComponentProps } from '../../utils/child-props'
-import { omit, pick } from 'lodash-es'
+import omit from 'lodash/omit'
+import pick from 'lodash/pick'
 
 const VaTextareaProps = extractComponentProps(VaTextarea)
 

--- a/packages/ui/src/components/va-input/components/VaTextarea/VaTextarea.vue
+++ b/packages/ui/src/components/va-input/components/VaTextarea/VaTextarea.vue
@@ -10,7 +10,7 @@
 
 <script lang="ts">
 import { computed, defineComponent, onMounted, ref, watch, nextTick } from 'vue'
-import { pick } from 'lodash-es'
+import pick from 'lodash/pick'
 import { useFormProps } from '../../../../composables/useForm'
 import { useTextareaRowHeight } from './useTextareaRowHeight'
 import { useEmitProxy } from '../../../../composables/useEmitProxy'

--- a/packages/ui/src/components/va-modal/tests/VaModal.spec.disabled.ts
+++ b/packages/ui/src/components/va-modal/tests/VaModal.spec.disabled.ts
@@ -1,4 +1,4 @@
-import { noop } from 'lodash-es'
+import noop from 'lodash/noop'
 import { mount } from '@vue/test-utils'
 
 import { testHasStatefulMixin } from '../../mixins/StatefulMixin/testHasStatefulMixin'

--- a/packages/ui/src/components/va-time-input/VaTimeInput.vue
+++ b/packages/ui/src/components/va-time-input/VaTimeInput.vue
@@ -83,7 +83,7 @@
 
 <script lang="ts">
 import { computed, defineComponent, InputHTMLAttributes, PropType, watch, ref } from 'vue'
-import { omit } from 'lodash-es'
+import omit from 'lodash/omit'
 import VaTimePicker from '../va-time-picker/VaTimePicker.vue'
 import VaInput from '../va-input/VaInput.vue'
 import VaIcon from '../va-icon/VaIcon.vue'

--- a/packages/ui/src/composables/useValidation.ts
+++ b/packages/ui/src/composables/useValidation.ts
@@ -1,5 +1,7 @@
 import { inject, onBeforeUnmount, onMounted, PropType, watch } from 'vue'
-import { isString, isFunction, flatten } from 'lodash-es'
+import flatten from 'lodash/flatten'
+import isFunction from 'lodash/isFunction'
+import isString from 'lodash/isString'
 import { useSyncProp } from './useSyncProp'
 import { FormServiceKey } from '../components/va-form/consts'
 import { useFocus } from './useFocus'

--- a/packages/ui/src/data/Records.ts
+++ b/packages/ui/src/data/Records.ts
@@ -1,4 +1,4 @@
-import { times } from 'lodash-es'
+import times from 'lodash/times'
 
 export const getInitialRecords = (amount = 50) => times(amount, () => ({ text: 'record', id: Math.random() }))
 

--- a/packages/ui/src/mixins/ClickOutsideMixin/ClickOutsideMixin.ts
+++ b/packages/ui/src/mixins/ClickOutsideMixin/ClickOutsideMixin.ts
@@ -2,7 +2,7 @@
 // 1/ https://github.com/react-bootstrap/react-overlays/blob/master/src/useRootClose.ts
 // 2/ https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ClickAwayListener/ClickAwayListener.js
 
-import { noop } from 'lodash-es'
+import noop from 'lodash/noop'
 import { Vue } from 'vue-class-component'
 
 import {

--- a/packages/ui/src/mixins/FormComponent/FormComponentMixin.ts
+++ b/packages/ui/src/mixins/FormComponent/FormComponentMixin.ts
@@ -1,4 +1,6 @@
-import { isString, isFunction, flatten } from 'lodash-es'
+import flatten from 'lodash/flatten'
+import isFunction from 'lodash/isFunction'
+import isString from 'lodash/isString'
 import { inject } from 'vue'
 import { mixins, Options, prop, Vue, setup } from 'vue-class-component'
 

--- a/packages/ui/src/services/config-transport/withConfigTransport.ts
+++ b/packages/ui/src/services/config-transport/withConfigTransport.ts
@@ -1,4 +1,7 @@
-import { isArray, isObject, camelCase, upperFirst } from 'lodash-es'
+import isArray from 'lodash/isArray'
+import isObject from 'lodash/isObject'
+import camelCase from 'lodash/camelCase'
+import upperFirst from 'lodash/upperFirst'
 import {
   DefineComponent,
   ComponentOptions,

--- a/packages/ui/src/services/global-config/global-config.ts
+++ b/packages/ui/src/services/global-config/global-config.ts
@@ -1,4 +1,5 @@
-import { merge, cloneDeep } from 'lodash-es'
+import merge from 'lodash/merge'
+import cloneDeep from 'lodash/cloneDeep'
 import { ref } from 'vue'
 import { GlobalConfig, GlobalConfigUpdater } from './types'
 import { getComponentsAllDefaultConfig, getComponentsDefaultConfig } from './config-default'

--- a/packages/ui/src/services/icon-config/icon-helpers.ts
+++ b/packages/ui/src/services/icon-config/icon-helpers.ts
@@ -1,4 +1,4 @@
-import { merge } from 'lodash-es'
+import merge from 'lodash/merge'
 import { getGlobalConfig } from '../global-config/global-config'
 import { isMatchDynamicSegments, dynamicSegments } from './utils/dynamic-segment'
 import { isMatchRegex, regexGroupsValues } from './utils/regex'

--- a/packages/ui/src/services/utils.ts
+++ b/packages/ui/src/services/utils.ts
@@ -1,6 +1,6 @@
 //  @ts-nocheck
 
-import { isObject } from 'lodash-es'
+import isObject from 'lodash/isObject'
 
 export const sleep = (ms = 0) => {
   return new Promise(resolve => setTimeout(resolve, ms))

--- a/yarn.lock
+++ b/yarn.lock
@@ -2862,14 +2862,7 @@
     "@types/interpret" "*"
     "@types/node" "*"
 
-"@types/lodash-es@^4.17.3":
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.4.tgz#b2e440d2bf8a93584a9fd798452ec497986c9b97"
-  integrity sha512-BBz79DCJbD2CVYZH67MBeHZRX++HF+5p8Mo5MzjZi64Wac39S3diedJYHZtScbRVf4DjZyN6LzA0SB0zy+HSSQ==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*", "@types/lodash@^4.14.161", "@types/lodash@^4.14.168":
+"@types/lodash@^4.14.161", "@types/lodash@^4.14.168":
   version "4.14.172"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.172.tgz#aad774c28e7bfd7a67de25408e03ee5a8c3d028a"
   integrity sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw==
@@ -4434,6 +4427,11 @@ ansi-regex@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -13371,6 +13369,11 @@ nanoid@^3.1.23:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.25.tgz#09ca32747c0e543f0e1814b7d3793477f9c8e152"
   integrity sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==
 
+nanoid@^3.1.32:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
+  integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -13920,6 +13923,15 @@ open@^8.0.2:
   version "8.2.1"
   resolved "https://registry.yarnpkg.com/open/-/open-8.2.1.tgz#82de42da0ccbf429bc12d099dad2e0975e14e8af"
   integrity sha512-rXILpcQlkF/QuFez2BJDf3GsqpjGKbkUUToAIGo9A0Q6ZkoSGogZJulrUdwRkrAsoQvoZsrjCYt8+zblOk7JQQ==
+  dependencies:
+    define-lazy-prop "^2.0.0"
+    is-docker "^2.1.1"
+    is-wsl "^2.2.0"
+
+open@^8.4.0:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-8.4.0.tgz#345321ae18f8138f82565a910fdc6b39e8c244f8"
+  integrity sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==
   dependencies:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"
@@ -16451,6 +16463,16 @@ rollup-plugin-typescript2@^0.30.0:
     resolve "1.20.0"
     tslib "2.1.0"
 
+rollup-plugin-visualizer@^5.5.4:
+  version "5.5.4"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.5.4.tgz#ce3461fdcbfdf784f52aa5205e1d166e2152bab0"
+  integrity sha512-CJQFUuZ75S1daGEkk62UH7lL6UFCoP86Sn/iz4gXBdamdwFeD5nPGCHHXfXCrly/wNgQOYTH7cdcxk4+OG3Xjw==
+  dependencies:
+    nanoid "^3.1.32"
+    open "^8.4.0"
+    source-map "^0.7.3"
+    yargs "^17.3.1"
+
 rollup-plugin-vue@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-vue/-/rollup-plugin-vue-6.0.0.tgz#e379e93e5ae9a8648522f698be2e452e8672aaf2"
@@ -17409,6 +17431,15 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
+string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string.prototype.trimend@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz#e75ae90c2942c63504686c18b287b4a0b1a45f80"
@@ -17475,6 +17506,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-bom@^2.0.0:
   version "2.0.0"
@@ -19803,6 +19841,11 @@ yargs-parser@^18.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^21.0.0:
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.0.tgz#a485d3966be4317426dd56bdb6a30131b281dc55"
+  integrity sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==
+
 yargs@^13.3.2:
   version "13.3.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
@@ -19865,6 +19908,19 @@ yargs@^16.0.0, yargs@^16.0.3:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yargs@^17.3.1:
+  version "17.3.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.3.1.tgz#da56b28f32e2fd45aefb402ed9c26f42be4c07b9"
+  integrity sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.0.0"
 
 yauzl@^2.10.0:
   version "2.10.0"


### PR DESCRIPTION
THIS PR with #1501 close #1511

Use `lodash` instead of `lodash-es`. It shouldn't break tree shaking if we use `lodash/[function]` import style. 
Because `vuestic-ui` must work with SSR (e.g. with node and CJS format) we don't need to use esm-only libs.