### PR TITLE
[#1876] `VaDataTable` remove extra `click` emit

### DIFF
--- a/packages/ui/src/components/va-data-table/VaDataTable.demo.vue
+++ b/packages/ui/src/components/va-data-table/VaDataTable.demo.vue
@@ -73,7 +73,9 @@
       <input type="checkbox" v-model="isStriped">
       <label>Striped style</label><br>
       <label>No data (due to filtering) message</label>
-      <input type="text" v-model="noDataFilteredHtml">
+      <input type="text" v-model="noDataFilteredHtml"><br />
+      <input type="checkbox" v-model="clickable" />
+      <label>Clickable rows</label>
 
       <va-data-table
         :columns="evenColumnsSortable2"
@@ -94,6 +96,7 @@
         :allow-footer-sorting="allowFooterSorting"
         :no-data-filtered-html="noDataFilteredHtml"
         :striped="isStriped"
+        :clickable="clickable"
         sticky-header
         style="--scroll-table-height: 250px; --scroll-table-color: orange;"
       />
@@ -698,6 +701,7 @@ export default defineComponent({
       hideDefaultHeader: false,
       footerClone: false,
       allowFooterSorting: false,
+      clickable: false,
 
       columnsTest2: ['columnOne', 'columnTwo'],
       itemsTest2: [{ columnOne: 1, columnThree: 3 }, { columnTwo: 2, columnOne: 1 }],

--- a/packages/ui/src/components/va-data-table/VaDataTable.new.demo.vue
+++ b/packages/ui/src/components/va-data-table/VaDataTable.new.demo.vue
@@ -1,10 +1,12 @@
 <template>
   <VbDemo>
     <VbCard title="Reactive data">
-      <button @click="shuffleItems">Shuffle</button>
+      <button @click="shuffleItems">Shuffle</button><br>
+      <input id="isClickable" type="checkbox" v-model="clickable">
+      <label for="isClickable">Clickable rows</label><br>
       <va-data-table
         :items="items"
-        :clickable="true"
+        :clickable="clickable"
         @row:click="rowEventType = $event.event.type, rowId = $event.item.id"
         @row:dblclick="rowEventType = $event.event.type, rowId = $event.item.id"
         @row:contextmenu="rowEventType = $event.event.type, rowId = $event.item.id"
@@ -355,6 +357,7 @@ export default defineComponent({
       sortBy: 'username',
       sortingOrder: 'asc',
 
+      clickable: false,
       selectable: true,
       selectedItems: [] as { id: number }[],
       selectMode: 'single',

--- a/packages/ui/src/components/va-data-table/VaDataTable.vue
+++ b/packages/ui/src/components/va-data-table/VaDataTable.vue
@@ -139,9 +139,9 @@
                 :model-value="isRowSelected(row)"
                 :color="selectedColor"
                 :aria-label="`select row ${row.initialIndex}`"
-                @click.shift.exact="shiftSelectRows(row)"
-                @click.ctrl.exact="ctrlSelectRow(row)"
-                @click.exact="ctrlSelectRow(row)"
+                @click.shift.exact.stop="shiftSelectRows(row)"
+                @click.ctrl.exact.stop="ctrlSelectRow(row)"
+                @click.exact.stop="ctrlSelectRow(row)"
               />
             </td>
 


### PR DESCRIPTION
closes #1876 

## Description

- [x] stop checkbox click events propagation
- [x] update `VaDataTable` demo 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
