### PR TITLE
Fix#1773/file upload single model value

### DIFF
--- a/packages/docs/src/locales/en/en.json
+++ b/packages/docs/src/locales/en/en.json
@@ -395,6 +395,7 @@
         "type": "Specify the format of component. Supported types are `single`, `list` and `gallery`",
         "fileTypes": "Specify supported file formats",
         "dropzone": "Enables Drag&Drop",
+        "hideFileList": "Hide file list if you want to show files somewhere else.",
         "value": "The array with uploaded files",
         "dropZoneText": "Custom drop zone label text",
         "uploadButtonText": "Custom upload button text"

--- a/packages/ui/src/components/va-file-upload/VaFileUpload.vue
+++ b/packages/ui/src/components/va-file-upload/VaFileUpload.vue
@@ -86,9 +86,8 @@ export default defineComponent({
     uploadButtonText: { type: String as PropType<string>, default: 'Upload file' },
 
     modelValue: {
-      type: Array as PropType<VaFile[]>,
+      type: [Object, Array] as PropType<VaFile | VaFile[]>,
       default: () => [],
-      validator: (value: VaFile[]) => Array.isArray(value),
     },
     type: {
       type: String as PropType<'list' | 'gallery' | 'single'>,
@@ -119,8 +118,14 @@ export default defineComponent({
     })
 
     const files = computed<VaFile[]>({
-      get () { return props.modelValue },
-      set (files) { emit('update:modelValue', files) },
+      get () { return Array.isArray(props.modelValue) ? props.modelValue : [props.modelValue] },
+      set (files) {
+        if (props.type === 'single') {
+          emit('update:modelValue', files[0])
+        } else {
+          emit('update:modelValue', files)
+        }
+      },
     })
 
     const validateFiles = (files: VaFile[]) => files.filter((file) => {

--- a/packages/ui/src/components/va-file-upload/VaFileUpload.vue
+++ b/packages/ui/src/components/va-file-upload/VaFileUpload.vue
@@ -38,7 +38,7 @@
       tabindex="-1"
     >
     <va-file-upload-list
-      v-if="files.length"
+      v-if="files.length && !$props.hideFileList"
       :type="type"
       :files="files"
       :color="colorComputed"
@@ -78,6 +78,7 @@ export default defineComponent({
   props: {
     fileTypes: { type: String as PropType<string>, default: '' },
     dropzone: { type: Boolean as PropType<boolean>, default: false },
+    hideFileList: { type: Boolean as PropType<boolean>, default: false },
     color: { type: String as PropType<string>, default: 'primary' },
     disabled: { type: Boolean as PropType<boolean>, default: false },
     undo: { type: Boolean as PropType<boolean>, default: false },

--- a/packages/ui/src/components/va-file-upload/VaFileUpload.vue
+++ b/packages/ui/src/components/va-file-upload/VaFileUpload.vue
@@ -156,11 +156,8 @@ export default defineComponent({
       if (!f) { return }
 
       const validatedFiles = props.fileTypes ? validateFiles(Array.from(f)) : f
-      if (props.type === 'single') {
-        files.value = [...validatedFiles]
-      } else {
-        files.value = [...files.value, ...validatedFiles]
-      }
+
+      files.value = props.type === 'single' ? (validatedFiles as VaFile[]) : [...files.value, ...validatedFiles]
 
       emit('file-added', validatedFiles)
     }

--- a/packages/ui/src/components/va-file-upload/VaFileUpload.vue
+++ b/packages/ui/src/components/va-file-upload/VaFileUpload.vue
@@ -150,7 +150,12 @@ export default defineComponent({
       if (!f) { return }
 
       const validatedFiles = props.fileTypes ? validateFiles(Array.from(f)) : f
-      files.value = [...files.value, ...validatedFiles]
+      if (props.type === 'single') {
+        files.value = [...validatedFiles]
+      } else {
+        files.value = [...files.value, ...validatedFiles]
+      }
+
       emit('file-added', validatedFiles)
     }
 


### PR DESCRIPTION
closes #1773

- [x] Now model value is single file in type === single
![image](https://user-images.githubusercontent.com/23530004/169626457-3d5418d5-6bb7-479f-a7de-54cbc1fbb16d.png)
- [x] Added `hideFileList` prop. I didn't need to show file to user in some list in my project.