### PR TITLE
[#1411] input wrapper resize fix

### DIFF
--- a/packages/docs/src/components/DocsContent.vue
+++ b/packages/docs/src/components/DocsContent.vue
@@ -119,3 +119,19 @@ export default defineComponent({
   },
 })
 </script>
+
+<style lang="scss">
+.va-content p {
+  font-size: 1.2rem;
+}
+
+.va-content h5 {
+  margin-top: 4rem;
+  line-height: 1.25;
+
+  &:first-of-type {
+    margin-top: 1.25rem;
+    margin-bottom: 0.75rem;
+  }
+}
+</style>

--- a/packages/docs/src/components/DocsContent.vue
+++ b/packages/docs/src/components/DocsContent.vue
@@ -119,19 +119,3 @@ export default defineComponent({
   },
 })
 </script>
-
-<style lang="scss">
-.va-content p {
-  font-size: 1.2rem;
-}
-
-.va-content h5 {
-  margin-top: 4rem;
-  line-height: 1.25;
-
-  &:first-of-type {
-    margin-top: 1.25rem;
-    margin-bottom: 0.75rem;
-  }
-}
-</style>

--- a/packages/ui/src/components/va-input/components/VaInputWrapper.vue
+++ b/packages/ui/src/components/va-input/components/VaInputWrapper.vue
@@ -307,8 +307,11 @@ export default defineComponent({
 
   &--labeled {
     .va-input__content-wrapper {
-      padding-top: 12px;
       height: 100%;
+      width: -moz-available;
+      width: -webkit-fill-available;
+      width: fill-available;
+      padding-top: 12px;
       align-items: flex-end;
     }
 


### PR DESCRIPTION
close: #1411 

## Description
CSS fill available fixes this problem. Input will grow-shrink depending on free space and component's width would not be affected by amount of active icons.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
