### PR TITLE
Added code font alert in typography docs

### DIFF
--- a/packages/docs/public/index.html
+++ b/packages/docs/public/index.html
@@ -28,7 +28,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@5.9.55/css/materialdesignicons.min.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400">
-    <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined">
     <script src="https://kit.fontawesome.com/5460c87b2a.js" crossorigin="anonymous"></script>

--- a/packages/docs/public/index.html
+++ b/packages/docs/public/index.html
@@ -28,6 +28,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@5.9.55/css/materialdesignicons.min.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400">
+    <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined">
     <script src="https://kit.fontawesome.com/5460c87b2a.js" crossorigin="anonymous"></script>

--- a/packages/docs/public/index.html
+++ b/packages/docs/public/index.html
@@ -27,8 +27,7 @@
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@5.9.55/css/materialdesignicons.min.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400&display=swap">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined">
     <script src="https://kit.fontawesome.com/5460c87b2a.js" crossorigin="anonymous"></script>

--- a/packages/docs/src/locales/en/en.json
+++ b/packages/docs/src/locales/en/en.json
@@ -3549,6 +3549,7 @@
     "titled": "Title heading",
     "textStyles": "Text styles",
     "codeSnippet": "Code snippet",
+    "codeSnippetWarn": "You need to install `Source Code Pro` font if you want to use `.code-snippet` class",
     "textCode": "Text-code",
     "other": "Other typography styles",
     "orderedList": "Ordered list",

--- a/packages/docs/src/page-configs/styles/typography/code-examples/font.ts
+++ b/packages/docs/src/page-configs/styles/typography/code-examples/font.ts
@@ -1,0 +1,1 @@
+export const fontUsing = '<link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap" rel="stylesheet">'

--- a/packages/docs/src/page-configs/styles/typography/page-config.ts
+++ b/packages/docs/src/page-configs/styles/typography/page-config.ts
@@ -1,5 +1,6 @@
 import { ApiDocsBlock } from '@/types/configTypes'
 import { PageGenerationHelper } from '@/helpers/DocsHelper'
+import { fontUsing } from './code-examples/font'
 
 const block = new PageGenerationHelper(__dirname)
 
@@ -18,6 +19,8 @@ const config: ApiDocsBlock[] = [
 
   block.headline('typography.codeSnippet'),
   block.example('codeSnippet'),
+  block.alert('typography.codeSnippetWarn', 'warning'),
+  block.code(fontUsing, 'html'),
 
   block.headline('typography.textCode'),
   block.example('textCode'),


### PR DESCRIPTION

## Description
Style sheets uses `Source Code Pro` but didn't import it. This pr import it in `docs/public/index.html`.
fixes #1339

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
