### PR TITLE
fix#1957 Remove collapse margin. Beautify accordion.

### DIFF
--- a/packages/ui/src/components/va-accordion/VaAccordion.vue
+++ b/packages/ui/src/components/va-accordion/VaAccordion.vue
@@ -32,8 +32,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import 'variables';
-
 .va-accordion {
   font-family: var(--va-font-family);
 

--- a/packages/ui/src/components/va-accordion/VaAccordion.vue
+++ b/packages/ui/src/components/va-accordion/VaAccordion.vue
@@ -32,7 +32,32 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
+@import 'variables';
+
 .va-accordion {
   font-family: var(--va-font-family);
+
+  // Do not remove border radius from expanded and next to it collapse
+  .va-collapse:not(.va-collapse--expanded, .va-collapse--expanded + .va-collapse) {
+    &:not(:first-child, :last-child) {
+      .va-collapse__header__content {
+        border-radius: 0;
+      }
+    }
+
+    &:first-child {
+      .va-collapse__header__content {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+      }
+    }
+
+    &:last-child {
+      .va-collapse__header__content {
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
+      }
+    }
+  }
 }
 </style>

--- a/packages/ui/src/components/va-accordion/_variables.scss
+++ b/packages/ui/src/components/va-accordion/_variables.scss
@@ -1,3 +1,0 @@
-:root {
-  --va-accordion-collapses-gap: 0.1rem;
-}

--- a/packages/ui/src/components/va-accordion/_variables.scss
+++ b/packages/ui/src/components/va-accordion/_variables.scss
@@ -1,0 +1,3 @@
+:root {
+  --va-accordion-collapses-gap: 0.1rem;
+}

--- a/packages/ui/src/components/va-collapse/VaCollapse.vue
+++ b/packages/ui/src/components/va-collapse/VaCollapse.vue
@@ -152,6 +152,7 @@ export default defineComponent({
       tabIndexComputed,
 
       computedClasses: computed(() => ({
+        'va-collapse--expanded': computedModelValue.value,
         'va-collapse--disabled': props.disabled,
         'va-collapse--solid': props.solid,
         'va-collapse--active': props.solid && computedModelValue.value,
@@ -192,7 +193,6 @@ export default defineComponent({
   &__body {
     transition: var(--va-collapse-body-transition);
     overflow: var(--va-collapse-body-overflow);
-    margin-top: var(--va-collapse-body-margin-top);
   }
 
   &__header {

--- a/packages/ui/src/components/va-collapse/_variables.scss
+++ b/packages/ui/src/components/va-collapse/_variables.scss
@@ -4,7 +4,6 @@
   --va-collapse-inset-margin: 0.5rem 0.5rem;
   --va-collapse-body-transition: all 0.3s linear;
   --va-collapse-body-overflow: hidden;
-  --va-collapse-body-margin-top: 0.1rem;
   --va-collapse-header-content-display: flex;
   --va-collapse-header-content-justify-content: space-between;
   --va-collapse-header-content-cursor: pointer;


### PR DESCRIPTION
closes #1957
closes https://github.com/epicmaxco/vuestic-ui/issues/1811

There was a gap between two sidebar elements. (even in our docs sidebar)
![image](https://user-images.githubusercontent.com/23530004/174353243-0237024a-9c76-46ba-8a52-b5553f788e17.png)

Made accordion without gaps:
![image](https://user-images.githubusercontent.com/23530004/174353382-d2da318c-1961-4b13-aa9a-100910ee45b8.png)
![image](https://user-images.githubusercontent.com/23530004/174353399-ae31e078-8a94-4d20-a371-c753f83bcd68.png)
