### PR TITLE
Fix#1812/remove confusing config aliases

### DIFF
--- a/packages/docs/src/App.vue
+++ b/packages/docs/src/App.vue
@@ -6,7 +6,7 @@
 <script>
 import { defineComponent } from '@vue/runtime-core'
 import emitter from 'tiny-emitter/instance'
-import { setColors } from '../../ui/src/main'
+import { useColors } from '../../ui/src/main'
 import { COLOR_THEMES, ThemeName } from './config/theme-config'
 
 const eventBus = {
@@ -24,7 +24,7 @@ export default defineComponent({
     }
   },
   setup () {
-    setColors(COLOR_THEMES[ThemeName.DEFAULT])
+    useColors().setColors(COLOR_THEMES[ThemeName.DEFAULT])
   },
 })
 </script>

--- a/packages/docs/src/components/DocsAnchor.vue
+++ b/packages/docs/src/components/DocsAnchor.vue
@@ -9,16 +9,20 @@
 import { defineComponent, PropType, computed } from 'vue'
 import { kebabCase } from 'lodash'
 import { TranslationString } from '../components/DocsApi/ManualApiOptions'
-import { getColors } from '../../../ui/src/main'
+import { useColors } from '../../../ui/src/main'
 
 export default defineComponent({
   name: 'DocsAnchor',
   props: {
     text: { type: String as PropType<TranslationString> },
   },
-  setup: (props) => ({
-    anchor: computed(() => kebabCase(props.text)),
-    colors: computed(() => getColors()),
-  }),
+  setup: (props) => {
+    const { getColors } = useColors()
+
+    return {
+      anchor: computed(() => kebabCase(props.text)),
+      colors: computed(() => getColors()),
+    }
+  },
 })
 </script>

--- a/packages/docs/src/components/DocsAnchor.vue
+++ b/packages/docs/src/components/DocsAnchor.vue
@@ -21,7 +21,7 @@ export default defineComponent({
 
     return {
       anchor: computed(() => kebabCase(props.text)),
-      colors: computed(() => getColors()),
+      colors: computed(getColors),
     }
   },
 })

--- a/packages/docs/src/components/header/components/ColorDropdown.vue
+++ b/packages/docs/src/components/header/components/ColorDropdown.vue
@@ -17,12 +17,13 @@
 </template>
 
 <script lang="ts">
-import { getColors } from 'vuestic-ui/src/main'
+import { useColors } from 'vuestic-ui/src/main'
 import { computed, defineComponent } from 'vue'
 
 export default defineComponent({
   name: 'DocsColorDropdown',
   setup () {
+    const { getColors } = useColors()
     const capitalizeFirstLetter = (text: string) => text.charAt(0).toUpperCase() + text.slice(1)
 
     const colorsArray = computed(() => {

--- a/packages/docs/src/components/header/components/HeaderSelector.vue
+++ b/packages/docs/src/components/header/components/HeaderSelector.vue
@@ -19,7 +19,8 @@
 
 import VaIconMenu from '../../iconset/VaIconMenu.vue'
 import VaIconMenuCollapsed from '../../iconset/VaIconMenuCollapsed.vue'
-import { getColors } from '../../../../../ui/src/main'
+import { useColors } from '../../../../../ui/src/main'
+import { computed } from 'vue'
 
 export default {
   name: 'DocsHeaderSelector',
@@ -34,10 +35,12 @@ export default {
     },
   },
 
-  computed: {
-    colors () {
-      return getColors()
-    },
+  setup () {
+    const { getColors } = useColors()
+
+    return {
+      colors: computed(() => getColors()),
+    }
   },
 }
 </script>

--- a/packages/docs/src/components/header/components/HeaderSelector.vue
+++ b/packages/docs/src/components/header/components/HeaderSelector.vue
@@ -39,7 +39,7 @@ export default {
     const { getColors } = useColors()
 
     return {
-      colors: computed(() => getColors()),
+      colors: computed(getColors),
     }
   },
 }

--- a/packages/docs/src/components/header/components/LanguageDropdown.vue
+++ b/packages/docs/src/components/header/components/LanguageDropdown.vue
@@ -30,7 +30,7 @@
 
 <script lang="ts">
 import { computed, defineComponent } from 'vue'
-import { getColors } from 'vuestic-ui/src/main'
+import { useColors } from 'vuestic-ui/src/main'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { languages } from '../../../locales'
@@ -61,6 +61,7 @@ export default defineComponent({
     }
 
     const options = languages
+    const { getColors } = useColors()
     const colors = computed(getColors)
     const currentLanguageName = computed(() => options.find(({ code }) => code === locale.value)?.name)
 

--- a/packages/docs/src/components/header/components/VuesticDocsLogo.vue
+++ b/packages/docs/src/components/header/components/VuesticDocsLogo.vue
@@ -10,16 +10,10 @@
   </svg>
 </template>
 
-<script>
-import { Options, Vue } from 'vue-class-component'
-import { getColors } from 'vuestic-ui/src/services/color-config/color-config'
+<script setup>
+import { computed } from 'vue'
+import { useColors } from 'vuestic-ui/src/services/color-config/color-config'
 
-@Options({
-  name: 'DocsVuesticLogo',
-})
-export default class VuesticLogo extends Vue {
-  get colors () {
-    return getColors()
-  }
-}
+const { getColors } = useColors()
+const colors = computed(getColors)
 </script>

--- a/packages/docs/src/components/header/components/VuesticLogo.vue
+++ b/packages/docs/src/components/header/components/VuesticLogo.vue
@@ -12,16 +12,10 @@
   </svg>
 </template>
 
-<script>
-import { Options, Vue } from 'vue-class-component'
-import { getColors } from 'vuestic-ui/src/services/color-config/color-config'
+<script setup>
+import { computed } from 'vue'
+import { useColors } from 'vuestic-ui/src/services/color-config/color-config'
 
-@Options({
-  name: 'vuestic-logo',
-})
-export default class VuesticLogo extends Vue {
-  get colors () {
-    return getColors()
-  }
-}
+const { getColors } = useColors()
+const colors = computed(getColors)
 </script>

--- a/packages/docs/src/components/landing/ColorTab.vue
+++ b/packages/docs/src/components/landing/ColorTab.vue
@@ -73,7 +73,7 @@ import { watch } from 'vue'
 import { Options, Vue } from 'vue-class-component'
 import { ThemeName, ThemeNameIterator } from '../../config/theme-config'
 import { capitalize } from 'lodash'
-import { getColors } from 'vuestic-ui/src/services/color-config/color-config'
+import { useColors } from 'vuestic-ui/src/services/color-config/color-config'
 
 @Options({
   name: 'LandingColorTab',
@@ -107,7 +107,7 @@ export default class ColorTab extends Vue {
   }
 
   get themes () {
-    return getColors() || {}
+    return useColors().getColors() || {}
   }
 }
 </script>

--- a/packages/docs/src/components/landing/Customize.vue
+++ b/packages/docs/src/components/landing/Customize.vue
@@ -137,7 +137,7 @@ import dedent from 'dedent'
 // @ts-ignore
 import Prism from '../PrismWrapper'
 import { shiftHSLAColor } from 'vuestic-ui/src/services/color-config/color-functions'
-import { getColors } from 'vuestic-ui/src/services/color-config/color-config'
+import { useColors } from 'vuestic-ui/src/services/color-config/color-config'
 
 @Options({
   name: 'LandingCustomize',
@@ -205,7 +205,7 @@ export default class Customize extends Vue {
   }
 
   get colors () {
-    return getColors()
+    return useColors().getColors()
   }
 
   get themeColor () {

--- a/packages/docs/src/components/landing/Footer.vue
+++ b/packages/docs/src/components/landing/Footer.vue
@@ -91,7 +91,7 @@ import { Options, Vue } from 'vue-class-component'
 import IconEpicmax from './icons/IconEpicmax.vue'
 import IconAdmin from './icons/IconAdmin.vue'
 import IconSpinners from './icons/IconSpinners.vue'
-import { getColor } from 'vuestic-ui/src/main'
+import { useColors } from 'vuestic-ui/src/main'
 import { markRaw } from 'vue'
 
 @Options({
@@ -103,7 +103,8 @@ export default class Footer extends Vue {
   IconSpinners = markRaw(IconSpinners);
 
   get primaryColor () {
-    return getColor('primary')
+    // TODO: Replace with setup FN
+    return useColors().getColor('primary')
   }
 }
 </script>

--- a/packages/docs/src/components/landing/icons/IconAdmin.vue
+++ b/packages/docs/src/components/landing/icons/IconAdmin.vue
@@ -8,15 +8,10 @@
   </svg>
 </template>
 
-<script>
-import { getColors } from '../../../../../ui/src/services/color-config/color-config'
+<script setup>
+import { computed } from 'vue'
+import { useColors } from 'vuestic-ui/src/services/color-config/color-config'
 
-export default {
-  name: 'IconAdmin',
-  computed: {
-    colors () {
-      return getColors()
-    },
-  },
-}
+const { getColors } = useColors()
+const colors = computed(getColors)
 </script>

--- a/packages/docs/src/components/landing/icons/IconEpicmax.vue
+++ b/packages/docs/src/components/landing/icons/IconEpicmax.vue
@@ -7,15 +7,10 @@
   </svg>
 </template>
 
-<script>
-import { getColors } from 'vuestic-ui/src/services/color-config/color-config'
+<script setup>
+import { computed } from 'vue'
+import { useColors } from 'vuestic-ui/src/services/color-config/color-config'
 
-export default {
-  name: 'IconEpicmax',
-  computed: {
-    colors () {
-      return getColors()
-    },
-  },
-}
+const { getColors } = useColors()
+const colors = computed(getColors)
 </script>

--- a/packages/docs/src/components/landing/icons/IconSpinners.vue
+++ b/packages/docs/src/components/landing/icons/IconSpinners.vue
@@ -8,15 +8,10 @@
   </svg>
 </template>
 
-<script>
-import { getColors } from 'vuestic-ui/src/services/color-config/color-config'
+<script setup>
+import { computed } from 'vue'
+import { useColors } from 'vuestic-ui/src/services/color-config/color-config'
 
-export default {
-  name: 'IconSpinners',
-  computed: {
-    colors () {
-      return getColors()
-    },
-  },
-}
+const { getColors } = useColors()
+const colors = computed(getColors)
 </script>

--- a/packages/docs/src/components/sidebar/algolia-search/algolia-color-plugin.ts
+++ b/packages/docs/src/components/sidebar/algolia-search/algolia-color-plugin.ts
@@ -1,7 +1,7 @@
-import { getColors } from '../../../../../ui/src/services/color-config/color-config'
+import { useColors } from '../../../../../ui/src/services/color-config/color-config'
 import { addOrUpdateStyleElement } from '../../../../../ui/src/services/dom-functions'
 import { getHoverColor } from '../../../../../ui/src/services/color-config/color-functions'
-import { App, ref, watch } from 'vue'
+import { App, computed, watch } from 'vue'
 
 const createThemeColorStyles = (themes: Record<string, string>): string => {
   let result = ''
@@ -16,7 +16,8 @@ const AlgoliaColorPlugin = {
   install (app: App) {
     app.mixin({
       setup () {
-        const colors = ref(getColors().colors)
+        const { getColors } = useColors()
+        const colors = computed(() => getColors().colors)
         return { colors }
       },
       created () {

--- a/packages/docs/src/layouts/default.vue
+++ b/packages/docs/src/layouts/default.vue
@@ -44,7 +44,7 @@ import type { RouteLocationNormalized } from 'vue-router'
 import Sidebar from '../components/sidebar/Sidebar.vue'
 import Header from '../components/header/Header.vue'
 import { COLOR_THEMES, ThemeName } from '../config/theme-config'
-import { setColors } from '../../../ui/src/main'
+import { useColors } from '../../../ui/src/main'
 import { navigationRoutes } from '../components/sidebar/navigationRoutes'
 import { debounce } from 'lodash'
 import { getSortedNavigationRoutes } from '../helpers/NavigationRoutesHelper'
@@ -113,7 +113,7 @@ export default class DocsLayout extends Vue {
   }
 
   changeTheme (themeName) {
-    setColors(COLOR_THEMES[themeName] || COLOR_THEMES[ThemeName.DEFAULT])
+    useColors().setColors(COLOR_THEMES[themeName] || COLOR_THEMES[ThemeName.DEFAULT])
   }
 
   // get crumbs () {

--- a/packages/docs/src/page-configs/services/colors-config/code-examples/components-config.ts
+++ b/packages/docs/src/page-configs/services/colors-config/code-examples/components-config.ts
@@ -1,15 +1,17 @@
 export const componentsConfigCode = `
-import { mergeGlobalConfig } from 'vuestic-ui'
+import { createVuestic } from 'vuestic-ui'
 
-mergeGlobalConfig({
-  colors: {
-    primary: '#ff00ff',
-    button: '#000'
-  },
-  components: {
-    VaButton: {
-      color: 'button'
-    }
-  }.
-})
+createApp(App)
+  .use(createVuestic({
+    colors: {
+      primary: '#ff00ff',
+      button: '#000'
+    },
+    components: {
+      VaButton: {
+        color: 'button'
+      }
+    },
+  }))
+  .mount('#app')
 `

--- a/packages/docs/src/page-configs/services/colors-config/code-examples/icons-config.ts
+++ b/packages/docs/src/page-configs/services/colors-config/code-examples/icons-config.ts
@@ -1,36 +1,40 @@
 export const iconsConfigCode = `
-import { createIconsConfig, mergeGlobalConfig } from 'vuestic-ui'
+import { createVuestic, createIconsConfig } from 'vuestic-ui'
 
-mergeGlobalConfig({
-  colors: {
-    primary: '#ff00ff',
-    player-icon: '#aaa',
-    success: '#0fb'
-  },
-  icons: createIconsConfig({ 
-    aliases: [
-      {
-        name: 'prev',
-        to: 'fa4-prev',
-        color: 'player-icon'
+createApp(App)
+  .use(createVuestic({
+    config: {
+      colors: {
+        primary: '#ff00ff',
+        'player-icon': '#aaa',
+        success: '#0fb'
       },
-      {
-        name: 'next',
-        to: 'fa4-next',
-        color: 'player-icon'
-      },
-      {
-        name: 'pause',
-        to: 'fa4-pause',
-        color: 'player-icon'
-      },
-      {
-        name: 'play',
-        to: 'fa4-play'
-        color: 'success'
-      }
-    ],
-    fonts: [...]
-  })
-})
+      icons: createIconsConfig({ 
+        aliases: [
+          {
+            name: 'prev',
+            to: 'fa4-prev',
+            color: 'player-icon'
+          },
+          {
+            name: 'next',
+            to: 'fa4-next',
+            color: 'player-icon'
+          },
+          {
+            name: 'pause',
+            to: 'fa4-pause',
+            color: 'player-icon'
+          },
+          {
+            name: 'play',
+            to: 'fa4-play'
+            color: 'success'
+          }
+        ],
+        fonts: [...]
+      })
+    }
+  }))
+  .mount('#app')
 `

--- a/packages/docs/src/page-configs/services/colors-config/examples/components/colors-editor.vue
+++ b/packages/docs/src/page-configs/services/colors-config/examples/components/colors-editor.vue
@@ -9,8 +9,7 @@
 </template>
 
 <script>
-import { ref, toRefs } from '@vue/reactivity'
-import { computed, watch } from '@vue/runtime-core'
+import { ref, toRefs, watch } from 'vue'
 
 export default {
   emits: ['update:modelValue'],

--- a/packages/docs/src/page-configs/services/icons-config/code-examples/setup-example.ts
+++ b/packages/docs/src/page-configs/services/icons-config/code-examples/setup-example.ts
@@ -1,11 +1,11 @@
 export const setupCodeExample = `
-import { VuesticPlugin, createIconsConfig } from 'vuestic-ui/src/main'
+import { createVuestic, createIconsConfig } from 'vuestic-ui/src/main'
 
 const aliases = [...]
 const fonts = [...]
 
 createApp(App)
-  .use(VuesticPlugin, {
+  .use(createVuestic, {
     icons: createIconsConfig({ aliases, fonts })
   })
   .mount('#app')

--- a/packages/docs/src/page-configs/services/icons-config/examples/font.vue
+++ b/packages/docs/src/page-configs/services/icons-config/examples/font.vue
@@ -1,15 +1,13 @@
 <template>
-  <div>
-    <div class="code">
-      {
-      <p class="tab"> name: <va-input v-model="iconName" />,</p>
-      <p class="tab">
-        resolve:
-        (<span class="params">{ {{ params }} }</span>) => ({ class: <span class="params">`{{ resolved }}`</span> })
-      </p>
-      }
-    </div>
-  </div>
+  <code class="code language-javascript">
+    {
+    <span class="tab"> name: <va-input v-model="iconName" />,</span>
+    <span class="tab">
+      resolve:
+      (<span class="params">{ {{ params }} }</span>) => ({ class: <span class="params">`{{ resolved }}`</span> })
+    </span>
+    }
+  </code>
 </template>
 
 <script>
@@ -55,6 +53,7 @@ export default {
 
   .tab {
     padding-left: 1rem;
+    display: block;
   }
 
   .params {
@@ -65,13 +64,12 @@ export default {
     margin: 0;
   }
 
-  .va-input:deep() {
+  .va-input {
     display: inline-block;
 
-    .va-input__container {
-      background: rgba($color: #000000, $alpha: 0.2) !important;
-      border-radius: 0.5rem !important;
-    }
+    --va-input-color: rgba(0, 0, 0, 0.2);
+
+    border-radius: 0.5rem !important;
   }
 }
 </style>

--- a/packages/docs/src/page-configs/ui-elements/hover/examples/Slot.vue
+++ b/packages/docs/src/page-configs/ui-elements/hover/examples/Slot.vue
@@ -8,14 +8,10 @@
   </va-hover>
 </template>
 
-<script>
-import { getColors } from 'vuestic-ui/src/services/color-config/color-config'
+<script setup>
+import { computed } from 'vue'
+import { useColors } from 'vuestic-ui/src/services/color-config/color-config'
 
-export default {
-  computed: {
-    colors () {
-      return getColors()
-    },
-  },
-}
+const { getColors } = useColors()
+const colors = computed(getColors)
 </script>

--- a/packages/docs/src/page-configs/ui-elements/hover/examples/Slot.vue
+++ b/packages/docs/src/page-configs/ui-elements/hover/examples/Slot.vue
@@ -10,7 +10,7 @@
 
 <script setup>
 import { computed } from 'vue'
-import { useColors } from 'vuestic-ui/src/services/color-config/color-config'
+import { useColors } from 'vuestic-ui/src/main'
 
 const { getColors } = useColors()
 const colors = computed(getColors)

--- a/packages/ui/src/components/va-config/VaConfig.demo.vue
+++ b/packages/ui/src/components/va-config/VaConfig.demo.vue
@@ -72,7 +72,7 @@
 
 <script>
 import { computed } from 'vue'
-import { getGlobalConfig, useGlobalConfig } from '../../services/global-config/global-config'
+import { useGlobalConfig } from '../../services/global-config/global-config'
 import { useColors } from '../../services/color-config/color-config'
 import VaButton from '../va-button'
 import VaRating from '../va-rating/'
@@ -178,7 +178,7 @@ export default {
     },
     setComponentsAllColor () {
       this.setGlobalConfig({
-        ...getGlobalConfig(),
+        ...this.getGlobalConfig(),
         componentsAll: {
           color: '#bd1313',
         },
@@ -186,7 +186,7 @@ export default {
     },
     resetComponentsAllColor () {
       this.setGlobalConfig({
-        ...getGlobalConfig(),
+        ...this.getGlobalConfig(),
         componentsAll: {},
       })
     },

--- a/packages/ui/src/components/va-input/components/VaInputWrapper.vue
+++ b/packages/ui/src/components/va-input/components/VaInputWrapper.vue
@@ -102,7 +102,7 @@ import { computed, defineComponent } from 'vue'
 import { useBem } from '../../../composables/useBem'
 import { useFormProps } from '../../../composables/useForm'
 import { useValidationProps } from '../../../composables/useValidation'
-import { getColor } from '../../../services/color-config/color-config'
+import { useColors } from '../../../services/color-config/color-config'
 import VaMessageList from './VaMessageList'
 
 export default defineComponent({
@@ -134,6 +134,7 @@ export default defineComponent({
   ],
 
   setup (props) {
+    const { getColor } = useColors()
     const { createModifiersClasses } = useBem('va-input')
 
     const colorComputed = computed(() => getColor(props.color))

--- a/packages/ui/src/composables/useColor.ts
+++ b/packages/ui/src/composables/useColor.ts
@@ -1,5 +1,5 @@
 import { PropType, computed, Ref, unref } from 'vue'
-import { getColor } from '../services/color-config/color-config'
+import { useColors } from '../services/color-config/color-config'
 
 /**
  * You could add these props to any component by destructuring them inside props option.
@@ -14,22 +14,23 @@ export const useColorProps = {
   },
 }
 
+/** @deprecated Use useColors instead */
 export function useColor (props: any) {
   const hasColorTheme = true
-  const theme = { getColor }
+  const { getColor } = useColors()
 
   const colorComputed = computed(() => {
-    return theme.getColor(props.color)
+    return getColor(props.color)
   })
 
   /** @deprecated */
   const computeColor = (prop?: string, defaultColor?: string) => {
-    return theme.getColor(prop, defaultColor)
+    return getColor(prop, defaultColor)
   }
 
   return {
     hasColorTheme,
-    theme,
+    theme: { getColor },
     colorComputed,
     computeColor,
   }

--- a/packages/ui/src/composables/useColor.ts
+++ b/packages/ui/src/composables/useColor.ts
@@ -16,7 +16,6 @@ export const useColorProps = {
 
 /** @deprecated Use useColors instead */
 export function useColor (props: any) {
-  const hasColorTheme = true
   const { getColor } = useColors()
 
   const colorComputed = computed(() => {

--- a/packages/ui/src/composables/useColor.ts
+++ b/packages/ui/src/composables/useColor.ts
@@ -28,7 +28,6 @@ export function useColor (props: any) {
   }
 
   return {
-    hasColorTheme,
     theme: { getColor },
     colorComputed,
     computeColor,

--- a/packages/ui/src/composables/useSize.ts
+++ b/packages/ui/src/composables/useSize.ts
@@ -1,5 +1,5 @@
 import { computed, getCurrentInstance, PropType } from 'vue'
-import { getGlobalConfig, SizeConfig } from '../services/global-config/global-config'
+import { useGlobalConfig, SizeConfig } from '../services/global-config/global-config'
 
 export const sizesConfig: SizeConfig = {
   defaultSize: 48,
@@ -59,6 +59,8 @@ export const useSize = (
   props: SizeProps,
   componentName: string | undefined = getCurrentInstance()?.type.name,
 ) => {
+  const { getGlobalConfig } = useGlobalConfig()
+
   const sizesConfigGlobal = computed<SizeConfig>(() => {
     return componentName
       ? getGlobalConfig().components?.[componentName]?.sizesConfig

--- a/packages/ui/src/main.ts
+++ b/packages/ui/src/main.ts
@@ -1,6 +1,6 @@
 export * from './vuestic-plugin'
-export { useColors, getColor, getColors, setColors } from './services/color-config/color-config'
-export { useGlobalConfig, getGlobalConfig, setGlobalConfig, mergeGlobalConfig } from './services/global-config/global-config'
+export { useColors } from './services/color-config/color-config'
+export { useGlobalConfig } from './services/global-config/global-config'
 export {
   useIcons,
   createIconsConfig,

--- a/packages/ui/src/services/color-config/ColorCSSVariablesUpdater.demo.vue
+++ b/packages/ui/src/services/color-config/ColorCSSVariablesUpdater.demo.vue
@@ -21,12 +21,12 @@
 </template>
 
 <script>
-import { setColors } from './color-config'
+import { useColors } from './color-config'
 
 export default {
   methods: {
     change (color) {
-      setColors({ danger: color })
+      useColors().setColors({ danger: color })
     },
   },
 }

--- a/packages/ui/src/services/color-config/color-config.ts
+++ b/packages/ui/src/services/color-config/color-config.ts
@@ -1,4 +1,4 @@
-import { GlobalConfig, useGlobalConfig } from '../global-config/global-config'
+import { GlobalConfig, useGlobalConfigSafe } from '../global-config/global-config'
 import {
   getBoxShadowColor,
   getHoverColor,
@@ -16,7 +16,13 @@ export type ColorConfig = { [colorName: string]: CssColor }
 
 // Here expose methods that user wants to use in vue component
 export const useColors = () => {
-  const { setGlobalConfig, getGlobalConfig } = useGlobalConfig()
+  const globalConfg = useGlobalConfigSafe()
+
+  if (!globalConfg) {
+    throw new Error('useColors must be used in setup function or Vuestic GlobalConfigPluign is not registered')
+  }
+
+  const { setGlobalConfig, getGlobalConfig } = globalConfg
 
   const setColors = (colors: ColorConfig): void => {
     setGlobalConfig((config: GlobalConfig) => ({

--- a/packages/ui/src/services/color-config/color-config.ts
+++ b/packages/ui/src/services/color-config/color-config.ts
@@ -36,17 +36,19 @@ export const useColors = () => {
   }
 
   /**
-   * Most default color - fallback when nothing else is found.
-   */
-  const DEFAULT_COLOR = getColors().primary
-
-  /**
    * Returns color from config by name or return prop if color is a valid hex, hsl, hsla, rgb or rgba color.
    * @param prop - should be color name or color in hex, hsl, hsla, rgb or rgba format.
    * @param preferVariables - function should return (if possible) CSS variable instead of hex (hex is needed to set opacity).
    * @param defaultColor - this color will be used if prop is invalid.
    */
-  const getColor = (prop?: string, defaultColor: string = DEFAULT_COLOR, preferVariables?: boolean): CssColor => {
+  const getColor = (prop?: string, defaultColor?: string, preferVariables?: boolean): CssColor => {
+    if (!defaultColor) {
+      /**
+       * Most default color - fallback when nothing else is found.
+       */
+      defaultColor = getColors().primary
+    }
+
     const colors = getColors()
 
     if (!prop) {
@@ -78,7 +80,7 @@ export const useColors = () => {
       .keys(colors)
       .filter((key) => colors[key] !== undefined)
       .reduce((acc: Record<string, any>, colorName: string) => {
-        acc[`--${prefix}-${colorName}`] = getColor(colors[colorName], DEFAULT_COLOR, true)
+        acc[`--${prefix}-${colorName}`] = getColor(colors[colorName], undefined, true)
         return acc
       }, {})
   }

--- a/packages/ui/src/services/color-config/color-config.ts
+++ b/packages/ui/src/services/color-config/color-config.ts
@@ -91,25 +91,3 @@ export const useColors = () => {
     colorsToCSSVariable,
   }
 }
-
-export const setColors = (colors: ColorConfig): void => {
-  useColors().setColors(colors)
-}
-
-export const getColors = (): ColorConfig => {
-  return useColors().getColors()
-}
-
-/**
- * Returns color from config by name or return prop if color is a valid hex, hsl, hsla, rgb or rgba color.
- * @param prop - should be color name or color in hex, hsl, hsla, rgb or rgba format.
- * @param preferVariables - function should return (if possible) CSS variable instead of hex (hex is needed to set opacity).
- * @param defaultColor - this color will be used if prop is invalid.
- */
-export const getColor = (prop?: string, defaultColor?: string, preferVariables?: boolean): CssColor => {
-  return useColors().getColor(prop, defaultColor, preferVariables)
-}
-
-export const colorsToCSSVariable = (colors: { [colorName: string]: string | undefined }, prefix = 'va') => {
-  return useColors().colorsToCSSVariable(colors, prefix)
-}

--- a/packages/ui/src/services/global-config/global-config.ts
+++ b/packages/ui/src/services/global-config/global-config.ts
@@ -1,6 +1,6 @@
 import merge from 'lodash/merge.js'
 import cloneDeep from 'lodash/cloneDeep.js'
-import { ref, inject, getCurrentInstance, Ref } from 'vue'
+import { ref, inject, Ref } from 'vue'
 import { GlobalConfig, GlobalConfigUpdater } from './types'
 import { getComponentsAllDefaultConfig, getComponentsDefaultConfig } from './config-default'
 import { createIconsConfig } from '../icon-config/icon-config-helpers'
@@ -9,6 +9,10 @@ import { colorsPresets } from '../color-config/color-theme-presets'
 export type ProvidedGlobalConfig = {
   globalConfig: Ref<GlobalConfig>,
   getGlobalConfig: () => GlobalConfig,
+  /**
+   * Set new global config
+   * @see mergeGlobalConfig if you want to update existing config
+   */
   setGlobalConfig: (updater: GlobalConfig | GlobalConfigUpdater) => void,
   mergeGlobalConfig: (updater: GlobalConfig | GlobalConfigUpdater) => void
 }
@@ -48,13 +52,13 @@ export function useGlobalConfigSafe () {
 }
 
 export function useGlobalConfig () {
-  const globalConfig = inject<ProvidedGlobalConfig>(GLOBAL_CONFIG)
+  const injected = inject<ProvidedGlobalConfig>(GLOBAL_CONFIG)
 
-  if (!globalConfig) {
+  if (!injected) {
     throw new Error('useGlobalConfig must be used in setup function or Vuestic GlobalConfigPluign is not registered')
   }
 
-  return globalConfig
+  return injected
 }
 
 export * from './types'

--- a/packages/ui/src/services/global-config/global-config.ts
+++ b/packages/ui/src/services/global-config/global-config.ts
@@ -55,17 +55,4 @@ export function useGlobalConfig () {
   return globalConfig
 }
 
-export function setGlobalConfig (updater: GlobalConfig | GlobalConfigUpdater) {
-  useGlobalConfig().setGlobalConfig(updater)
-}
-
-/** Merge current config with new value */
-export function mergeGlobalConfig (updater: GlobalConfig | GlobalConfigUpdater) {
-  useGlobalConfig().mergeGlobalConfig(updater)
-}
-
-export function getGlobalConfig (): GlobalConfig {
-  return useGlobalConfig().getGlobalConfig()
-}
-
 export * from './types'

--- a/packages/ui/src/services/global-config/global-config.ts
+++ b/packages/ui/src/services/global-config/global-config.ts
@@ -42,14 +42,16 @@ export const createGlobalConfig = () => {
   }
 }
 
+/** Use this function if you don't want to throw error if hook used ouside setup function by useGlobalConfig */
+export function useGlobalConfigSafe () {
+  return inject<ProvidedGlobalConfig>(GLOBAL_CONFIG)
+}
+
 export function useGlobalConfig () {
-  const globalConfig = inject<ProvidedGlobalConfig>(
-    GLOBAL_CONFIG,
-    getCurrentInstance()?.appContext.config.globalProperties.$vaConfig,
-  )
+  const globalConfig = inject<ProvidedGlobalConfig>(GLOBAL_CONFIG)
 
   if (!globalConfig) {
-    throw new Error('Global config plugin is not registered')
+    throw new Error('useGlobalConfig must be used in setup function or Vuestic GlobalConfigPluign is not registered')
   }
 
   return globalConfig

--- a/packages/ui/src/services/icon-config/icon-config-hooks.ts
+++ b/packages/ui/src/services/icon-config/icon-config-hooks.ts
@@ -1,8 +1,15 @@
 import { getIconConfiguration } from './icon-helpers'
+import { IconConfig, useGlobalConfig } from '../global-config/global-config'
 
 export const useIcons = (props: any) => {
+  const { getGlobalConfig } = useGlobalConfig()
+
+  const getIconConfig = (): IconConfig => {
+    return getGlobalConfig().icons || []
+  }
+
   return {
     // TODO: export here function that can dynamically change icons config
-    getIcon: (name: string) => getIconConfiguration(name),
+    getIcon: (name: string) => getIconConfiguration(name, getIconConfig()),
   }
 }

--- a/packages/ui/src/services/icon-config/icon-helpers.ts
+++ b/packages/ui/src/services/icon-config/icon-helpers.ts
@@ -1,5 +1,4 @@
 import merge from 'lodash/merge.js'
-import { getGlobalConfig } from '../global-config/global-config'
 import { isMatchDynamicSegments, dynamicSegments } from './utils/dynamic-segment'
 import { isMatchRegex, regexGroupsValues } from './utils/regex'
 import {
@@ -11,10 +10,6 @@ import {
   isIconConfigurationRegex,
   IconProps,
 } from './types'
-
-const getIconConfig = (): IconConfig => {
-  return getGlobalConfig().icons || []
-}
 
 const isMatchConfiguration = (iconName: string, iconConfiguration: IconConfiguration) => {
   if (isIconConfigurationString(iconConfiguration)) {
@@ -86,7 +81,7 @@ const iconPropsFromIconConfiguration = (iconConfiguration: IconConfiguration): I
   return configuration
 }
 
-export const getIconConfiguration = (name: string, iconConfig: IconConfig = getIconConfig()): IconProps => {
+export const getIconConfiguration = (name: string, iconConfig: IconConfig): IconProps => {
   const configuration = findIconConfiguration(name, iconConfig)
 
   if (configuration === undefined) { return {} }


### PR DESCRIPTION
closes [#1816](https://github.com/epicmaxco/vuestic-ui/issues/1812)
closes https://github.com/epicmaxco/vuestic-ui/issues/1809
close #1573

According to Composition API and [Multi Application Instances](https://vuejs.org/guide/essentials/application.html#multiple-application-instances) features we can not store globally ref with global config. For that, we use provide/inject. So, getGlobalConfig can not be used outside setup context anymore. I propose to remove this confusing functions and allow user to use the same methods from composables. 


LMK, if you think that we need to deprecate this hooks, instead of removing them. 


This PR also fixes some bugs in demo, for example.