### PR TITLE
[#1781] Fix: docs sidebar active route determination

### DIFF
--- a/packages/docs/src/components/sidebar/Sidebar.vue
+++ b/packages/docs/src/components/sidebar/Sidebar.vue
@@ -106,9 +106,8 @@ export default defineComponent({
       return path === route.path
     }
 
-    const routeHasActiveChild = (section: NavigationRoute) => {
-      return section.children?.some(({ name }) => route.path.endsWith(`/${name}`))
-    }
+    const routeHasActiveChild = (section: NavigationRoute) =>
+      section.children?.some(({ name }) => route.path.endsWith(`/${name}`))
 
     const setActiveExpand = () => {
       value.value = props.navigationRoutes.map((route, i) => {

--- a/packages/docs/src/components/sidebar/Sidebar.vue
+++ b/packages/docs/src/components/sidebar/Sidebar.vue
@@ -107,7 +107,7 @@ export default defineComponent({
     }
 
     const routeHasActiveChild = (section: NavigationRoute) => {
-      return section.children?.some(({ name }) => route.path.endsWith(name))
+      return section.children?.some(({ name }) => route.path.endsWith(`/${name}`))
     }
 
     const setActiveExpand = () => {


### PR DESCRIPTION
closes #1781 

## Description
Strict check that current path ends with a route name.

### Changes
- [x] condition for sidebar route to be active

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
