### PR TITLE
[#1752] Modal padding and Content improvements

### DIFF
--- a/packages/docs/src/locales/en/en.json
+++ b/packages/docs/src/locales/en/en.json
@@ -1891,6 +1891,10 @@
         }
       ]
     },
+    "customContent": {
+      "title": "Custom content",
+      "text": "You can remove default padding with `no-padding` prop and change default action buttons with `content` slot."
+    },
     "anchor": {
       "title": "Slot: `anchor`",
       "text": "Using the `anchor` slot, the user can access the `show()`, `hide()` and `toggle()` methods."

--- a/packages/docs/src/page-configs/ui-elements/modal/examples/CustomContent.vue
+++ b/packages/docs/src/page-configs/ui-elements/modal/examples/CustomContent.vue
@@ -1,0 +1,28 @@
+<template>
+  <va-button @click="showCustomContent = !showCustomContent">
+    Show custom content modal
+  </va-button>
+  <va-modal
+    v-model="showCustomContent"
+    no-padding
+  >
+    <template #content="{ ok }">
+      <va-image :ratio="16/9" src="https://picsum.photos/1500" />
+      <va-card-title>
+        Title!
+      </va-card-title>
+      <va-card-content>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Id perferendis, illum rem dolorum obcaecati dolorem. Laborum, odio ipsum qui quaerat itaque reiciendis error nemo tenetur beatae. Vel obcaecati magni maxime!
+      </va-card-content>
+      <va-card-actions>
+        <va-button @click="ok" color="warning">Ok!</va-button>
+      </va-card-actions>
+    </template>
+  </va-modal>
+</template>
+
+<script>
+export default {
+  data () { return { showCustomContent: false } },
+}
+</script>

--- a/packages/docs/src/page-configs/ui-elements/modal/page-config.ts
+++ b/packages/docs/src/page-configs/ui-elements/modal/page-config.ts
@@ -42,6 +42,11 @@ const config: ApiDocsBlock[] = [
     'Anchor',
   ),
   ...block.exampleBlock(
+    'modal.customContent.title',
+    'modal.customContent.text',
+    'CustomContent',
+  ),
+  ...block.exampleBlock(
     'modal.disableAnimation.title',
     'modal.disableAnimation.text',
     'DisableAnimation',

--- a/packages/ui/src/components/va-modal/VaModal.demo.vue
+++ b/packages/ui/src/components/va-modal/VaModal.demo.vue
@@ -41,6 +41,18 @@
         />
       </p>
     </VbCard>
+    <VbCard title="custom content">
+      <button @click="showCustomContent = !showCustomContent">
+        Show custom content modal
+      </button>
+      <va-modal
+        v-model="showCustomContent"
+      >
+        <template #content>
+          <h1>Custom content modal</h1>
+        </template>
+      </va-modal>
+    </VbCard>
     <VbCard title="fullscreen, slots use, custom action">
       <button @click="showFullScreenModal = !showFullScreenModal">
         Show modal
@@ -65,6 +77,14 @@
         <template #anchor="{ show }">
           <button @click="show()">Anchor-button</button>
         </template>
+        <div>{{ message }}</div>
+      </va-modal>
+    </VbCard>
+    <VbCard title="No padding">
+      <button @click="showNoPaddingModal = !showNoPaddingModal">
+        Show no padding modal
+      </button>
+      <va-modal no-padding v-model="showNoPaddingModal">
         <div>{{ message }}</div>
       </va-modal>
     </VbCard>
@@ -322,6 +342,7 @@ export default {
       showModalSizeSmall: false,
       showModalSizeMedium: false,
       showModalSizeLarge: false,
+      showCustomContent: false,
       showFullScreenModal: false,
       showAnchorModal: false,
       showActionsModal: false,
@@ -347,6 +368,7 @@ export default {
       showModalCustomBackground: false,
       showModalNested1: false,
       showModalNested2: false,
+      showNoPaddingModal: false,
       message: this.$vb.lorem(),
       longMessage: this.$vb.lorem(5000),
     }

--- a/packages/ui/src/components/va-modal/VaModal.demo.vue
+++ b/packages/ui/src/components/va-modal/VaModal.demo.vue
@@ -85,7 +85,7 @@
         Show no padding modal
       </button>
       <va-modal no-padding v-model="showNoPaddingModal">
-        <div>{{ message }}</div>
+        {{ message }}
       </va-modal>
     </VbCard>
     <VbCard title="stateful">

--- a/packages/ui/src/components/va-modal/VaModal.vue
+++ b/packages/ui/src/components/va-modal/VaModal.vue
@@ -51,59 +51,63 @@
                 @keydown.space="cancel"
                 @keydown.enter="cancel"
               />
-
               <div
                 class="va-modal__inner"
                 :style="{ maxWidth: $props.maxWidth, maxHeight: $props.maxHeight }"
               >
-                <div
-                  v-if="title"
-                  class="va-modal__title"
-                  :style="{ color: getColor('primary') }"
-                >
-                  {{ $props.title }}
+                <div v-if="$slots.content">
+                  <slot name="content" />
                 </div>
-                <div
-                  v-if="$slots.header"
-                  class="va-modal__header"
-                >
-                  <slot name="header" />
-                </div>
-                <div
-                  v-if="$props.message"
-                  class="va-modal__message"
-                >
-                  {{ $props.message }}
-                </div>
-                <div
-                  v-if="$slots.default"
-                  class="va-modal__message"
-                >
-                  <slot />
-                </div>
-                <div
-                  v-if="($props.cancelText || $props.okText) && !$props.hideDefaultActions"
-                  class="va-modal__footer"
-                >
-                  <va-button
-                    v-if="$props.cancelText"
-                    color="gray"
-                    class="mr-2"
-                    flat
-                    @click="cancel"
+                <template v-if="!$slots.content">
+                  <div
+                    v-if="title"
+                    class="va-modal__title"
+                    :style="{ color: getColor('primary') }"
                   >
-                    {{ $props.cancelText }}
-                  </va-button>
-                  <va-button @click="ok">
-                    {{ $props.okText }}
-                  </va-button>
-                </div>
-                <div
-                  v-if="$slots.footer"
-                  class="va-modal__footer"
-                >
-                  <slot name="footer" />
-                </div>
+                    {{ $props.title }}
+                  </div>
+                  <div
+                    v-if="$slots.header"
+                    class="va-modal__header"
+                  >
+                    <slot name="header" />
+                  </div>
+                  <div
+                    v-if="$props.message"
+                    class="va-modal__message"
+                  >
+                    {{ $props.message }}
+                  </div>
+                  <div
+                    v-if="$slots.default"
+                    class="va-modal__message"
+                  >
+                    <slot />
+                  </div>
+                  <div
+                    v-if="($props.cancelText || $props.okText) && !$props.hideDefaultActions"
+                    class="va-modal__footer"
+                  >
+                    <va-button
+                      v-if="$props.cancelText"
+                      color="gray"
+                      class="mr-2"
+                      flat
+                      @click="cancel"
+                    >
+                      {{ $props.cancelText }}
+                    </va-button>
+                    <va-button @click="ok">
+                      {{ $props.okText }}
+                    </va-button>
+                  </div>
+                  <div
+                    v-if="$slots.footer"
+                    class="va-modal__footer"
+                  >
+                    <slot name="footer" />
+                  </div>
+                </template>
               </div>
             </div>
           </div>
@@ -172,6 +176,7 @@ export default defineComponent({
     blur: { type: Boolean, default: false },
     zIndex: { type: [Number, String] as PropType<number | string | undefined>, default: undefined },
     backgroundColor: { type: String, default: 'white' },
+    noPadding: { type: Boolean, default: false },
   },
   setup (props, { emit }) {
     const rootElement = shallowRef<HTMLElement>()
@@ -184,6 +189,7 @@ export default defineComponent({
       'va-modal--fullscreen': props.fullscreen,
       'va-modal--mobile-fullscreen': props.mobileFullscreen,
       'va-modal--fixed-layout': props.fixedLayout,
+      'va-modal--noPadding': props.noPadding,
       [`va-modal--size-${props.size}`]: props.size !== 'medium',
     }))
     const computedModalContainerStyle = computed(() => ({ 'z-index': props.zIndex } as StyleValue))
@@ -406,23 +412,29 @@ export default defineComponent({
   &--fixed-layout {
     .va-modal__inner {
       overflow: hidden;
-      padding: $modal-padding-top 0 $modal-padding-bottom;
+      padding: var(--va-modal-padding-top) 0 var(--va-modal-padding-bottom);
       max-height: calc(100vh - 2rem);
 
       .va-modal__header,
       .va-modal__footer,
       .va-modal__title {
-        padding: 0 $modal-padding-right 0 $modal-padding-left;
+        padding: 0 var(--va-modal-padding-right) 0 var(--va-modal-padding-left);
       }
 
       .va-modal__message {
-        padding: 0 $modal-padding-right 0 $modal-padding-left;
+        padding: 0 var(--va-modal-padding-right) 0 var(--va-modal-padding-left);
         overflow: auto;
       }
     }
 
     .va-modal__dialog {
       overflow: hidden;
+    }
+  }
+
+  &--noPadding {
+    .va-modal__inner {
+      padding: 0;
     }
   }
 
@@ -435,7 +447,7 @@ export default defineComponent({
     display: flex;
     position: relative;
     flex-flow: column;
-    padding: $modal-padding-top $modal-padding-right $modal-padding-bottom $modal-padding-left;
+    padding: var(--va-modal-padding);
     max-width: map_get($grid-breakpoints, md);
     margin: auto;
 

--- a/packages/ui/src/components/va-modal/VaModal.vue
+++ b/packages/ui/src/components/va-modal/VaModal.vue
@@ -56,7 +56,7 @@
                 :style="{ maxWidth: $props.maxWidth, maxHeight: $props.maxHeight }"
               >
                 <div v-if="$slots.content">
-                  <slot name="content" />
+                  <slot name="content" v-bind="{ cancel, ok }" />
                 </div>
                 <template v-if="!$slots.content">
                   <div

--- a/packages/ui/src/components/va-modal/VaModal.vue
+++ b/packages/ui/src/components/va-modal/VaModal.vue
@@ -189,7 +189,7 @@ export default defineComponent({
       'va-modal--fullscreen': props.fullscreen,
       'va-modal--mobile-fullscreen': props.mobileFullscreen,
       'va-modal--fixed-layout': props.fixedLayout,
-      'va-modal--noPadding': props.noPadding,
+      'va-modal--no-padding': props.noPadding,
       [`va-modal--size-${props.size}`]: props.size !== 'medium',
     }))
     const computedModalContainerStyle = computed(() => ({ 'z-index': props.zIndex } as StyleValue))
@@ -432,7 +432,7 @@ export default defineComponent({
     }
   }
 
-  &--noPadding {
+  &--no-padding {
     .va-modal__inner {
       padding: 0;
     }

--- a/packages/ui/src/components/va-modal/_variables.scss
+++ b/packages/ui/src/components/va-modal/_variables.scss
@@ -16,6 +16,11 @@
   --va-modal-opacity-transition: opacity calc(var(--va-modal-basic-duration) * 0.5) cubic-bezier(1, 0.5, 0.8, 1);
   --va-modal-transform-transition: transform var(--va-modal-basic-duration) ease;
   --va-modal-overlay-background-blur-radius: 4px;
+  --va-modal-padding: var(--va-modal-padding-top) var(--va-modal-padding-right) var(--va-modal-padding-bottom) var(--va-modal-padding-left);
+  --va-modal-padding-top: 1.25rem;
+  --va-modal-padding-right: 1.5rem;
+  --va-modal-padding-bottom: 1.5rem;
+  --va-modal-padding-left: 1.5rem;
 
   /* Dialog */
   --va-modal-dialog-min-height: 3.125rem;

--- a/packages/ui/src/styles/resources/_variables.scss
+++ b/packages/ui/src/styles/resources/_variables.scss
@@ -315,10 +315,6 @@ $display-margins: (
 
 // Modals
 $zindex-modal: 1050 !default;
-$modal-padding-top: 1.25rem !default;
-$modal-padding-right: 1.875rem !default;
-$modal-padding-bottom: 1.5rem !default;
-$modal-padding-left: 1.5rem !default;
 
 // Affix
 $zindex-affix: 10 !default;


### PR DESCRIPTION
Fix #1752
## Description
- Added padding variables to manage padding
- Added `no-padding` prop
- Added `content` slot which replace all the content inside `va-modal__inner`

- Removed hardcoded paddings and this could brake some of the users code, not sure how to resolve it
```
  $modal-padding-top: 1.25rem !default;
  $modal-padding-right: 1.875rem !default;
  $modal-padding-bottom: 1.5rem !default;
  $modal-padding-left: 1.5rem !default;
```

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
