### PR TITLE
[#1701] Fix tab `id` value in the `VaTabs`

### DIFF
--- a/packages/ui/src/components/va-tabs/VaTabs.demo.vue
+++ b/packages/ui/src/components/va-tabs/VaTabs.demo.vue
@@ -55,8 +55,8 @@
     >
       <va-tabs
         v-model="tabValue1"
-        prev-icon="arrow_back_ios"
-        next-icon="arrow_forward_ios"
+        prev-icon="arrow_back"
+        next-icon="arrow_forward"
       >
         <template #tabs>
           <va-tab

--- a/packages/ui/src/components/va-tabs/VaTabs.vue
+++ b/packages/ui/src/components/va-tabs/VaTabs.vue
@@ -224,15 +224,13 @@ export default defineComponent({
       tabsList.value.forEach((tab: TabComponent) => {
         tab.updateSidePositions()
 
-        if (tabSelected.value) {
-          const isTabSelected = (tab.name?.value || tab.id) === tabSelected.value
+        const isTabSelected = (tab.name?.value || tab.id) === tabSelected.value
 
-          tab.isActive = tab.isActiveRouterLink || isTabSelected
+        tab.isActive = tab.isActiveRouterLink || isTabSelected
 
-          if (tab.isActive) {
-            moveToTab(tab)
-            updateSlider(tab)
-          }
+        if (tab.isActive) {
+          moveToTab(tab)
+          updateSlider(tab)
         }
       })
 
@@ -363,7 +361,7 @@ export default defineComponent({
     }
 
     const registerTab = (tab: TabComponent) => {
-      const idx = tabsList.value.push(tab)
+      const idx = tabsList.value.push(tab) - 1
 
       tab.id = tab.name?.value || idx
     }


### PR DESCRIPTION
## Description
close #1701 

changes:
- [x] set the value of the tab (`tabComponent`) `id` to its index in the `tabsList` of the `VaTabs` component

![chrome-capture (1)](https://user-images.githubusercontent.com/55198465/165077426-157ac4ea-83f5-41e9-9bd0-96c7bbb12718.gif)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
