### PR TITLE
[#1838] va-radio tab selection fix, accessibility updates

### DIFF
--- a/packages/ui/src/components/va-radio/VaRadio.vue
+++ b/packages/ui/src/components/va-radio/VaRadio.vue
@@ -8,15 +8,17 @@
       type="radio"
       :checked="isActive"
       :disabled="disabled"
-      :name="name"
+      :name="getName"
+      :value="computedLabel"
       @change="onClick"
       @focus="onFocus"
-      :tabindex="tabindex"
+      :tabindex="getTabIndex"
     >
 
     <span
       class="va-radio__icon"
       :style="iconComputedStyles"
+      aria-hidden="true"
     >
       <span
         class="va-radio__icon__background"
@@ -40,6 +42,7 @@
 import { defineComponent, PropType, computed } from 'vue'
 import { useColors } from '../../composables/useColor'
 import { useFormProps, useForm } from '../../composables/useForm'
+import { generateUniqueId } from '../../services/utils'
 
 export default defineComponent({
   name: 'VaRadio',
@@ -104,6 +107,8 @@ export default defineComponent({
       computedLabel,
       onClick,
       onFocus,
+      getName: computed(() => props.name || generateUniqueId()),
+      getTabIndex: computed(() => props.readonly || props.disabled ? -1 : props.tabindex),
     }
   },
 })

--- a/packages/ui/src/components/va-radio/VaRadio.vue
+++ b/packages/ui/src/components/va-radio/VaRadio.vue
@@ -2,15 +2,16 @@
   <label
     class="va-radio"
     :class="computedClass"
-    role="button"
   >
     <input
       class="va-radio__input"
       type="radio"
       :checked="isActive"
       :disabled="disabled"
+      :readonly="readonly"
       :name="computedName"
       :value="computedLabel"
+      :aria-checked="isActive"
       @change="onClick"
       @focus="onFocus"
       :tabindex="computedTabIndex"

--- a/packages/ui/src/components/va-radio/VaRadio.vue
+++ b/packages/ui/src/components/va-radio/VaRadio.vue
@@ -2,17 +2,18 @@
   <label
     class="va-radio"
     :class="computedClass"
+    role="button"
   >
     <input
       class="va-radio__input"
       type="radio"
       :checked="isActive"
       :disabled="disabled"
-      :name="getName"
+      :name="computedName"
       :value="computedLabel"
       @change="onClick"
       @focus="onFocus"
-      :tabindex="getTabIndex"
+      :tabindex="computedTabIndex"
     >
 
     <span
@@ -107,8 +108,8 @@ export default defineComponent({
       computedLabel,
       onClick,
       onFocus,
-      getName: computed(() => props.name || generateUniqueId()),
-      getTabIndex: computed(() => props.readonly || props.disabled ? -1 : props.tabindex),
+      computedName: computed(() => props.name || generateUniqueId()),
+      computedTabIndex: computed(() => props.readonly || props.disabled ? -1 : props.tabindex),
     }
   },
 })
@@ -157,13 +158,7 @@ export default defineComponent({
   }
 
   &__input {
-    width: 0;
-    height: 0;
-    position: absolute;
-    top: 0;
-    left: 0;
-    opacity: 0;
-    z-index: -1;
+    @include visually-hidden;
   }
 
   &__icon {

--- a/packages/ui/src/components/va-radio/VaRadio.vue
+++ b/packages/ui/src/components/va-radio/VaRadio.vue
@@ -12,15 +12,15 @@
       :name="computedName"
       :value="computedLabel"
       :aria-checked="isActive"
+      :tabindex="computedTabIndex"
       @change="onClick"
       @focus="onFocus"
-      :tabindex="computedTabIndex"
     >
 
     <span
+      aria-hidden="true"
       class="va-radio__icon"
       :style="iconComputedStyles"
-      aria-hidden="true"
     >
       <span
         class="va-radio__icon__background"

--- a/packages/ui/src/styles/global/_utility-global.scss
+++ b/packages/ui/src/styles/global/_utility-global.scss
@@ -21,5 +21,5 @@
 }
 
 .visually-hidden {
- @include visually-hidden;
+  @include visually-hidden;
 }

--- a/packages/ui/src/styles/global/_utility-global.scss
+++ b/packages/ui/src/styles/global/_utility-global.scss
@@ -21,14 +21,5 @@
 }
 
 .visually-hidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  border: 0;
-  padding: 0;
-  white-space: nowrap;
-  clip-path: inset(100%);
-  clip: rect(0 0 0 0);
-  overflow: hidden;
+ @include visually-hidden;
 }

--- a/packages/ui/src/styles/resources/_mixins.scss
+++ b/packages/ui/src/styles/resources/_mixins.scss
@@ -184,3 +184,16 @@
     opacity: $opacity;
   }
 }
+
+@mixin visually-hidden() {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  border: 0;
+  padding: 0;
+  white-space: nowrap;
+  clip-path: inset(100%);
+  clip: rect(0 0 0 0);
+  overflow: hidden;
+}


### PR DESCRIPTION
close: #1838 

## Description
`VaRadio` `Tab` navigation was broken - now it's fixed. Few minor related accessibility updates. 

P.S. Safari tab navigation - `Opt` + `Tab` (https://stackoverflow.com/questions/1848390/safari-ignoring-tabindex). Can think about global service to replace this behaviour (not sure if we need to).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)