### PR TITLE
Fix#1427 VaSelect slot focus. Refator VaInputWrapper.

### DIFF
--- a/packages/docs/src/page-configs/ui-elements/select/examples/ContentSlot.vue
+++ b/packages/docs/src/page-configs/ui-elements/select/examples/ContentSlot.vue
@@ -8,7 +8,7 @@
       multiple
     >
       <template #content="{ valueString }">
-        <div>{{ valueString }}</div>
+        <div tabindex="1">{{ valueString }}</div>
       </template>
     </va-select>
 
@@ -20,14 +20,16 @@
       multiple
     >
       <template #content="{ value }">
-        <va-chip
-          v-for="chip in value.slice(0, 3)"
-          :key="chip"
-          size="small"
-          class="mr-1 my-1"
-        >
-          {{ chip }}
-        </va-chip>
+        <div tabindex="1">
+          <va-chip
+            v-for="chip in value.slice(0, 3)"
+            :key="chip"
+            size="small"
+            class="mr-1 my-1"
+          >
+            {{ chip }}
+          </va-chip>
+        </div>
       </template>
     </va-select>
 
@@ -39,16 +41,18 @@
       multiple
     >
       <template #content="{ value }">
-        <va-chip
-          v-for="chip in value"
-          :key="chip"
-          size="small"
-          class="mr-1 my-1"
-          closeable
-          @update:modelValue="deleteChip(chip)"
-        >
-          {{ chip }}
-        </va-chip>
+        <div tabindex="1">
+          <va-chip
+            v-for="chip in value"
+            :key="chip"
+            size="small"
+            class="mr-1 my-1"
+            closeable
+            @update:modelValue="deleteChip(chip)"
+          >
+            {{ chip }}
+          </va-chip>
+        </div>
       </template>
     </va-select>
   </div>

--- a/packages/ui/src/components/va-input/VaInput.vue
+++ b/packages/ui/src/components/va-input/VaInput.vue
@@ -84,7 +84,7 @@ import { computed, defineComponent, InputHTMLAttributes, PropType, ref, toRefs }
 import { useFormProps } from '../../composables/useForm'
 import { useValidation, useValidationProps, useValidationEmits, ValidationProps } from '../../composables/useValidation'
 import { useCleave, useCleaveProps } from './hooks/useCleave'
-import { useFocus } from '../../composables/useFocus'
+import { useFocusDeep } from '../../composables/useFocusDeep'
 import { useEmitProxy } from '../../composables/useEmitProxy'
 import VaInputWrapper from './components/VaInputWrapper.vue'
 import { useClearableProps, useClearable, useClearableEmits } from '../../composables/useClearable'
@@ -154,7 +154,7 @@ export default defineComponent({
   setup (props, { emit, attrs, slots }) {
     const input = ref<HTMLInputElement | typeof VaTextarea | undefined>()
 
-    const { isFocused, onFocus: onFocusListener, onBlur: onBlurListener } = useFocus()
+    const isFocused = useFocusDeep()
 
     const reset = () => {
       emit('update:modelValue', props.clearValue)
@@ -200,13 +200,11 @@ export default defineComponent({
     const onFocus = (e: Event) => {
       inputListeners.onFocus(e)
       validationListeners.onFocus()
-      onFocusListener()
     }
 
     const onBlur = (e: Event) => {
       inputListeners.onBlur(e)
       validationListeners.onBlur()
-      onBlurListener()
     }
 
     const inputEvents = {

--- a/packages/ui/src/components/va-input/components/VaInputWrapper.vue
+++ b/packages/ui/src/components/va-input/components/VaInputWrapper.vue
@@ -224,6 +224,7 @@ export default defineComponent({
   &__text {
     width: 100%;
     position: relative;
+    min-height: var(--va-input-line-height);
 
     input,
     textarea {
@@ -292,7 +293,7 @@ export default defineComponent({
     .va-input-wrapper__text {
       height: 100%;
       padding-top: 12px;
-      align-items: flex-end;
+      box-sizing: content-box;
     }
 
     .va-input-wrapper__label {

--- a/packages/ui/src/components/va-input/components/VaInputWrapper.vue
+++ b/packages/ui/src/components/va-input/components/VaInputWrapper.vue
@@ -2,9 +2,10 @@
   <div
     class="va-input-wrapper"
     :class="wrapperClass"
+    :style="wrapperStyle"
     @click="$emit('click', $event)"
   >
-    <div class="va-input-wrapper__input">
+    <div class="va-input-wrapper__container">
       <div
         v-if="$slots.prepend"
         class="va-input-wrapper__prepend-inner"
@@ -13,67 +14,52 @@
         <slot name="prepend" />
       </div>
 
-      <div class="va-input-wrapper__content">
+      <div
+        class="va-input-wrapper__field"
+        ref="container"
+      >
         <div
-          class="va-input__container"
-          ref="container"
-          :style="{ borderColor: borderColorComputed }"
+          v-if="$slots.prependInner"
+          class="va-input-wrapper__prepend-inner"
+          @click="$emit('click-prepend-inner', $event)"
         >
-          <div
-            v-if="$slots.prependInner"
-            class="va-input__prepend-inner"
-            @click="$emit('click-prepend-inner', $event)"
+          <slot name="prependInner" />
+        </div>
+
+        <div class="va-input-wrapper__text">
+          <label
+            v-if="label"
+            aria-hidden="true"
+            class="va-input-wrapper__label"
+            :style="{ color: colorComputed }"
           >
-            <slot name="prependInner" />
-          </div>
+            {{ label }}
+            <span
+              v-if="requiredMark"
+              class="va-input-wrapper__required-mark"
+            >
+              *
+            </span>
+          </label>
 
-          <div class="va-input__content-wrapper">
-            <div class="va-input__content">
-              <label
-                v-if="label"
-                aria-hidden="true"
-                class="va-input__label"
-                :style="{ color: colorComputed }"
-              >
-                {{ label }}
-                <span
-                  v-if="requiredMark"
-                  class="va-input__required-mark"
-                >
-                  *
-                </span>
-              </label>
-
-              <div v-if="$slots.content" class="va-input__content__input">
-                <slot name="content" />
-              </div>
-
-              <slot />
-            </div>
-          </div>
-
-          <div
-            v-if="$slots.icon"
-            class="va-input__icons"
-            @click="$emit('click-icon', $event)"
-          >
-            <slot name="icon" />
-          </div>
-
-          <div
-            v-if="$slots.appendInner"
-            class="va-input__append-inner"
-            @click="$emit('click-append-inner', $event)"
-          >
-            <slot name="appendInner" />
-          </div>
+          <slot />
         </div>
 
         <div
-          v-if="bordered"
-          class="va-input--bordered__border"
-          :style="{ borderColor: borderColorComputed }"
-        />
+          v-if="$slots.icon"
+          class="va-input-wrapper__icons"
+          @click="$emit('click-icon', $event)"
+        >
+          <slot name="icon" />
+        </div>
+
+        <div
+          v-if="$slots.appendInner"
+          class="va-input-wrapper__append-inner"
+          @click="$emit('click-append-inner', $event)"
+        >
+          <slot name="appendInner" />
+        </div>
       </div>
 
       <div
@@ -85,6 +71,7 @@
       </div>
     </div>
 
+    <!-- TODO: Can we move it out? -->
     <div v-if="hasMessages" class="va-input-wrapper__message-list-wrapper">
       <slot name="messages" v-bind="{ messages: messagesComputed, errorLimit, color: messagesColor }">
         <va-message-list
@@ -100,6 +87,7 @@
 <script lang="ts">
 import { computed, defineComponent } from 'vue'
 import { useBem } from '../../../composables/useBem'
+import { useCSSVariables } from '../../../composables/useCSSVariables'
 import { useFormProps } from '../../../composables/useForm'
 import { useValidationProps } from '../../../composables/useValidation'
 import { useColors } from '../../../services/color-config/color-config'
@@ -137,10 +125,14 @@ export default defineComponent({
   setup (props) {
     const { getColor } = useColors()
 
-    const wrapperClass = useBem('va-input', () => ({
+    const wrapperClass = useBem('va-input-wrapper', () => ({
       ...pick(props, ['outline', 'bordered', 'success', 'focused', 'error', 'disabled', 'readonly']),
       labeled: !!props.label,
       solid: !props.outline && !props.bordered,
+    }))
+
+    const wrapperStyle = useCSSVariables('va-input-wrapper', () => ({
+      color: colorComputed.value,
     }))
 
     const colorComputed = computed(() => getColor(props.color))
@@ -153,9 +145,9 @@ export default defineComponent({
 
     return {
       wrapperClass,
+      wrapperStyle,
 
       colorComputed,
-      borderColorComputed: computed(() => props.focused ? colorComputed.value : undefined),
 
       messagesColor: computed(() => {
         if (props.error) { return 'danger' }
@@ -175,39 +167,36 @@ export default defineComponent({
 @import '../../../styles/resources/index.scss';
 @import '../variables';
 
-.va-input {
+.va-input-wrapper {
   position: relative;
   color: var(--va-input-text-color);
   cursor: var(--va-input-cursor);
   font-family: var(--va-font-family);
 
-  &--readonly {
-    cursor: default;
-  }
+  // Util CSS variables used to change component style during runtime
+  --va-input-wrapper-color: var(--va-primary);
+  --va-input-wrapper-background: var(--va-input-color);
+  --va-input-wrapper-background-opacity: 1;
+  --va-input-wrapper-border-color: var(--va-input-bordered-color);
 
-  &--disabled {
-    @include va-disabled;
-  }
-
-  &__container {
-    display: flex;
+  &__field {
     position: relative;
+    display: flex;
     align-items: center;
     width: 100%;
     min-height: var(--va-input-min-height);
-    border-color: var(--va-input-color);
+    border-color: var(--va-input-wrapper-border-color);
     border-style: solid;
     border-width: var(--va-input-border-width);
-    overflow: hidden;
     padding: 0 var(--va-input-content-horizontal-padding);
     z-index: 0;
+    overflow: hidden;
 
-    @include va-background(var(--va-input-color), null, -1);
+    @include va-background(var(--va-input-wrapper-background), var(--va-input-wrapper-background-opacity), -1);
 
     /* Creates gap between prepend, content, validation icons, append */
     & > * {
       padding-right: var(--va-input-content-items-gap);
-      line-height: 0;
 
       &:last-child {
         padding-right: 0;
@@ -215,22 +204,15 @@ export default defineComponent({
     }
   }
 
-  &-wrapper__input {
+  &__container {
     display: flex;
     align-items: center;
   }
 
-  &-wrapper__message-list-wrapper {
+  &__message-list-wrapper {
     margin-top: 2px;
   }
 
-  &-wrapper__content {
-    position: relative;
-    flex-grow: 1;
-  }
-
-  &-wrapper__prepend-inner,
-  &-wrapper__append-inner,
   &__prepend-inner,
   &__append-inner {
     display: flex;
@@ -239,45 +221,37 @@ export default defineComponent({
     align-items: center;
   }
 
-  &__content-wrapper {
-    width: stretch;
-    display: flex;
-    align-items: center;
+  &__text {
+    width: 100%;
+    position: relative;
 
-    .va-input__content {
+    input,
+    textarea {
+      @include va-scroll(var(--va-input-scroll-color));
+
       width: 100%;
-      position: relative;
+      // Use line-height as min-height for empty content slot
+      min-height: var(--va-input-line-height);
+      color: var(--va-input-text-color);
+      background-color: transparent;
+      border-style: none;
+      outline: none;
+      line-height: var(--va-input-line-height);
+      font-size: var(--va-input-font-size);
+      font-family: inherit;
+      font-weight: var(--va-input-font-weight);
+      font-style: var(--va-input-font-style);
+      font-stretch: var(--va-input-font-stretch);
+      letter-spacing: var(--va-input-letter-spacing);
+      transform: translateY(-1px);
+      cursor: inherit;
 
-      input {
-        cursor: inherit;
+      &::-webkit-scrollbar {
+        width: 10px;
       }
 
-      &__input {
-        @include va-scroll(var(--va-input-scroll-color));
-
-        width: 100%;
-        // Use line-height as min-height for empty content slot
-        min-height: var(--va-input-line-height);
-        color: var(--va-input-text-color);
-        background-color: transparent;
-        border-style: none;
-        outline: none;
-        line-height: var(--va-input-line-height);
-        font-size: var(--va-input-font-size);
-        font-family: inherit;
-        font-weight: var(--va-input-font-weight);
-        font-style: var(--va-input-font-style);
-        font-stretch: var(--va-input-font-stretch);
-        letter-spacing: var(--va-input-letter-spacing);
-        transform: translateY(-1px);
-
-        &::-webkit-scrollbar {
-          width: 10px;
-        }
-
-        &::placeholder {
-          color: var(--va-input-placeholder-text-color);
-        }
+      &::placeholder {
+        color: var(--va-input-placeholder-text-color);
       }
     }
   }
@@ -315,17 +289,16 @@ export default defineComponent({
   }
 
   &--labeled {
-    .va-input__content-wrapper {
+    .va-input-wrapper__text {
       height: 100%;
       padding-top: 12px;
       align-items: flex-end;
     }
 
-    .va-input__label {
+    .va-input-wrapper__label {
       @include va-ellipsis();
 
       height: 12px;
-      transform: translateY(-100%);
       position: absolute;
       left: 0;
       top: 0;
@@ -345,61 +318,25 @@ export default defineComponent({
     }
   }
 
-  /* We have 3 styles and two states for each style separately */
+  /* Styles */
   &--solid {
-    .va-input__container {
-      border-color: var(--va-input-color);
+    --va-input-wrapper-border-color: var(--va-input-color);
+
+    .va-input-wrapper__field {
       border-radius: var(--va-input-border-radius);
-    }
-
-    &.va-input--success {
-      .va-input__container {
-        @include va-background-opacity(var(--va-input-success-color), var(--va-input-opacity));
-
-        border-color: var(--va-input-success-color);
-      }
-    }
-
-    &.va-input--error {
-      .va-input__container {
-        @include va-background-opacity(var(--va-input-error-color), var(--va-input-opacity));
-
-        border-color: var(--va-input-error-color);
-      }
     }
   }
 
   &--outline {
-    .va-input__container {
+    .va-input-wrapper__field {
       border-radius: 0;
-      border-color: var(--va-input-bordered-color);
-    }
-
-    &.va-input--success {
-      .va-input__container {
-        @include va-background-opacity(var(--va-input-success-color), var(--va-input-opacity));
-
-        border-color: var(--va-input-success-color);
-      }
-    }
-
-    &.va-input--error {
-      .va-input__container {
-        @include va-background-opacity(var(--va-input-error-color), var(--va-input-opacity));
-
-        border-color: var(--va-input-error-color);
-      }
     }
   }
 
   &--bordered {
-    /*
-      We can not just set border-bottom, because we also have border on the other sides.
-      We also can not use after or before, because we need to set border-color according to
-      color prop
-    */
-    &__border {
-      border-color: var(--va-input-bordered-color);
+    &::after {
+      content: '';
+      border-color: var(--va-input-wrapper-border-color);
       position: absolute;
       height: 0;
       border-bottom-width: var(--va-input-border-width);
@@ -408,31 +345,35 @@ export default defineComponent({
       bottom: 0;
     }
 
-    .va-input__container {
+    .va-input-wrapper__field {
       border-top-left-radius: var(--va-input-border-radius);
       border-top-right-radius: var(--va-input-border-radius);
       border-color: transparent !important;
     }
+  }
 
-    &.va-input--success {
-      .va-input__container {
-        @include va-background-opacity(var(--va-input-success-color), var(--va-input-opacity));
-      }
+  // States
+  &--focused {
+    --va-input-wrapper-border-color: var(--va-input-wrapper-color);
+  }
 
-      .va-input--bordered__border {
-        border-color: var(--va-input-success-color);
-      }
-    }
+  &--readonly {
+    cursor: default;
+  }
 
-    &.va-input--error {
-      .va-input__container {
-        @include va-background-opacity(var(--va-input-error-color), var(--va-input-opacity));
-      }
+  &--disabled {
+    @include va-disabled;
+  }
 
-      .va-input--bordered__border {
-        border-color: var(--va-input-error-color);
-      }
-    }
+  // States: Validations
+  &--error {
+    --va-input-wrapper-background: var(--va-input-error-color, --va-danger);
+    --va-input-wrapper-background-opacity: var(--va-input-opacity);
+  }
+
+  &--success {
+    --va-input-wrapper-background: var(--va-input-success-color, --va-success);
+    --va-input-wrapper-background-opacity: var(--va-input-opacity);
   }
 }
 </style>

--- a/packages/ui/src/components/va-input/index.ts
+++ b/packages/ui/src/components/va-input/index.ts
@@ -1,6 +1,7 @@
 import withConfigTransport from '../../services/config-transport/withConfigTransport'
 import _VaInput from './VaInput.vue'
 
+export { default as VaInputWrapper } from './components/VaInputWrapper.vue'
 export { VaMessageList } from './components/VaMessageList'
 export { default as VaMessageListWrapper } from './components/VaMessageListWrapper.vue'
 

--- a/packages/ui/src/components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/va-select/VaSelect.vue
@@ -68,6 +68,7 @@
             aria-hidden="false"
             aria-label="reset"
             class="va-select__icons__reset"
+            tabindex="0"
             v-bind="clearIconProps"
             @click.stop="reset"
             @keydown.enter.stop="reset"

--- a/packages/ui/src/components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/va-select/VaSelect.vue
@@ -20,88 +20,88 @@
     @click.prevent="onSelectClick()"
   >
     <template #anchor>
-      <div class="va-select">
-        <va-input
-          ref="input"
-          aria-label="selected option"
-          :model-value="valueComputedString"
-          :success="$props.success"
-          :error="computedError"
-          :color="$props.color"
-          :label="$props.label"
-          :placeholder="$props.placeholder"
-          :loading="$props.loading"
-          :disabled="$props.disabled"
-          :outline="$props.outline"
-          :bordered="$props.bordered"
-          :required-mark="$props.requiredMark"
-          :tabindex="tabIndexComputed"
-          :messages="$props.messages"
-          :error-messages="computedErrorMessages"
-          readonly
-          @focus="onInputFocus()"
-          @blur="onInputBlur()"
+      <va-input-wrapper
+        aria-label="selected option"
+        class="va-select"
+        :model-value="valueComputedString"
+        :success="$props.success"
+        :error="computedError"
+        :color="$props.color"
+        :label="$props.label"
+        :placeholder="$props.placeholder"
+        :loading="$props.loading"
+        :disabled="$props.disabled"
+        :outline="$props.outline"
+        :bordered="$props.bordered"
+        :required-mark="$props.requiredMark"
+        :tabindex="tabIndexComputed"
+        :messages="$props.messages"
+        :error-messages="computedErrorMessages"
+        :focused="isFocused"
+        @focus="onInputFocus()"
+        @blur="onInputBlur()"
+      >
+        <template
+          v-if="$slots.prepend"
+          #prepend
         >
-          <template
-            v-if="$slots.prepend"
-            #prepend
+          <slot name="prepend" />
+        </template>
+
+        <template
+          v-if="$slots.append"
+          #append
+        >
+          <slot name="append" />
+        </template>
+
+        <template
+          v-if="$slots.prependInner"
+          #prependInner
+        >
+          <slot name="prependInner" />
+        </template>
+
+        <template #icon>
+          <va-icon
+            v-if="showClearIcon"
+            aria-hidden="false"
+            aria-label="reset"
+            class="va-select__icons__reset"
+            v-bind="clearIconProps"
+            @click.stop="reset"
+            @keydown.enter.stop="reset"
+            @keydown.space.stop="reset"
+          />
+        </template>
+
+        <template #appendInner>
+          <slot
+            v-if="$slots.appendInner"
+            name="appendInner"
+          />
+          <va-icon
+            :color="toggleIconColor"
+            :name="toggleIcon"
+          />
+        </template>
+
+        <template
+          #default
+        >
+          <slot
+            name="content"
+            v-bind="{ valueString: valueComputedString, value: valueComputed }"
           >
-            <slot name="prepend" />
-          </template>
-
-          <template
-            v-if="$slots.append"
-            #append
-          >
-            <slot name="append" />
-          </template>
-
-          <template
-            v-if="$slots.prependInner"
-            #prependInner
-          >
-            <slot name="prependInner" />
-          </template>
-
-          <template #icon>
-            <va-icon
-              v-if="showClearIcon"
-              aria-hidden="false"
-              aria-label="reset"
-              class="va-select__icons__reset"
-              v-bind="clearIconProps"
-              @click.stop="reset"
-              @keydown.enter.stop="reset"
-              @keydown.space.stop="reset"
-            />
-          </template>
-
-          <template #appendInner>
-            <slot
-              v-if="$slots.appendInner"
-              name="appendInner"
-            />
-            <va-icon
-              :color="toggleIconColor"
-              :name="toggleIcon"
-            />
-          </template>
-
-          <template
-            v-if="$slots.content"
-            #content
-          >
-            <slot
-              name="content"
-              v-bind="{ valueString: valueComputedString, value: valueComputed }"
-            />
-          </template>
-        </va-input>
-      </div>
+            <input tabindex="-1" ref="input" readonly v-model="valueComputedString" />
+          </slot>
+        </template>
+      </va-input-wrapper>
     </template>
 
     <!-- Stop propagation for enter keyup event, to prevent VaDropdown closing -->
     <va-dropdown-content
+      ref="dropdownContent"
       class="va-select-dropdown__content"
       :style="{ width: $props.width }"
       @keyup.enter.stop="() => undefined"
@@ -166,10 +166,11 @@ import { useColors } from '../../services/color-config/color-config'
 import { warn } from '../../services/utils'
 import { VaDropdown, VaDropdownContent } from '../va-dropdown'
 import { VaIcon } from '../va-icon'
-import { VaInput } from '../va-input'
+import { VaInput, VaInputWrapper } from '../va-input'
 import { VaSelectOptionList } from './VaSelectOptionList'
-import { useFocus } from '../../composables/useFocus'
 import { SelectDropdownIcon, SelectOption, Placement } from './types'
+import { useFocusDeep } from '../../composables/useFocusDeep'
+import { useHTMLElement } from '../../composables/useHTMLElement'
 
 export default defineComponent({
   name: 'VaSelect',
@@ -180,6 +181,7 @@ export default defineComponent({
     VaDropdown,
     VaDropdownContent,
     VaInput,
+    VaInputWrapper,
   },
 
   emits: [
@@ -255,7 +257,8 @@ export default defineComponent({
     const optionList = ref<typeof VaSelectOptionList>()
     const input = ref<typeof VaInput>()
     const searchBar = ref<typeof VaInput>()
-    const { isFocused } = useFocus()
+    const isInputFocused = useFocusDeep()
+    const isFocused = computed(() => isInputFocused.value || showDropdownContent.value)
 
     const { getHoverColor } = useColors()
     const { getOptionByValue, getValue, getText, getTrackBy, getGroupBy } = useSelectableList(props)
@@ -512,7 +515,7 @@ export default defineComponent({
 
     const hideAndFocus = () => {
       hideDropdown()
-      input.value?.focus()
+      isInputFocused.value = true
     }
 
     const focusSearchBar = () => {
@@ -533,7 +536,7 @@ export default defineComponent({
     })
 
     const onInputFocus = () => {
-      isFocused.value = true
+      isInputFocused.value = true
       onFocus()
     }
 
@@ -542,8 +545,8 @@ export default defineComponent({
 
       onBlur()
 
-      isFocused.value
-        ? isFocused.value = false
+      isInputFocused.value
+        ? isInputFocused.value = false
         : validate()
     }
 
@@ -629,6 +632,8 @@ export default defineComponent({
     }
 
     return {
+      isFocused,
+
       input,
       optionList,
       searchBar,
@@ -698,10 +703,6 @@ export default defineComponent({
 
 .va-select {
   cursor: var(--va-select-cursor);
-
-  .va-input {
-    cursor: var(--va-select-cursor);
-  }
 
   &__icons {
     &__reset {

--- a/packages/ui/src/composables/useAccessTrap.ts
+++ b/packages/ui/src/composables/useAccessTrap.ts
@@ -1,0 +1,27 @@
+export const useAccessTrap = <BindName extends string, Value>(defaults: Record<BindName, Value>) => {
+  const binded: string[] = []
+
+  /** If key accessed in trap, it will not be accessable in untrapped */
+  const trap = new Proxy(defaults, {
+    get (target, key: BindName) {
+      binded.push(key)
+      return target[key]
+    },
+  })
+
+    /** If key hasn't been accessed from trap it will be available in untrapped */
+  const untrapped = new Proxy(defaults, {
+    get (target, key: BindName) {
+      if (binded.includes(key)) { return }
+      return target[key]
+    },
+    ownKeys () {
+      return Object.keys(defaults).filter((key) => !binded.includes(key))
+    },
+  })
+
+  return {
+    trap,
+    untrapped,
+  }
+}

--- a/packages/ui/src/composables/useCSSVariables.ts
+++ b/packages/ui/src/composables/useCSSVariables.ts
@@ -1,0 +1,6 @@
+import kebab from 'lodash/kebabCase.js'
+import { computed } from 'vue'
+
+export const useCSSVariables = (prefix: string, cb: () => Record<string, string>) => {
+  return computed(() => Object.entries(cb()).map(([key, value]) => ({ [`--${prefix}-${kebab(key)}`]: value })))
+}

--- a/packages/ui/src/composables/useCaptureEvent.ts
+++ b/packages/ui/src/composables/useCaptureEvent.ts
@@ -1,0 +1,11 @@
+import { onMounted, onBeforeUnmount } from 'vue'
+
+/** Register globally event catcher. SSR safe */
+export const useCaptureEvent = (event: string, cb: (...args: any[]) => void) => {
+  onMounted(() => {
+    window.addEventListener(event, cb, true)
+  })
+  onBeforeUnmount(() => {
+    window.removeEventListener(event, cb)
+  })
+}

--- a/packages/ui/src/composables/useCurrentElement.ts
+++ b/packages/ui/src/composables/useCurrentElement.ts
@@ -1,0 +1,13 @@
+import { onMounted, onBeforeUnmount, ref, getCurrentInstance, onUpdated, Ref } from 'vue'
+
+/** Returns ref of current component instance element */
+export const useCurrentElement = (el?: Ref<HTMLElement | undefined>) => {
+  if (el) { return el }
+  const vm = getCurrentInstance()!
+  const currentEl = ref<HTMLElement>()
+  onMounted(() => { currentEl.value = vm.proxy!.$el ?? undefined })
+  onUpdated(() => { currentEl.value = vm.proxy!.$el ?? undefined })
+  onBeforeUnmount(() => { currentEl.value = vm.proxy!.$el ?? undefined })
+
+  return currentEl
+}

--- a/packages/ui/src/composables/useFocusDeep.ts
+++ b/packages/ui/src/composables/useFocusDeep.ts
@@ -1,0 +1,53 @@
+import { onMounted, onBeforeUnmount, ref, getCurrentInstance, onUpdated, computed, nextTick } from 'vue'
+
+const useCaptureEvent = (event: string, cb: (...args: any[]) => void) => {
+  onMounted(() => {
+    window.addEventListener(event, cb, true)
+    cb()
+  })
+  onBeforeUnmount(() => {
+    window.removeEventListener(event, cb)
+  })
+}
+
+const useActiveElement = () => {
+  const activeEl = ref<HTMLElement>()
+
+  const onFocus = () => {
+    activeEl.value = document.activeElement as HTMLElement
+  }
+
+  useCaptureEvent('focus', onFocus)
+  useCaptureEvent('blur', onFocus)
+
+  return activeEl
+}
+
+const useCurrentElement = () => {
+  const vm = getCurrentInstance()!
+  const el = ref<HTMLElement>()
+  onMounted(() => { el.value = vm.proxy!.$el })
+  onUpdated(() => { el.value = vm.proxy!.$el })
+
+  return el
+}
+
+export const useFocusDeep = () => {
+  const focused = useActiveElement()
+  const current = useCurrentElement()
+
+  return computed({
+    get () {
+      if (!focused.value) { return false }
+      if (focused.value === current.value) { return true }
+      return current.value?.contains(focused.value)
+    },
+    set (value) {
+      if (value) {
+        current.value?.focus()
+      } else {
+        current.value?.blur()
+      }
+    },
+  })
+}

--- a/packages/ui/src/composables/useHTMLElement.ts
+++ b/packages/ui/src/composables/useHTMLElement.ts
@@ -1,0 +1,36 @@
+import { computed, getCurrentInstance, onBeforeUnmount, onMounted, onUpdated, Ref, ref } from 'vue'
+
+const extractHTMLElement = (el: any): HTMLElement => el && '$el' in el ? el.$el : el
+
+export const useTemplateRef = (key: string) => {
+  const vm = getCurrentInstance()!
+  const el = ref<HTMLElement | undefined>()
+
+  const updateEl = () => {
+    el.value = vm.proxy?.$refs[key] as HTMLElement
+  }
+
+  onMounted(updateEl)
+  onUpdated(updateEl)
+  onBeforeUnmount(updateEl)
+
+  return el
+}
+
+export const useHTMLElement = (key?: string): Ref<HTMLElement> => {
+  if (key) {
+    const el = useTemplateRef(key)
+    return computed({
+      get () { return extractHTMLElement(el.value) },
+      set (value) { el.value = value },
+    })
+  }
+
+  const el = ref()
+  return computed({
+    set (value) {
+      el.value = extractHTMLElement(value)
+    },
+    get () { return el.value },
+  })
+}


### PR DESCRIPTION
closes https://github.com/epicmaxco/vuestic-ui/issues/1427
closes https://github.com/epicmaxco/vuestic-ui/issues/1839

Created useFocusDeep composable so we can check for focused children.
Refactor VaInputWrapper, so focused can be passed from VaSelect. Removed a lot of extra CSS and DOM elements.
Now select looks like selected when Dropdown is shown. (We could check for deep focus in dropdown content, but it is overhead).