### PR TITLE
Fix redeclaration of @vue/runtime-core.

### DIFF
--- a/packages/ui/src/components/va-dropdown/plugin/index.ts
+++ b/packages/ui/src/components/va-dropdown/plugin/index.ts
@@ -21,7 +21,7 @@ export const VaDropdownPlugin = defineVuesticPlugin(() => ({
   },
 }))
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     $vaDropdown: typeof vaDropdownPlugin
 

--- a/packages/ui/src/components/va-modal/plugin/index.ts
+++ b/packages/ui/src/components/va-modal/plugin/index.ts
@@ -15,7 +15,7 @@ export const VaModalPlugin = defineVuesticPlugin(() => ({
   },
 }))
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     $vaModal: ReturnType<typeof createVaModalPlugin>
   }

--- a/packages/ui/src/components/va-toast/plugin/index.ts
+++ b/packages/ui/src/components/va-toast/plugin/index.ts
@@ -1,10 +1,11 @@
-import { App } from 'vue'
+import { App, ref } from 'vue'
 import { defineVuesticPlugin, defineGlobalProperty } from '../../../vuestic-plugin/utils'
 import { createToastInstance, closeById, closeAllNotifications, NotificationOptions } from '../toast'
 
 const createVaToastPlugin = (app: App) => ({
   /** Returns toast instance id */
   init (options: string | NotificationOptions) {
+    console.log(ref)
     return createToastInstance(options, app?._context)
   },
 
@@ -19,11 +20,11 @@ const createVaToastPlugin = (app: App) => ({
 
 export const VaToastPlugin = defineVuesticPlugin(() => ({
   install (app) {
-    defineGlobalProperty(app, '$vaToast', createVaToastPlugin(app))
+    defineGlobalProperty(app, '$vaToast' as any, createVaToastPlugin(app))
   },
 }))
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     $vaToast: ReturnType<typeof createVaToastPlugin>
   }

--- a/packages/ui/src/components/va-toast/plugin/index.ts
+++ b/packages/ui/src/components/va-toast/plugin/index.ts
@@ -5,7 +5,6 @@ import { createToastInstance, closeById, closeAllNotifications, NotificationOpti
 const createVaToastPlugin = (app: App) => ({
   /** Returns toast instance id */
   init (options: string | NotificationOptions) {
-    console.log(ref)
     return createToastInstance(options, app?._context)
   },
 
@@ -20,7 +19,7 @@ const createVaToastPlugin = (app: App) => ({
 
 export const VaToastPlugin = defineVuesticPlugin(() => ({
   install (app) {
-    defineGlobalProperty(app, '$vaToast' as any, createVaToastPlugin(app))
+    defineGlobalProperty(app, '$vaToast', createVaToastPlugin(app))
   },
 }))
 

--- a/packages/ui/src/services/color-config/plugin/index.ts
+++ b/packages/ui/src/services/color-config/plugin/index.ts
@@ -9,7 +9,7 @@ export const ColorConfigPlugin = defineVuesticPlugin(() => ({
   },
 }))
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     $vaColorConfig: ReturnType<typeof createColorConfigPlugin>
   }

--- a/packages/ui/src/services/global-config/plugin/index.ts
+++ b/packages/ui/src/services/global-config/plugin/index.ts
@@ -16,7 +16,7 @@ export const GlobalConfigPlugin = defineVuesticPlugin((config: GlobalConfig | un
   },
 }))
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     $vaConfig: ReturnType<typeof createGlobalConfig>
   }

--- a/packages/ui/src/vuestic-plugin/utils/global-properties.ts
+++ b/packages/ui/src/vuestic-plugin/utils/global-properties.ts
@@ -7,7 +7,7 @@ export const extractGlobalProperties = (app: App) => app.config.globalProperties
  * Type safe set vue global property
  * Declare type before use this method.
  * ```
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     $vaThing: ThingType
   }


### PR DESCRIPTION
closes https://github.com/epicmaxco/vuestic-ui/issues/1879

For some reason, we need to declare 'vue' instead of '@vue/runtime-dom' if we want to add global properties.

# Before
![image](https://user-images.githubusercontent.com/23530004/171067010-73551c98-b1df-4a5a-a0f0-63b6f3682e6f.png)

Result (read before in issue)
# After
![image](https://user-images.githubusercontent.com/23530004/171067044-d774f44c-8cb5-44e0-8ce3-f14d740c3595.png)
![image](https://user-images.githubusercontent.com/23530004/171066959-fbc584af-0a40-4dc7-b52d-292b5518a6e4.png)
