### PR TITLE
Feat/component global types

### DIFF
--- a/packages/docs/src/main.ts
+++ b/packages/docs/src/main.ts
@@ -28,8 +28,3 @@ useGtag(app, router)
 useTranslateIfExists(app)
 
 app.mount('#app')
-
-declare module 'vue' {
-  // eslint-disable-next-line @typescript-eslint/no-empty-interface
-  export interface GlobalComponents extends VuesticComponents {}
-}

--- a/packages/docs/src/main.ts
+++ b/packages/docs/src/main.ts
@@ -5,7 +5,7 @@ import { i18n } from './locales/i18n'
 
 // plugin to change algolia colors according docs theme
 import AlgoliaColorPlugin from './components/sidebar/algolia-search/algolia-color-plugin'
-import { createVuestic } from 'vuestic-ui/src/main'
+import { createVuestic, VuesticComponents } from 'vuestic-ui/src/main'
 import { VuesticConfig } from './config/vuestic-config'
 import { useGtag } from './services/gtag'
 import { useTranslateIfExists } from './locales/translateIfExistsPlugin'
@@ -28,3 +28,8 @@ useGtag(app, router)
 useTranslateIfExists(app)
 
 app.mount('#app')
+
+declare module 'vue' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface GlobalComponents extends VuesticComponents {}
+}

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -3,7 +3,7 @@ import {
   addPluginTemplate,
   addAutoImport
 } from '@nuxt/kit'
-import { GlobalConfig } from 'vuestic-ui'
+import { GlobalConfig, VuesticComponents } from 'vuestic-ui'
 import { resolve } from 'pathe'
 import { NuxtOptions } from '@nuxt/schema'
 import { distDir } from './dirs'
@@ -83,4 +83,8 @@ declare module '@nuxt/schema' {
   interface NuxtConfig {
     vuestic?: VuesticOptions
   }
+}
+
+declare module 'vue' {
+  export interface GlobalComponents extends VuesticComponents {}
 }

--- a/packages/ui/src/vue-book/book-main.ts
+++ b/packages/ui/src/vue-book/book-main.ts
@@ -46,10 +46,4 @@ app.use(createVuesticEssential({
   plugins: { VaToastPlugin, VaDropdownPlugin },
 }))
 
-// We don't register any component globally in vue-book
-declare module 'vue' {
-  // eslint-disable-next-line @typescript-eslint/no-empty-interface
-  export interface GlobalComponents extends VuesticComponents<''> {}
-}
-
 app.mount('#app')

--- a/packages/ui/src/vue-book/book-main.ts
+++ b/packages/ui/src/vue-book/book-main.ts
@@ -8,7 +8,7 @@ import demoIconAliases from './vuestic-config/demo-icon-aliases'
 import demoIconFonts from './vuestic-config/demo-icon-fonts'
 
 import './vue-book-overrides.scss'
-import { createIconsConfig, createVuesticEssential, VaToastPlugin, VaDropdownPlugin } from '../main'
+import { createIconsConfig, createVuesticEssential, VaToastPlugin, VaDropdownPlugin, VuesticComponents } from '../main'
 import { colorsPresets } from '../services/color-config/color-theme-presets'
 
 const app = createApp(App)
@@ -45,5 +45,11 @@ app.use(createVuesticEssential({
   },
   plugins: { VaToastPlugin, VaDropdownPlugin },
 }))
+
+// We don't register any component globally in vue-book
+declare module 'vue' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface GlobalComponents extends VuesticComponents<''> {}
+}
 
 app.mount('#app')

--- a/packages/ui/src/vuestic-plugin/create-vuestic/create-vuestic.ts
+++ b/packages/ui/src/vuestic-plugin/create-vuestic/create-vuestic.ts
@@ -22,12 +22,3 @@ export const createVuestic = defineVuesticPlugin((options: { config?: GlobalConf
     usePlugin(app, VaToastPlugin)
   },
 }))
-
-type VuesticComponents = typeof vuesticComponents
-
-declare module 'vue' {
-  export type GlobalComponents = {
-    // Register all Vuestic components globally
-    [key in keyof VuesticComponents]: VuesticComponents[key]
-  }
-}

--- a/packages/ui/src/vuestic-plugin/create-vuestic/create-vuestic.ts
+++ b/packages/ui/src/vuestic-plugin/create-vuestic/create-vuestic.ts
@@ -2,6 +2,13 @@ import type { GlobalConfig } from '../../services/global-config/global-config'
 import { defineVuesticPlugin, usePlugin } from '../utils'
 import { GlobalConfigPlugin, VaDropdownPlugin, VaToastPlugin, ColorConfigPlugin } from '../vuestic-plugins'
 import * as vuesticComponents from '../vuestic-components'
+import type { VuesticComponents } from '../global-components'
+
+// Declare all components globally
+declare module 'vue' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface GlobalComponents extends VuesticComponents {}
+}
 
 /**
  * Globally register all vuestic components and plugins

--- a/packages/ui/src/vuestic-plugin/global-components.ts
+++ b/packages/ui/src/vuestic-plugin/global-components.ts
@@ -13,13 +13,14 @@ type VuesticComponentNames = keyof VuesticComponentsMap
 /**
  * Names of Vuestic components that must be accessable globally.
  *
- * @exmaple
+ * @example
  * This will register all vuestic components globally:
  * ```
  * declare module 'vue' {
  *   export interface GlobalComponents extends VuesticComponents {}
  * }
  * ```
+ *
  * @example
  * If you using tree-shaking and want to register only specific components:
  * ```

--- a/packages/ui/src/vuestic-plugin/global-components.ts
+++ b/packages/ui/src/vuestic-plugin/global-components.ts
@@ -1,0 +1,39 @@
+import * as vuesticComponents from './vuestic-components'
+
+/** Utility type: Show type instad of import word */
+type Map<O extends Record<any, any>> = { [K in keyof O]: O[K] }
+/** Utility type: Check if key exist in object before access */
+type SafeAccess<O, K> = K extends keyof O ? O[K] : never
+
+/** List of all exported components */
+type VuesticComponentsMap = Map<typeof vuesticComponents>
+/** Component names */
+type VuesticComponentNames = keyof VuesticComponentsMap
+
+/**
+ * Names of Vuestic components that must be accessable globally.
+ *
+ * @exmaple
+ * This will register all vuestic components globally:
+ * ```
+ * declare module 'vue' {
+ *   export interface GlobalComponents extends VuesticComponents {}
+ * }
+ * ```
+ * @example
+ * If you using tree-shaking and want to register only specific components:
+ * ```
+ * declare module 'vue' {
+ *   export interface GlobalComponents extends VuesticComponents<'VaButton' | 'VaInput'> {}
+ * }
+ * ```
+ * Now only `VaButton` and `VaInput` types will be registered globally.
+ *
+ * @notice this will only register types, you need to use createVuesticEssetial to register components.
+ *
+ * @important Prefer interface instead of type, this will break all component types.
+ * @eslint You can safely ignore `@typescript-eslint/no-empty-interface` eslint rule
+ * */
+export type VuesticComponents<NAMES extends string = VuesticComponentNames> = {
+  [name in NAMES]: SafeAccess<VuesticComponentsMap, name>
+}

--- a/packages/ui/src/vuestic-plugin/index.ts
+++ b/packages/ui/src/vuestic-plugin/index.ts
@@ -1,5 +1,6 @@
 export * from './vuestic-plugins'
 export * from './create-vuestic'
+export * from './global-components'
 
 // TODO: Remove deperecated plugins after v1.5.0
 export * from './old/vuestic-plugin'


### PR DESCRIPTION
Closes https://github.com/epicmaxco/vuestic-ui/issues/1763

Made a way to register components, do not register them or register only specific components globally.

Registered them for docs and nuxt module. Vue book uses tree-shaking, so we do not declare global components for vue-book package.