### PR TITLE
Fix show code button focus state in docs.

### DIFF
--- a/packages/docs/src/components/DocsExample.vue
+++ b/packages/docs/src/components/DocsExample.vue
@@ -5,11 +5,9 @@
       <va-button
         v-if="!exampleOptions.forceShowCode"
         class="mt-2 d-block docs-example__show-code-button"
-        style="background: transparent !important; box-shadow: none !important;"
         flat
         size="small"
         color="primary"
-        :rounded="false"
         @click="showCode = !showCode"
       >
         {{ showCode ? $t('docsExample.hideCode') : $t('docsExample.showCode') }}
@@ -119,11 +117,9 @@ export default {
 <style lang="scss">
 .docs-example {
   &__show-code-button {
-    .va-button {
-      &__content {
-        padding: 0 !important;
-      }
-    }
+    --va-button-sm-content-px: 6px;
+
+    transform: translateX(calc(var(--va-button-sm-content-px) * -1));
   }
 }
 </style>


### PR DESCRIPTION
closes https://github.com/epicmaxco/vuestic-ui/issues/1118

I just made padding smaller.
![image](https://user-images.githubusercontent.com/23530004/169620538-637aa26e-2dc1-423f-8f59-8b4f1ae0db39.png)
