### PR TITLE
Add tabs to code examples with object format.

### DIFF
--- a/packages/docs/src/components/DocsCode.vue
+++ b/packages/docs/src/components/DocsCode.vue
@@ -31,29 +31,12 @@ export default defineComponent({
   setup (props) {
     const isString = computed(() => typeof props.code === 'string')
 
-    const tabs = computed(() => {
-      const result: string[] = []
-      if (isString.value) {
-        return result
-      } else {
-        for (const key of Object.keys(props.code)) {
-          result.push(key)
-        }
-        return result
-      }
-    })
+    const tabs = computed(() => isString.value ? [] : Object.keys(props.code))
 
-    const contents = computed(() => {
-      const result: string[] = []
-      if (isString.value) {
-        result.push(applyTranslations((props.code as string).replace(/^\n|\n$/g, '')))
-      } else {
-        for (const key of tabs.value) {
-          result.push(applyTranslations((props.code as Record<string, string>)[key].replace(/^\n|\n$/g, '')))
-        }
-      }
-      return result
-    })
+    const contents = computed(() => isString.value
+      ? [applyTranslations((props.code as string).trim())]
+      : tabs.value.map(tab => applyTranslations((props.code as Record<string, string>)[tab].trim()),
+      ))
 
     const index = ref(1)
 

--- a/packages/docs/src/components/DocsCode.vue
+++ b/packages/docs/src/components/DocsCode.vue
@@ -32,7 +32,7 @@ export default defineComponent({
     const isString = computed(() => typeof props.code === 'string')
 
     const tabs = computed(() => {
-      const result: Array<string> = []
+      const result: string[] = []
       if (isString.value) {
         return result
       } else {
@@ -44,12 +44,12 @@ export default defineComponent({
     })
 
     const contents = computed(() => {
-      const result: Array<string> = []
+      const result: string[] = []
       if (isString.value) {
-        result.push(applyTranslations(props.code.replace(/^\n|\n$/g, '')))
+        result.push(applyTranslations((props.code as string).replace(/^\n|\n$/g, '')))
       } else {
         for (const key of tabs.value) {
-          result.push(applyTranslations(props.code[key].replace(/^\n|\n$/g, '')))
+          result.push(applyTranslations((props.code as Record<string, string>)[key].replace(/^\n|\n$/g, '')))
         }
       }
       return result

--- a/packages/docs/src/components/DocsCode.vue
+++ b/packages/docs/src/components/DocsCode.vue
@@ -10,7 +10,7 @@
     </template>
   </va-tabs>
   <prism-wrapper
-    :code="contents[index-1]"
+    :code="contents[index]"
     :lang="$props.language"
     class="DocsCode"
   />
@@ -38,7 +38,7 @@ export default defineComponent({
       : tabs.value.map(tab => applyTranslations((props.code as Record<string, string>)[tab].trim()),
       ))
 
-    const index = ref(1)
+    const index = ref(0)
 
     const doShowCode = ref(true)
 

--- a/packages/docs/src/components/DocsCode.vue
+++ b/packages/docs/src/components/DocsCode.vue
@@ -1,6 +1,16 @@
 <template>
+  <va-tabs v-if="!isString" v-model="index">
+    <template #tabs>
+      <va-tab
+        v-for="tab in tabs"
+        :key="tab"
+      >
+        {{ tab }}
+      </va-tab>
+    </template>
+  </va-tabs>
   <prism-wrapper
-    :code="formattedCode"
+    :code="contents[index-1]"
     :lang="$props.language"
     class="DocsCode"
   />
@@ -16,10 +26,36 @@ export default defineComponent({
   components: { PrismWrapper },
   props: {
     language: { type: String as PropType<string>, default: 'javascript' },
-    code: { type: String as PropType<string>, default: '' },
+    code: { type: [Object, String] as PropType<Record<string, string> | string>, default: '' },
   },
   setup (props) {
-    const formattedCode = computed(() => applyTranslations(props.code.replace(/^\n|\n$/g, '')))
+    const isString = computed(() => typeof props.code === 'string')
+
+    const tabs = computed(() => {
+      const result: Array<string> = []
+      if (isString.value) {
+        return result
+      } else {
+        for (const key of Object.keys(props.code)) {
+          result.push(key)
+        }
+        return result
+      }
+    })
+
+    const contents = computed(() => {
+      const result: Array<string> = []
+      if (isString.value) {
+        result.push(applyTranslations(props.code.replace(/^\n|\n$/g, '')))
+      } else {
+        for (const key of tabs.value) {
+          result.push(applyTranslations(props.code[key].replace(/^\n|\n$/g, '')))
+        }
+      }
+      return result
+    })
+
+    const index = ref(1)
 
     const doShowCode = ref(true)
 
@@ -30,7 +66,7 @@ export default defineComponent({
 
     watch(() => props.code, forceUpdate, { immediate: true })
 
-    return { formattedCode }
+    return { isString, tabs, contents, index }
   },
 })
 </script>

--- a/packages/docs/src/helpers/DocsHelper.ts
+++ b/packages/docs/src/helpers/DocsHelper.ts
@@ -4,7 +4,7 @@ import {
   BlockType,
   ApiDocsBlock,
   TextBlock,
-  CodeString,
+  CodeStringOrObject,
   LinkOptions,
   ExampleOptions, CodeLanguage, ListBlock,
 } from '../types/configTypes'
@@ -86,7 +86,7 @@ export class PageGenerationHelper {
     }
   }
 
-  code (code: CodeString, language: CodeLanguage = 'javascript'): ApiDocsBlock {
+  code (code: CodeStringOrObject, language: CodeLanguage = 'javascript'): ApiDocsBlock {
     return {
       type: BlockType.CODE,
       code,

--- a/packages/docs/src/page-configs/extensions/ag-grid/page-config.ts
+++ b/packages/docs/src/page-configs/extensions/ag-grid/page-config.ts
@@ -1,10 +1,10 @@
 import { ApiDocsBlock, Dependencies } from '@/types/configTypes'
 import { PageGenerationHelper } from '@/helpers/DocsHelper'
 
-const installCommand = `
-npm install @vuestic/ag-grid-theme
-// $t('all.code.or')
-yarn add @vuestic/ag-grid-theme`
+const installCommandObject = {
+  npm: 'npm install @vuestic/ag-grid-theme',
+  yarn: 'yarn add @vuestic/ag-grid-theme',
+}
 
 const setClass = `<template>
   <ag-grid-vue class='ag-theme-vuestic' ... />
@@ -28,7 +28,7 @@ const config: ApiDocsBlock[] = [
   block.link('ag-grid.otherTables.dataTable', '/ui-elements/data-table'),
   block.headline('ag-grid.installation'),
   block.paragraph('ag-grid.dependencies'),
-  block.code(installCommand, 'bash'),
+  block.code(installCommandObject, 'bash'),
   block.paragraph('ag-grid.importStyles'),
   block.code(setClass, 'html'),
   block.code(importStyles, 'scss'),

--- a/packages/docs/src/page-configs/getting-started/configuration-guide/code-examples/icons.ts
+++ b/packages/docs/src/page-configs/getting-started/configuration-guide/code-examples/icons.ts
@@ -1,8 +1,7 @@
-export const iconsInstall = `
-yarn add material-design-icons-iconfont -D
-// {{ $t('all.code.or') }}
-npm install material-design-icons-iconfont -D
-`
+export const iconsInstallObject = {
+  yarn: 'yarn add material-design-icons-iconfont -D',
+  npm: 'npm install material-design-icons-iconfont -D',
+}
 
 export const iconsConfig = `
 // main.js

--- a/packages/docs/src/page-configs/getting-started/configuration-guide/page-config.ts
+++ b/packages/docs/src/page-configs/getting-started/configuration-guide/page-config.ts
@@ -2,7 +2,7 @@ import { ApiDocsBlock } from '@/types/configTypes'
 import { PageGenerationHelper } from '@/helpers/DocsHelper'
 import {
   colorsConfig,
-  iconsInstall,
+  iconsInstallObject,
   iconsConfig,
   componentsConfig,
 } from './code-examples'
@@ -19,7 +19,7 @@ const config: ApiDocsBlock[] = [
 
   block.subtitle('configurationGuide.icons.title'),
   block.paragraph('configurationGuide.icons.description'),
-  block.code(iconsInstall, 'bash'),
+  block.code(iconsInstallObject, 'bash'),
 
   block.headline('configurationGuide.icons.subtitle'),
   block.paragraph('configurationGuide.icons.subDescription'),

--- a/packages/docs/src/page-configs/getting-started/installation/code-examples/installation.ts
+++ b/packages/docs/src/page-configs/getting-started/installation/code-examples/installation.ts
@@ -1,9 +1,3 @@
-export const installation = `
-npm install vuestic-ui
-// {{ $t('all.code.or') }}
-yarn add vuestic-ui
-`
-
 export const installationObject = {
   npm: 'npm install vuestic-ui',
   yarn: 'yarn add vuestic-ui',

--- a/packages/docs/src/page-configs/getting-started/installation/code-examples/installation.ts
+++ b/packages/docs/src/page-configs/getting-started/installation/code-examples/installation.ts
@@ -3,3 +3,8 @@ npm install vuestic-ui
 // {{ $t('all.code.or') }}
 yarn add vuestic-ui
 `
+
+export const installationObject = {
+  npm: 'npm install vuestic-ui',
+  yarn: 'yarn add vuestic-ui',
+}

--- a/packages/docs/src/page-configs/getting-started/installation/page-config.ts
+++ b/packages/docs/src/page-configs/getting-started/installation/page-config.ts
@@ -1,7 +1,7 @@
 import { ApiDocsBlock } from '@/types/configTypes'
 import { PageGenerationHelper } from '@/helpers/DocsHelper'
 import {
-  installation,
+  installationObject,
   quickStart,
   fontInstallationCSS,
   fontInstallationHTML,
@@ -30,7 +30,7 @@ const config: ApiDocsBlock[] = [
   block.paragraph('installation.manual.prerequisites'),
   block.list(['installation.manual.node', 'installation.manual.npm']),
   block.paragraph('installation.manual.afterCheck'),
-  block.code(installation, 'bash'),
+  block.code(installationObject, 'bash'),
 
   block.headline('installation.fonts.title'),
   block.paragraph('installation.fonts.description'),

--- a/packages/docs/src/types/configTypes.ts
+++ b/packages/docs/src/types/configTypes.ts
@@ -8,7 +8,7 @@ import { TableData, TableColumn } from '../components/DocsTable/DocsTableTypes'
 import { DefineComponent } from 'vue'
 import { VueConstructor } from 'vue-class-component'
 
-export type CodeString = string
+export type CodeStringOrObject = string | Record<string, string>
 export type CodeLanguage = 'javascript' | 'scss' | 'bash' | 'html'
 // example: for `/examples/va-affix/Bottom.vue` use `va-affix/Bottom.vue` here.
 
@@ -81,7 +81,7 @@ export type ApiDocsBlock =
   }
   | {
     type: BlockType.CODE,
-    code: CodeString,
+    code: CodeStringOrObject,
     language: CodeLanguage,
   }
   | {


### PR DESCRIPTION
## Description
Add tabs to code examples.
fixes #1674

## Markup:
Pass in code object with keys as tab, values as code content.
<details>
```vue
block.code({
   'npm': 'npm install @vuestic/agGrid-theme',
   'yarn': 'yarn add @vuestic/agGrid-theme'
})
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
