### PR TITLE
[#1479] vuestic docs website tweaks

### DIFF
--- a/packages/docs/src/components/DocsContent.vue
+++ b/packages/docs/src/components/DocsContent.vue
@@ -119,3 +119,19 @@ export default defineComponent({
   },
 })
 </script>
+
+<style lang="scss">
+.va-content p {
+  font-size: 1.2rem;
+}
+
+.va-content h5 {
+  margin-top: 4rem;
+  line-height: 1.25;
+
+  &:first-of-type {
+    margin-top: 1.25rem;
+    margin-bottom: 0.75rem;
+  }
+}
+</style>


### PR DESCRIPTION
## Description
close: #1479 

Seems, that these changes are needed only for docs website, not for va-content component, so, linked styles were just overwritten.

> for some reasons we use h1, h3, h5, h6. can we use h1, h2, h3, h4 instead.

It is possible, but more styles should be overwritten. I guest, this is not a todo item, but just a suggestion for this moment.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
