### PR TITLE
[Proposal] defineComposable

### DIFF
--- a/packages/ui/src/composables/useStateful.ts
+++ b/packages/ui/src/composables/useStateful.ts
@@ -1,4 +1,41 @@
 import { ref, computed, PropType, Ref } from 'vue'
+import { defineComposable } from '../types/defineComposable'
+
+// TODO: Remove this example
+const useStaateful2 = defineComposable(
+  ({ props, emit }) => <D>(initialValue: D) => {
+    const valueState = ref(initialValue === undefined ? props.modelValue : initialValue)
+
+    const valueComputed = computed({
+      get () {
+        if (props.stateful) {
+          return valueState.value
+        }
+        return props.modelValue
+      },
+      set (value: D) {
+        if (props.stateful) {
+          valueState.value = value
+        }
+        emit('update:modelValue', value)
+      },
+    })
+
+    return { valueComputed }
+  },
+
+  {
+    props: {
+      stateful: Boolean,
+      modelValue: { type: undefined as any },
+    },
+    emits: ['update:modelValue'],
+  },
+)
+
+const { valueComputed } = useStaateful2('Puk')
+const arr = useStaateful2.$emits
+const p = useStaateful2.$props
 
 export type StatefulProps<T> = {
   stateful: boolean

--- a/packages/ui/src/types/defineComposable/defineComposable.spec.ts
+++ b/packages/ui/src/types/defineComposable/defineComposable.spec.ts
@@ -14,12 +14,9 @@ describe('defineComposable', () => {
         color: String,
       }
 
-      const useColor = defineComposable({
-        composable () {
-          return this.props.color
-        },
-        props,
-      })
+      const useColor = defineComposable(
+        ({ props }) => props.color, { props },
+      )
 
       // Emits shoudn't exist in useColor
       expect(useColor.$props).toEqual(props)
@@ -28,12 +25,9 @@ describe('defineComposable', () => {
   )
   it('emits',
     () => {
-      const useColor = defineComposable({
-        composable () {
-          return this.emit('click')
-        },
-        emits,
-      })
+      const useColor = defineComposable(({ emit }) => {
+        emit('click')
+      }, { emits })
 
       // $props shoudn't exist in useColor
       expect(useColor.$props).toEqual(undefined)

--- a/packages/ui/src/types/defineComposable/defineComposable.spec.ts
+++ b/packages/ui/src/types/defineComposable/defineComposable.spec.ts
@@ -1,0 +1,43 @@
+import { defineComposable } from './defineComposable'
+
+const props = {
+  color: String,
+}
+
+const emits = ['click']
+
+// TODO: Improve tests with component wrapper.
+describe('defineComposable', () => {
+  it('propss',
+    () => {
+      const props = {
+        color: String,
+      }
+
+      const useColor = defineComposable({
+        composable () {
+          return this.props.color
+        },
+        props,
+      })
+
+      // Emits shoudn't exist in useColor
+      expect(useColor.$props).toEqual(props)
+      expect(useColor.$emits).toEqual(undefined)
+    },
+  )
+  it('emits',
+    () => {
+      const useColor = defineComposable({
+        composable () {
+          return this.emit('click')
+        },
+        emits,
+      })
+
+      // $props shoudn't exist in useColor
+      expect(useColor.$props).toEqual(undefined)
+      expect(useColor.$emits).toEqual(emits)
+    },
+  )
+})

--- a/packages/ui/src/types/defineComposable/defineComposable.ts
+++ b/packages/ui/src/types/defineComposable/defineComposable.ts
@@ -1,0 +1,27 @@
+import { getCurrentInstance } from 'vue'
+import { TypedComposable, TypedComposableThis, PropOptions } from './types'
+
+const composableThis: TypedComposableThis<unknown, unknown> = {
+  // Current instance must be available in setup function
+  get props () { return getCurrentInstance()!.props },
+  get emit () { return getCurrentInstance()!.emit },
+}
+
+/** This function allows you to create composable and define it required props and emits */
+export const defineComposable = <
+  ENames extends string,
+  Props extends PropOptions | undefined = undefined,
+  Emits extends ENames[] | undefined = undefined,
+  Composable extends (this: TypedComposableThis<Props, Emits>, ...args: any[]) => any = (this: TypedComposableThis<Props, Emits>, ...args: any[]) => any,
+>(options: {
+    composable: Composable,
+    props?: Props,
+    emits?: Emits,
+}) => {
+  const s = options.composable as any
+
+  s.$props = options?.props
+  s.$emits = options?.emits
+
+  return s.bind(composableThis) as TypedComposable<Composable, Props, Emits>
+}

--- a/packages/ui/src/types/defineComposable/index.ts
+++ b/packages/ui/src/types/defineComposable/index.ts
@@ -1,0 +1,1 @@
+export { defineComposable } from './defineComposable'

--- a/packages/ui/src/types/defineComposable/types.ts
+++ b/packages/ui/src/types/defineComposable/types.ts
@@ -1,4 +1,4 @@
-import type { ExtractPropTypes, Prop } from 'vue'
+import type { ExtractPropTypes, Prop, ComponentInternalInstance } from 'vue'
 
 /** Utility type. Adds key to object if value is not undefined */
 type OptionalObject<Key extends string, Value> = Value extends undefined ? Record<'', never> : Record<Key, Value>
@@ -7,12 +7,12 @@ type OptionalObject<Key extends string, Value> = Value extends undefined ? Recor
 type ExtractKeys<T> = T extends Array<infer V> ? V : never
 
 /** This of composable function */
-export type TypedComposableThis<Props, Emits> = {
+export type TypedComposableContext<Props, Emits> = {
   /** Current instance props */
   readonly props: ExtractPropTypes<Props>,
   /** Current instance emit */
-  readonly emit: (event: ExtractKeys<Emits>, ...args: any[]) => void,
-}
+  readonly emit: (event: Emits, ...args: any[]) => void,
+} & Omit<ComponentInternalInstance, 'props' | 'emit'>
 
 export type TypedComposable<
   C extends (...args: any[]) => any,

--- a/packages/ui/src/types/defineComposable/types.ts
+++ b/packages/ui/src/types/defineComposable/types.ts
@@ -3,9 +3,6 @@ import type { ExtractPropTypes, Prop, ComponentInternalInstance } from 'vue'
 /** Utility type. Adds key to object if value is not undefined */
 type OptionalObject<Key extends string, Value> = Value extends undefined ? Record<'', never> : Record<Key, Value>
 
-/** Utility type. Extracts names from array */
-type ExtractKeys<T> = T extends Array<infer V> ? V : never
-
 /** This of composable function */
 export type TypedComposableContext<Props, Emits> = {
   /** Current instance props */
@@ -15,7 +12,7 @@ export type TypedComposableContext<Props, Emits> = {
 } & Omit<ComponentInternalInstance, 'props' | 'emit'>
 
 export type TypedComposable<
-  C extends (...args: any[]) => any,
+  C,
   Props,
   Emits,
 > = C & OptionalObject<'$props', Props> & OptionalObject<'$emits', Emits>

--- a/packages/ui/src/types/defineComposable/types.ts
+++ b/packages/ui/src/types/defineComposable/types.ts
@@ -1,0 +1,24 @@
+import type { ExtractPropTypes, Prop } from 'vue'
+
+/** Utility type. Adds key to object if value is not undefined */
+type OptionalObject<Key extends string, Value> = Value extends undefined ? Record<'', never> : Record<Key, Value>
+
+/** Utility type. Extracts names from array */
+type ExtractKeys<T> = T extends Array<infer V> ? V : never
+
+/** This of composable function */
+export type TypedComposableThis<Props, Emits> = {
+  /** Current instance props */
+  readonly props: ExtractPropTypes<Props>,
+  /** Current instance emit */
+  readonly emit: (event: ExtractKeys<Emits>, ...args: any[]) => void,
+}
+
+export type TypedComposable<
+  C extends (...args: any[]) => any,
+  Props,
+  Emits,
+> = C & OptionalObject<'$props', Props> & OptionalObject<'$emits', Emits>
+
+/** Vue props options types */
+export type PropOptions<P = Record<any, any>> = { [K in keyof P]: Prop<P[K]> | null; }


### PR DESCRIPTION
This is a type safe solution, allow us and newbie easily read and understand composables.

Example:

```ts
const useTextColor = defineComposable(({ props, emit }) => (background: string) => {
  emit('initBg', background)

  return computed(() => props.textColor ? getColor(props.textColor) : getTextColor(background))
}, { props: { textColor: String }, emits: ['initBg'] })
```

```ts
export default defineComponent({
  props: {
    ...useTextColor.$props,
  },
  emits: [...useTextColor.$emits],

  setup() {
    return {
      ...useTextColor(),
    }
  }
})
```

## Plus
- First of all, this will not break emit or prop type (like useStateful makes):
VaAlert
![image](https://user-images.githubusercontent.com/23530004/168405575-c08f957a-fd96-4631-baf1-92f9091ae584.png)
- It type composable props and emit in composable. By default, getCurrentInstance() returns any...
- It easier to pass emits and props to component from composable from one thing, instead of importing useTextColorProps etc.

## Minus
- Something specific, not documented in vue docs. But, if we have agreement on `useTextColorProps`, let's better have it documented with Typescript. 
- Has additional wrapper (perfomance?), but who cares? getCurrentInstace just access to one stored let.


## Should be composables context free?
Yes.. But we don't want pass props every time to composable. Don't we? For example useTextColor works like a mixin, execpt we pass background color manually. Copying props.textColor every time will make code harder to read and refactor.
