### PR TITLE
Prevent pagination numeric buttons changin its width if content is long.

### DIFF
--- a/packages/ui/src/components/va-button-group/VaButtonGroup.vue
+++ b/packages/ui/src/components/va-button-group/VaButtonGroup.vue
@@ -88,19 +88,19 @@ export default defineComponent({
 
   .va-button {
     margin: var(--va-button-group-button-margin);
-    box-shadow: none !important;
+    box-shadow: none;
   }
 
   & > .va-button:last-child {
     width: auto;
-    padding-right: 1rem !important;
+    padding-right: 1rem;
 
     &.va-button--small {
-      padding-right: 0.75rem !important;
+      padding-right: 0.75rem;
     }
 
     &.va-button--large {
-      padding-right: 1.5rem !important;
+      padding-right: 1.5rem;
     }
   }
 
@@ -120,7 +120,7 @@ export default defineComponent({
   & > .va-button:not(:last-child) {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
-    padding-right: 0.5rem;
+    padding-right: var(--va-button-group-gap);
     border-right: 0;
 
     .va-button__content {
@@ -136,7 +136,7 @@ export default defineComponent({
   & > .va-button + .va-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
-    padding-left: 0.5rem;
+    padding-left: var(--va-button-group-gap);
     border-left: 0;
 
     .va-button__content {

--- a/packages/ui/src/components/va-button-group/_variables.scss
+++ b/packages/ui/src/components/va-button-group/_variables.scss
@@ -2,6 +2,7 @@
   --va-button-group-display: flex;
   --va-button-group-justify-content: stretch;
   --va-button-group-border-radius: 1.5rem;
+  --va-button-group-gap: 0.5rem;
 
   /* Button */
   --va-button-group-button-margin: 0;

--- a/packages/ui/src/components/va-pagination/VaPagination.vue
+++ b/packages/ui/src/components/va-pagination/VaPagination.vue
@@ -23,12 +23,13 @@
     <slot v-if="!$props.input">
       <va-button
         v-for="(n, i) in paginationRange"
+        outline
+        class="va-pagination__numeric-button"
         :key="i"
         :style="activeButtonStyle(n)"
         :disabled="$props.disabled || n === '...'"
         :class="{ 'va-button--ellipsis': n === '...'}"
         @click="onUserInput(n)"
-        outline
       >
         {{ n }}
       </va-button>
@@ -242,6 +243,35 @@ export default defineComponent({
 
     &--flat {
       border-top-width: var(--va-pagination-input-flat-border-top-width);
+    }
+  }
+
+  &__numeric-button {
+    &.va-button {
+      .va-button__content {
+        // Remove paddings from button content
+        padding: 0;
+        justify-content: center;
+      }
+
+      // Add paddings to button content in min-width
+      &--normal {
+        .va-button__content {
+          min-width: calc(var(--va-button-content-px) * 2 + var(--va-pagination-button-content-width));
+        }
+      }
+
+      &--small {
+        .va-button__content {
+          min-width: calc(var(--va-button-sm-content-px) * 2 + var(--va-pagination-button-content-width));
+        }
+      }
+
+      &--large {
+        .va-button__content {
+          min-width: calc(var(--va-button-lg-content-px) * 2 + var(--va-pagination-button-content-width));
+        }
+      }
     }
   }
 

--- a/packages/ui/src/components/va-pagination/_variables.scss
+++ b/packages/ui/src/components/va-pagination/_variables.scss
@@ -4,4 +4,5 @@
   --va-pagination-input-text-align: center;
   --va-pagination-input-font-size: 1rem;
   --va-pagination-input-flat-border-top-width: 0;
+  --va-pagination-button-content-width: 8px;
 }


### PR DESCRIPTION
closes https://github.com/epicmaxco/vuestic-ui/issues/1275

![firefox_cBAzqD40GP](https://user-images.githubusercontent.com/23530004/169624291-750ffb6e-61a1-49b8-894e-9fc620923a31.gif)
