### PR TITLE
fix: carrousel demo slots wrong name

### DIFF
--- a/packages/docs/src/page-configs/ui-elements/carousel/examples/Slots.vue
+++ b/packages/docs/src/page-configs/ui-elements/carousel/examples/Slots.vue
@@ -6,7 +6,7 @@
 
     <template #prev-arrow> Go back! </template>
 
-    <template #prev-next> Go forward! </template>
+    <template #next-arrow> Go forward! </template>
 
     <template #indicator="{ index }"> Go to {{ index }} </template>
   </va-carousel>

--- a/packages/ui/src/components/va-carousel/VaCarousel.vue
+++ b/packages/ui/src/components/va-carousel/VaCarousel.vue
@@ -24,7 +24,7 @@
         class="va-carousel__arrow va-carousel__arrow--right"
         @click="next"
       >
-        <slot name="prev-next">
+        <slot name="next-arrow">
           <va-hover #default="{ hover }" stateful>
             <va-button :color="hover ? computedHoverColor : computedColor" :icon="vertical ? 'expand_more' : 'chevron_right'" />
           </va-hover>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail -->
The demo with slots is using wrong slots names.

```diff
- prev-next
+ next-arrow
```


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
