### PR TITLE
va-input accepts `pattern` and `inputmode` props

### DIFF
--- a/packages/docs/src/locales/en/en.json
+++ b/packages/docs/src/locales/en/en.json
@@ -670,7 +670,9 @@
         "focused": "Applies focus style",
         "canBeFocused": "If false, then input can not be focused using mouse or keyboard",
         "requiredMark": "Adds required mark to the label",
-        "immediateValidation": "Sets the validation to be performed when the component is mounted"
+        "immediateValidation": "Sets the validation to be performed when the component is mounted",
+        "pattern": "The pattern prop specifies a regular expression the input value should match",
+        "inputmode": "The inputmode prop is an enumerated prop that hints at the type of data that might be entered by the user while editing the element or its contents. This alows a browser to display an apropriate virtual keyboard"
       },
       "events": {
         "change": "Emitted when the input loose focus or on `enter`",

--- a/packages/ui/src/components/va-input/VaInput.vue
+++ b/packages/ui/src/components/va-input/VaInput.vue
@@ -206,7 +206,7 @@ export default defineComponent({
 
     const computedInputAttributes = computed(() => ({
       ...computedChildAttributes.value,
-      ...pick(props, ['type', 'tabindex', 'disabled', 'readonly', 'placeholder']),
+      ...pick(props, ['type', 'tabindex', 'disabled', 'readonly', 'placeholder', 'pattern', 'inputmode']),
     }) as InputHTMLAttributes)
 
     return {

--- a/packages/ui/src/components/va-input/VaInput.vue
+++ b/packages/ui/src/components/va-input/VaInput.vue
@@ -120,6 +120,9 @@ export default defineComponent({
     label: { type: String, default: '' },
     type: { type: String as PropType<'text' | 'textarea'>, default: 'text' },
     loading: { type: Boolean, default: false },
+    pattern: { type: String },
+    inputmode: { type: String, default: 'text' },
+
     // style
     color: { type: String, default: 'primary' },
     outline: { type: Boolean, default: false },


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Now va-input accepts `pattern` and `input-mode` props and use those to enhance mobile device experiences.
Fixes #1566

## Markup:
<!-- Paste your markup here. -->
<details>
Pattern is probably used in form submit check. Inputmode can decide what kind virtual keyboard is show to input.

```vue
<va-input pattern="[0-9]{8}" inputmode="tel" />
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
