### PR TITLE
fix#1816 escape vuestic import in docs

### DIFF
--- a/packages/docs/src/components/DocsCode.vue
+++ b/packages/docs/src/components/DocsCode.vue
@@ -10,7 +10,7 @@
     </template>
   </va-tabs>
   <prism-wrapper
-    :code="contents[index]"
+    :code="escapeVuesticImport(contents[index])"
     :lang="$props.language"
     class="DocsCode"
   />
@@ -47,9 +47,14 @@ export default defineComponent({
       nextTick(() => { doShowCode.value = true }) // nextTick() triggers v-if, that causes re-rendering of component.
     }
 
+    // Hack: Remove this with alias when moving to vite.
+    const escapeVuesticImport = (code: string) => {
+      return code.replace(/vuestic-ui\/src\/main/g, 'vuestic-ui')
+    }
+
     watch(() => props.code, forceUpdate, { immediate: true })
 
-    return { isString, tabs, contents, index }
+    return { isString, tabs, contents, index, escapeVuesticImport }
   },
 })
 </script>


### PR DESCRIPTION
closes https://github.com/epicmaxco/vuestic-ui/issues/1816

Before
![image](https://user-images.githubusercontent.com/23530004/174391506-aa6fcdf4-a263-47a0-a133-499954a8ba2d.png)

Now
![image](https://user-images.githubusercontent.com/23530004/174391485-8d1d0b59-4137-43a2-8476-08135d4bea00.png)
