### PR TITLE
[#1478] landing visual tweaks

### DIFF
--- a/packages/docs/src/assets/fonts.scss
+++ b/packages/docs/src/assets/fonts.scss
@@ -28,7 +28,7 @@
 // text
 @mixin text-font() {
   font-weight: normal;
-  font-size: 1.1rem;
+  font-size: 1.2rem;
 
   @include lg(font-size, 1rem);
   @include md(font-size, 0.95rem);

--- a/packages/docs/src/components/DocsContent.vue
+++ b/packages/docs/src/components/DocsContent.vue
@@ -119,3 +119,19 @@ export default defineComponent({
   },
 })
 </script>
+
+<style lang="scss">
+.va-content p {
+  font-size: 1.2rem;
+}
+
+.va-content h5 {
+  margin-top: 4rem;
+  line-height: 1.25;
+
+  &:first-of-type {
+    margin-top: 1.25rem;
+    margin-bottom: 0.75rem;
+  }
+}
+</style>

--- a/packages/docs/src/components/DocsContent.vue
+++ b/packages/docs/src/components/DocsContent.vue
@@ -119,19 +119,3 @@ export default defineComponent({
   },
 })
 </script>
-
-<style lang="scss">
-.va-content p {
-  font-size: 1.2rem;
-}
-
-.va-content h5 {
-  margin-top: 4rem;
-  line-height: 1.25;
-
-  &:first-of-type {
-    margin-top: 1.25rem;
-    margin-bottom: 0.75rem;
-  }
-}
-</style>

--- a/packages/docs/src/components/header/Header.vue
+++ b/packages/docs/src/components/header/Header.vue
@@ -138,7 +138,7 @@ export default class Header extends mixins(PropsMixin) {
   }
 
   &__links__button {
-    font-weight: $font-weight-bold;
+    font-weight: 600;
 
     .button__text {
       margin-left: 0.375rem;

--- a/packages/docs/src/components/header/components/ColorDropdown.vue
+++ b/packages/docs/src/components/header/components/ColorDropdown.vue
@@ -47,7 +47,7 @@ export default defineComponent({
 
   &__icon {
     .va-button__content {
-      font-weight: bold;
+      font-weight: 600;
     }
 
     position: relative;

--- a/packages/docs/src/components/header/components/LanguageDropdown.vue
+++ b/packages/docs/src/components/header/components/LanguageDropdown.vue
@@ -4,7 +4,7 @@
       color="primary"
       flat
       :label="currentLanguageName"
-      :offset="[0, 25]"
+      :offset="[0, 10]"
     >
       <div class="language-dropdown__content">
         <va-list-item
@@ -78,11 +78,11 @@ export default defineComponent({
 
 <style lang="scss">
 .language-dropdown {
-  font-weight: 700;
+  font-weight: 600;
   cursor: pointer;
 
   .va-button__content {
-    font-weight: bold;
+    font-weight: 600;
   }
 
   &__item {

--- a/packages/docs/src/components/header/components/LanguageDropdown.vue
+++ b/packages/docs/src/components/header/components/LanguageDropdown.vue
@@ -78,7 +78,6 @@ export default defineComponent({
 
 <style lang="scss">
 .language-dropdown {
-  font-weight: 600;
   cursor: pointer;
 
   .va-button__content {

--- a/packages/docs/src/components/header/components/LanguageDropdown.vue
+++ b/packages/docs/src/components/header/components/LanguageDropdown.vue
@@ -88,6 +88,7 @@ export default defineComponent({
     padding-bottom: 0.625rem;
     cursor: pointer;
     flex-wrap: nowrap;
+    font-weight: 600;
 
     &:hover,
     &.active {

--- a/packages/docs/src/components/header/components/VersionDropdown.vue
+++ b/packages/docs/src/components/header/components/VersionDropdown.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="color: var(--va-primary);">
+  <div class="version-dropdown">
     v{{ uiVersion }}
   </div>
 </template>
@@ -24,3 +24,10 @@ export default class VersionDropdown extends Vue {
   }
 }
 </script>
+
+<style lang="scss">
+.version-dropdown {
+  color: var(--va-primary);
+  font-weight: 600;
+}
+</style>

--- a/packages/docs/src/components/landing/Admin.vue
+++ b/packages/docs/src/components/landing/Admin.vue
@@ -119,7 +119,8 @@ export default class Admin extends Vue {}
     @include size(12);
     @include text-font();
 
-    padding-top: 1.5rem;
+    padding-top: 1rem;
+    line-height: 1.5;
     text-align: center;
   }
 
@@ -235,7 +236,7 @@ export default class Admin extends Vue {}
       @include text-font();
 
       padding-left: 1rem;
-      line-height: 1.8rem;
+      line-height: 1.5;
     }
   }
 }

--- a/packages/docs/src/components/landing/Customize.vue
+++ b/packages/docs/src/components/landing/Customize.vue
@@ -487,7 +487,7 @@ export default class Customize extends Vue {
     @include text-font();
 
     color: #ffffff;
-    padding-top: 3rem;
+    padding-top: 1rem;
     text-align: center;
 
     // sm

--- a/packages/docs/src/components/landing/Footer.vue
+++ b/packages/docs/src/components/landing/Footer.vue
@@ -145,6 +145,7 @@ export default class Footer extends Vue {
     @include size(12);
     @include text-font();
 
+    line-height: 1.5;
     padding: 3rem 0 4rem;
     text-align: center;
 

--- a/packages/docs/src/components/landing/Header.vue
+++ b/packages/docs/src/components/landing/Header.vue
@@ -14,8 +14,8 @@
         </div>
         <nav class="header__links">
           <!-- vuestic buttons -->
-          <va-button :to="`/${$root.$i18n.locale}/introduction/overview`" class="header__links--link" flat color="primary">{{ $t('landing.header.buttons.overview') }}</va-button>
-          <va-button :to="`/${$root.$i18n.locale}/introduction/roadmap`" class="header__links--link" flat color="primary">{{ $t('landing.header.buttons.docs') }}</va-button>
+          <va-button :to="`/${$root.$i18n.locale}/introduction/overview`" class="header__links--link" flat color="black">{{ $t('landing.header.buttons.overview') }}</va-button>
+          <va-button :to="`/${$root.$i18n.locale}/introduction/overview`" class="header__links--link" flat color="primary">{{ $t('landing.header.buttons.docs') }}</va-button>
           <va-button href="https://discord.gg/u7fQdqQt8c" target="blank" class="header__links--link" flat color="primary">{{ $t('landing.header.buttons.discord') }}</va-button>
           <LanguageDropdown />
           <stars-button class="ml-2" repo="epicmaxco/vuestic-ui" />
@@ -30,7 +30,7 @@
             </va-list-item>
             <va-list-item>
               <va-list-item-section class="mobile-menu__link">
-                <router-link :to="`/${$root.$i18n.locale}/introduction/roadmap`">{{ $t('landing.header.buttons.docs') }}</router-link>
+                <router-link :to="`/${$root.$i18n.locale}/introduction/overview`">{{ $t('landing.header.buttons.docs') }}</router-link>
               </va-list-item-section>
             </va-list-item>
             <va-list-item>

--- a/packages/docs/src/components/landing/OpenSource.vue
+++ b/packages/docs/src/components/landing/OpenSource.vue
@@ -73,7 +73,7 @@ export default class OpenSource extends Vue {}
   &__title {
     @include title-font();
 
-    padding-bottom: 1.7rem;
+    padding-bottom: 1rem;
 
     // sm
     @include sm(text-align, center);
@@ -88,7 +88,7 @@ export default class OpenSource extends Vue {}
   &__text {
     @include text-font();
 
-    line-height: 1.5rem;
+    line-height: 1.5;
 
     // sm
     @include sm(text-align, center);

--- a/packages/docs/src/components/landing/Preview.vue
+++ b/packages/docs/src/components/landing/Preview.vue
@@ -212,7 +212,7 @@ export default {
 
     text-align: center;
     padding: 0.75rem 0 0.5rem;
-    line-height: 1.8rem;
+    line-height: 1.5;
   }
 
   &__link {

--- a/packages/docs/src/components/landing/SeamlessIntegration/SeamlessIntegration.vue
+++ b/packages/docs/src/components/landing/SeamlessIntegration/SeamlessIntegration.vue
@@ -135,7 +135,7 @@ export default class Seamless extends Vue {
     @include size(12);
     @include text-font();
 
-    padding-top: 3rem;
+    padding-top: 1rem;
     text-align: center;
 
     // sm

--- a/packages/ui/src/components/va-icon/VaIcon.vue
+++ b/packages/ui/src/components/va-icon/VaIcon.vue
@@ -48,7 +48,7 @@ export default defineComponent({
     const computedAttrs = computed(() => ({ ...iconConfig.value.attrs, ...omit(attrs, ['class']) }))
 
     const getSpinClass = (spin?: string | boolean) => {
-      if (spin === undefined) { return }
+      if (spin === undefined || spin === false) { return }
       return spin === 'counter-clockwise' ? 'va-icon--spin-reverse' : 'va-icon--spin'
     }
 


### PR DESCRIPTION
## Description
close: #1478 

All items from 1478 were closed, but i should mention some moments:

> set primary color to 2550c0 (not 4382d9)

There is no 4382d9 at all, but i can see 2550c0. So, i guess, it was already changed.

> docs menu items should lead to introduction > Overview (not to the roadmap)

Done, but it seems strange, that overview & doc links lead to the one page. May be overview link should have '/' href? It's logically, cause of another item: "overview should be black on the landing page".

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
