### PR TITLE
Don't use global components in vue-book. Fix unresolved components.

### DIFF
--- a/packages/ui/src/components/va-button/VaButton.demo.vue
+++ b/packages/ui/src/components/va-button/VaButton.demo.vue
@@ -492,12 +492,13 @@
 </template>
 
 <script>
-
+import VaIcon from '../va-icon'
+import VaConfig from '../va-config'
 import VaButton from './index'
 
 export default {
   components: {
-    VaButton,
+    VaButton, VaIcon, VaConfig,
   },
   data () {
     return {

--- a/packages/ui/src/components/va-config/VaConfig.demo.vue
+++ b/packages/ui/src/components/va-config/VaConfig.demo.vue
@@ -161,23 +161,24 @@
 </template>
 
 <script>
+import { computed } from 'vue'
 import { getGlobalConfig, useGlobalConfig } from '../../services/global-config/global-config'
 import ColorMixin from '../../services/color-config/ColorMixin'
 import { useColors } from '../../services/color-config/color-config'
 import VaButton from '../va-button'
-import { computed } from 'vue'
 import VaRating from '../va-rating/'
 // import VaBadge from '../va-badge'
 
 // import ConfigUsageTest from './ConfigUsageTest.vue'
 // import withConfigTransport from '../../services/config-transport/withConfigTransport'
-// import VaConfig from './VaConfig'
+import VaConfig from './'
 
 export default {
   mixins: [ColorMixin],
   components: {
     VaRating,
     VaButton,
+    VaConfig,
     // VaBadge,
     // VaConfig,
     // ConfigUsageTest: withConfigTransport(ConfigUsageTest),

--- a/packages/ui/src/components/va-data-table/VaDataTable.demo.vue
+++ b/packages/ui/src/components/va-data-table/VaDataTable.demo.vue
@@ -493,6 +493,9 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 import VaDataTable from './'
+import VaSwitch from '../va-switch'
+import VaPagination from '../va-pagination'
+import VaButton from '../va-button'
 import { cloneDeep, shuffle } from 'lodash-es'
 
 interface EvenItems {
@@ -506,6 +509,9 @@ interface EvenItems {
 export default defineComponent({
   components: {
     VaDataTable,
+    VaSwitch,
+    VaPagination,
+    VaButton,
   },
 
   data () {

--- a/packages/ui/src/components/va-data-table/VaDataTable.new.demo.vue
+++ b/packages/ui/src/components/va-data-table/VaDataTable.new.demo.vue
@@ -158,14 +158,18 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue'
-import VaDataTable from './'
 import { cloneDeep, shuffle } from 'lodash-es'
+import VaDataTable from './'
+import VaChip from '../va-chip'
+import VaAlert from '../va-alert'
 
 export default defineComponent({
   name: 'VaDataTableNewDemo',
 
   components: {
     VaDataTable,
+    VaChip,
+    VaAlert,
   },
 
   data () {

--- a/packages/ui/src/components/va-date-input/VaDateInput.demo.vue
+++ b/packages/ui/src/components/va-date-input/VaDateInput.demo.vue
@@ -149,6 +149,7 @@
 
 <script lang="ts">
 import { VaDateInput } from './index'
+import VaChip from '../va-chip'
 
 const datePlusDay = (date: Date, days: number) => {
   const d = new Date(date)
@@ -158,7 +159,7 @@ const datePlusDay = (date: Date, days: number) => {
 const nextWeek = datePlusDay(new Date(), 7)
 
 export default {
-  components: { VaDateInput },
+  components: { VaDateInput, VaChip },
   data () {
     return {
       value: new Date(),

--- a/packages/ui/src/components/va-date-picker/VaDatePicker.demo.vue
+++ b/packages/ui/src/components/va-date-picker/VaDatePicker.demo.vue
@@ -154,6 +154,7 @@
 
 <script lang="ts">
 import { VaDatePicker } from './index'
+import VaChip from '../va-chip'
 
 const datePlusDay = (date: Date, days: number) => {
   const d = new Date(date)
@@ -163,7 +164,7 @@ const datePlusDay = (date: Date, days: number) => {
 const nextWeek = datePlusDay(new Date(), 7)
 
 export default {
-  components: { VaDatePicker },
+  components: { VaDatePicker, VaChip },
   data () {
     return {
       value: new Date(),

--- a/packages/ui/src/components/va-dropdown/VaDropdown.demo.vue
+++ b/packages/ui/src/components/va-dropdown/VaDropdown.demo.vue
@@ -344,11 +344,12 @@
 </template>
 
 <script>
-import VaDropdown from './index'
+import VaDropdown, { VaDropdownContent } from './'
 import DropdownCloseButton from './__demo__/DropdownCloseButton'
+import VaInput from '../va-input'
 
 export default {
-  components: { DropdownCloseButton, VaDropdown },
+  components: { DropdownCloseButton, VaDropdown, VaInput, VaDropdownContent },
   data () {
     return {
       possiblePositions: [

--- a/packages/ui/src/components/va-file-upload/VaFileUploadGalleryItem/VaFileUploadGalleryItem.vue
+++ b/packages/ui/src/components/va-file-upload/VaFileUploadGalleryItem/VaFileUploadGalleryItem.vue
@@ -56,6 +56,7 @@ import { Options, Vue, prop, mixins } from 'vue-class-component'
 
 import { colorToRgba } from '../../../services/color-config/color-functions'
 import VaIcon from '../../va-icon'
+import VaButton from '../../va-button'
 
 import VaFileUploadUndo from '../VaFileUploadUndo'
 
@@ -78,6 +79,7 @@ const FileUploadGalleryItemPropsMixin = Vue.with(FileUploadGalleryItemProps)
   components: {
     VaIcon,
     VaFileUploadUndo,
+    VaButton,
   },
   emits: ['remove'],
 })

--- a/packages/ui/src/components/va-form/VaForm.demo.vue
+++ b/packages/ui/src/components/va-form/VaForm.demo.vue
@@ -153,6 +153,8 @@
 <script>
 import VaForm from './index'
 import VaInput from '../va-input'
+import VaSelect from '../va-select'
+import VaButton from '../va-button'
 import VaFormReset from './VaForm-reset'
 
 export default {
@@ -160,6 +162,8 @@ export default {
     VaFormReset,
     VaForm,
     VaInput,
+    VaSelect,
+    VaButton,
   },
   data () {
     return {

--- a/packages/ui/src/components/va-input/VaInput.demo.vue
+++ b/packages/ui/src/components/va-input/VaInput.demo.vue
@@ -583,6 +583,7 @@ import VaInput from './index'
 import VaButton from './../va-button'
 import VaIcon from './../va-icon'
 import VaInputValidation from './VaInput-validation'
+import VaCheckbox from '../va-checkbox'
 
 export default {
   components: {
@@ -590,6 +591,7 @@ export default {
     VaInput,
     VaButton,
     VaIcon,
+    VaCheckbox,
   },
   data () {
     return {

--- a/packages/ui/src/components/va-select/VaSelect.demo.vue
+++ b/packages/ui/src/components/va-select/VaSelect.demo.vue
@@ -558,16 +558,17 @@
 import CountriesList from '../../data/CountriesList'
 import VaIcon from '../va-icon'
 import VaCheckbox from '../va-checkbox'
+import VaChip from '../va-chip'
+import VaSelect from './index'
 
 import { objectOptionsList, iconOptionsList } from './getDemoData'
-import VaSelect from './index'
 
 const positions = ['top', 'bottom']
 
 const random = () => Math.ceil(Math.random() * 10000) + ''
 
 export default {
-  components: { VaSelect, VaIcon, VaCheckbox },
+  components: { VaSelect, VaIcon, VaCheckbox, VaChip },
   data () {
     return {
       allowCreateValue: '',

--- a/packages/ui/src/components/va-tabs/VaTabs.vue
+++ b/packages/ui/src/components/va-tabs/VaTabs.vue
@@ -68,6 +68,7 @@ import ColorMixin from '../../services/color-config/ColorMixin'
 import { StatefulMixin } from '../../mixins/StatefulMixin/StatefulMixin'
 import VaButton from '../va-button'
 import VaTab from './VaTab/VaTab.vue'
+import VaConfig from '../va-config'
 
 export class TabsService {
   // eslint-disable-next-line no-useless-constructor
@@ -123,7 +124,7 @@ export const TabsServiceKey = Symbol('TabsService')
 
 @Options({
   name: 'VaTabs',
-  components: { VaButton },
+  components: { VaButton, VaConfig },
   emits: ['update:modelValue', 'click:next', 'click:prev'],
 })
 export default class VaTabs extends mixins(

--- a/packages/ui/src/components/va-time-input/VaTimeInput.demo.vue
+++ b/packages/ui/src/components/va-time-input/VaTimeInput.demo.vue
@@ -69,10 +69,11 @@
 
 <script>
 import VaTimeInput from './VaTimeInput.vue'
+import VaIcon from '../va-icon'
 
 export default {
   components: {
-    VaTimeInput,
+    VaTimeInput, VaIcon,
   },
 
   data () {

--- a/packages/ui/src/vue-book/book-main.ts
+++ b/packages/ui/src/vue-book/book-main.ts
@@ -12,10 +12,9 @@ import demoIconAliases from './vuestic-config/demo-icon-aliases'
 import demoIconFonts from './vuestic-config/demo-icon-fonts'
 
 import './vue-book-overrides.scss'
-import { createIconsConfig, VuesticPlugin } from '../main'
+import { createIconsConfig, VuesticPluginsWithoutComponents } from '../main'
 import { colorsPresets } from '../services/color-config/color-theme-presets'
 
-// @ts-ignore
 const app = createApp(App)
 
 const routes = [
@@ -34,13 +33,10 @@ const router = createRouter({
   routes,
 })
 
-// app.use(ColorHelpersPlugin)
 app.use(VueBookComponents)
-app.use(ToastInstall)
-app.use(DropdownPopperSubplugin)
 app.use(router)
 
-app.use(VuesticPlugin, {
+app.use(VuesticPluginsWithoutComponents, {
   icons: createIconsConfig({
     aliases: demoIconAliases,
     fonts: demoIconFonts,


### PR DESCRIPTION
closes #1518

In this PR I removed global components from vue-book, so now we forced to import child components directly in component. This will fix unresolved components issue in tree-shaking build.

Would be nice to have some eslint rule, but this PR is only hotfix.