### PR TITLE
Fix #1758: `VaSelect` actions and navigation

### DIFF
--- a/packages/ui/src/components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/va-select/VaSelect.vue
@@ -16,6 +16,7 @@
     @keydown.up.stop.prevent="showDropdown()"
     @keydown.down.stop.prevent="showDropdown()"
     @keydown.space.stop.prevent="showDropdown()"
+    @keydown.enter.stop.prevent="showDropdown()"
     @click.prevent="onSelectClick()"
   >
     <template #anchor>
@@ -515,7 +516,7 @@ export default defineComponent({
 
     const focusOptionList = () => {
       optionList.value?.focus()
-      optionList.value?.hoverFirstOption()
+      !props.modelValue && optionList.value?.hoverFirstOption()
     }
 
     const focusSearchOrOptions = () => nextTick(() => {

--- a/packages/ui/src/components/va-select/VaSelectOptionList/VaSelectOptionList.vue
+++ b/packages/ui/src/components/va-select/VaSelectOptionList/VaSelectOptionList.vue
@@ -221,9 +221,12 @@ export default defineComponent({
       hoverNextOption,
       hoverFirstOption,
       focus,
+      scrollToOption,
     }
 
     return {
+      rootElement,
+
       getColor,
       filteredOptions,
       optionGroups,


### PR DESCRIPTION
## Description
Close #1758
<!-- Describe your changes in detail -->
All `VaSelect` actions and keyboard navigation were completely broken, now it is fixed.

## Details:

- Keyboard navigation works
- UX improved - `VaSelect` will scroll to and focus last selected option
- All `actions` that were using `optionList` functions work now - `hintedSearch` etc.

</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)