### PR TITLE
[#1620] Fix `VaDateInput` icon color

### DIFF
--- a/packages/ui/src/components/va-date-input/VaDateInput.vue
+++ b/packages/ui/src/components/va-date-input/VaDateInput.vue
@@ -146,6 +146,7 @@ export default defineComponent({
     const { syncProp: isOpenSync } = useSyncProp(isOpen, 'is-open', emit, false)
 
     const isRangeModelValueGuardDisabled = computed(() => !resetOnClose.value)
+
     const {
       valueComputed,
       reset: resetInvalidRange,

--- a/packages/ui/src/components/va-date-input/VaDateInput.vue
+++ b/packages/ui/src/components/va-date-input/VaDateInput.vue
@@ -90,7 +90,6 @@ const VaInputProps = {
   ...useFormProps,
 
   label: { type: String, required: false },
-  color: { type: String, default: 'primary' },
   placeholder: { type: String, default: '' },
   tabindex: { type: Number, default: 0 },
   outline: { Boolean, default: false },
@@ -110,9 +109,9 @@ export default defineComponent({
 
   props: {
     ...VaInputProps,
+    ...useClearableProps,
     ...extractComponentProps(VaDatePicker),
 
-    ...useClearableProps,
     clearValue: { type: Date as PropType<VaDatePickerModelValue>, default: undefined },
 
     resetOnClose: { type: Boolean, default: true },
@@ -127,6 +126,7 @@ export default defineComponent({
     rangeDelimiter: { type: String, default: ' ~ ' },
     manualInput: { type: Boolean, default: false },
 
+    color: { type: String, default: 'primary' },
     leftIcon: { type: Boolean, default: false },
     icon: { type: String, default: 'calendar_today' },
   },


### PR DESCRIPTION
## Description
close #1620

changes:
- [x] remove `color` prop override

<img width="333" alt="image" src="https://user-images.githubusercontent.com/55198465/161534725-6a66b687-7a0a-4435-990d-3ecf585c08fb.png">

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
