### PR TITLE
[#1657] VaRadio readonly state, VaRadio & VaSwitch examples updated

### DIFF
--- a/packages/ui/src/components/va-card/VaCard.vue
+++ b/packages/ui/src/components/va-card/VaCard.vue
@@ -120,9 +120,7 @@ export default defineComponent({
   }
 
   &--disabled {
-    opacity: 0.6;
-    pointer-events: none;
-    user-select: none;
+    @include va-disabled;
   }
 
   &--link {

--- a/packages/ui/src/components/va-radio/VaRadio.demo.vue
+++ b/packages/ui/src/components/va-radio/VaRadio.demo.vue
@@ -49,6 +49,15 @@
         disabled
       />
     </VbCard>
+    <VbCard title="Readonly">
+      <va-radio
+        v-for="(option, index) in options"
+        :key="index"
+        v-model="selectedOptionString"
+        :option="option"
+        readonly
+      />
+    </VbCard>
     <VbCard title="Left label">
       <va-radio
         v-for="(option, index) in options"

--- a/packages/ui/src/components/va-radio/VaRadio.vue
+++ b/packages/ui/src/components/va-radio/VaRadio.vue
@@ -38,31 +38,33 @@
 
 <script lang="ts">
 import { defineComponent, PropType, computed } from 'vue'
-
 import { useColors } from '../../composables/useColor'
+import { useFormProps, useForm } from '../../composables/useForm'
 
 export default defineComponent({
   name: 'VaRadio',
   emits: ['update:modelValue', 'focus'],
   props: {
+    ...useFormProps,
     modelValue: { type: null as any as PropType<unknown>, default: null },
     option: { type: null as any as PropType<unknown>, default: null },
     name: { type: String as PropType<string>, default: '' },
-    disabled: { type: Boolean as PropType<boolean>, default: false },
     label: { type: String as PropType<string>, default: '' },
     leftLabel: { type: Boolean as PropType<boolean>, default: false },
     color: { type: String as PropType<string>, default: 'primary' },
     tabindex: { type: Number as PropType<number>, default: 0 },
-    readonly: { type: Boolean, default: false },
   },
   setup (props, { emit }) {
     const { getColor } = useColors()
 
+    const { createComputedClass } = useForm(props)
+    const formComputedClasses = createComputedClass('va-radio')
+
     const isActive = computed(() => props.modelValue === props.option)
 
     const computedClass = computed(() => ({
-      'va-radio--disabled': props.disabled,
       'va-radio--left-label': props.leftLabel,
+      ...formComputedClasses.value,
     }))
 
     const iconBackgroundComputedStyles = computed(() => ({
@@ -128,6 +130,16 @@ export default defineComponent({
 
   &--disabled {
     cursor: var(--va-radio-disabled-cursor);
+  }
+
+  &--readonly {
+    @include va-readonly;
+
+    .va-radio--left-label,
+    .va-radio__text {
+      cursor: initial;
+      pointer-events: auto;
+    }
   }
 
   &--left-label {

--- a/packages/ui/src/components/va-radio/VaRadio.vue
+++ b/packages/ui/src/components/va-radio/VaRadio.vue
@@ -53,6 +53,7 @@ export default defineComponent({
     leftLabel: { type: Boolean as PropType<boolean>, default: false },
     color: { type: String as PropType<string>, default: 'primary' },
     tabindex: { type: Number as PropType<number>, default: 0 },
+    readonly: { type: Boolean, default: false },
   },
   setup (props, { emit }) {
     const { getColor } = useColors()
@@ -85,7 +86,10 @@ export default defineComponent({
 
     const computedLabel = computed(() => props.label || props.option)
 
-    const onClick = (e: Event) => emit('update:modelValue', props.option, e)
+    const onClick = (e: Event) => {
+      if (props.readonly || props.disabled) { return }
+      emit('update:modelValue', props.option, e)
+    }
 
     const onFocus = (e: Event) => emit('focus', e)
 

--- a/packages/ui/src/components/va-switch/VaSwitch.demo.vue
+++ b/packages/ui/src/components/va-switch/VaSwitch.demo.vue
@@ -143,6 +143,12 @@
         disabled
       />
     </VbCard>
+    <VbCard title="Readonly">
+      <va-switch
+        v-model="value"
+        readonly
+      />
+    </VbCard>
     <VbCard title="Loading">
       <va-switch
         v-model="value"

--- a/packages/ui/src/components/va-switch/VaSwitch.vue
+++ b/packages/ui/src/components/va-switch/VaSwitch.vue
@@ -147,6 +147,7 @@ export default defineComponent({
       'va-switch--small': props.size === 'small',
       'va-switch--large': props.size === 'large',
       'va-switch--disabled': props.disabled,
+      'va-switch--readonly': props.readonly,
       'va-switch--left-label': props.leftLabel,
       'va-switch--error': computedError.value,
       'va-switch--on-keyboard-focus': hasKeyboardFocus.value,
@@ -249,6 +250,15 @@ export default defineComponent({
 
   &--disabled {
     @include va-disabled;
+  }
+
+  &--readonly {
+    @include va-readonly;
+
+    .va-switch__label {
+      cursor: initial;
+      pointer-events: auto;
+    }
   }
 
   &--left-label {

--- a/packages/ui/src/styles/resources/_mixins.scss
+++ b/packages/ui/src/styles/resources/_mixins.scss
@@ -33,6 +33,11 @@
   user-select: none;
 }
 
+@mixin va-readonly() {
+  cursor: default;
+  pointer-events: none;
+}
+
 @mixin theme-button-variant($color, $background, $border, $shadow) {
   $hover-bg: lighten($background, 10%);
   $disabled-bg: darken($background, 15%);


### PR DESCRIPTION
close: #1657 

## Description
- `VaSwitch` has readonly state. Example added.
- Added readonly state for `VaRadio` (and example). I'd thought about implementing this via `useSelectable`, but it is not suitable in its current form, and its adaptation looks like an unnecessary complication of the common composable cause of a single case.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
