### PR TITLE
Fix/plugin without components

### DIFF
--- a/packages/ui/build/rollup/generate-rollup-inputs.js
+++ b/packages/ui/build/rollup/generate-rollup-inputs.js
@@ -20,8 +20,7 @@ export const getInputs = () => {
     .map((folderName) => `./src/components/${folderName}/index.ts`)
     .filter((filePath) => existsSync(filePath))
 
-  const utils = readdirSync('./src/utils')
-  const services = readDirRecursive('./src/services')
+  const vuesticPlugin = readDirRecursive('./src/vuestic-plugin')
 
-  return [...components]
+  return [...components, ...vuesticPlugin]
 }


### PR DESCRIPTION
Fixed tree-shaking in `VuesticPluginsWithoutComponents`. Now, `vuestic-plugins` files do not compile into one file. It makes bundles easy to tree-shake separated files.

Bundlers tests output.
![image](https://user-images.githubusercontent.com/23530004/155064796-443a8253-b17c-4d43-ae82-c1d790b3fd3a.png)

