### PR TITLE
Fix: va-rating-issues

### DIFF
--- a/packages/ui/src/components/va-rating/VaRating.demo.vue
+++ b/packages/ui/src/components/va-rating/VaRating.demo.vue
@@ -189,8 +189,8 @@
         <va-rating stateful />
       </va-config>
     </VbCard>
-    <VbCard title="One star (with halves) hover hitbox">
-      <va-rating stateful hover :max="1" halves />
+    <VbCard title="Widened wrapper hover-hitbox (with halves)">
+      <va-rating stateful hover :max="2" halves class="wide" />
     </VbCard>
   </VbDemo>
 </template>
@@ -211,3 +211,12 @@ export default {
   },
 }
 </script>
+
+<style lang="scss">
+.wide {
+  .va-rating-item__wrapper {
+    background-color: lightblue !important;
+    width: 100px;
+  }
+}
+</style>

--- a/packages/ui/src/components/va-rating/VaRating.demo.vue
+++ b/packages/ui/src/components/va-rating/VaRating.demo.vue
@@ -189,6 +189,9 @@
         <va-rating stateful />
       </va-config>
     </VbCard>
+    <VbCard title="One star (with halves) hover hitbox">
+      <va-rating stateful hover :max="1" halves />
+    </VbCard>
   </VbDemo>
 </template>
 

--- a/packages/ui/src/components/va-rating/VaRating.demo.vue
+++ b/packages/ui/src/components/va-rating/VaRating.demo.vue
@@ -59,9 +59,15 @@
       <va-rating :size="60" v-model="value" />
     </VbCard>
     <VbCard title="Disabled">
-      <va-rating disabled hover v-model="value" />
+      <va-rating disabled v-model="value" />
     </VbCard>
     <VbCard title="Readonly">
+      <va-rating readonly v-model="value" />
+    </VbCard>
+    <VbCard title="Disabled and hover">
+      <va-rating disabled hover v-model="value" />
+    </VbCard>
+    <VbCard title="Readonly and hover">
       <va-rating readonly hover v-model="value" />
     </VbCard>
     <VbCard title="With custom icons">

--- a/packages/ui/src/components/va-rating/VaRating.vue
+++ b/packages/ui/src/components/va-rating/VaRating.vue
@@ -19,6 +19,7 @@
         :empty-icon-color="$props.unselectedColor"
         :tabindex="tabIndexComputed"
         :disabled="$props.disabled"
+        :readonly="$props.readonly"
         @hover="isInteractionsEnabled && onItemHoveredValueUpdate(itemNumber - 1, $event)"
         @update:model-value="isInteractionsEnabled && onItemValueUpdate(itemNumber - 1, $event)"
       >

--- a/packages/ui/src/components/va-rating/components/VaRatingItem/VaRatingItem.vue
+++ b/packages/ui/src/components/va-rating/components/VaRatingItem/VaRatingItem.vue
@@ -44,6 +44,7 @@ export default defineComponent({
     hover: { type: Boolean, default: false },
     tabindex: { type: Number, default: 0 },
     disabled: { type: Boolean, default: false },
+    readonly: { type: Boolean, default: false },
     size: { type: [String, Number], default: 'medium' },
     emptyIconColor: { type: String },
     color: { type: String, default: 'primary' },
@@ -57,7 +58,7 @@ export default defineComponent({
     const hoveredValue = ref<number | null>(null)
 
     const visibleValue = computed(() => {
-      if (props.hover) {
+      if (props.hover && !props.disabled && !props.readonly) {
         return hoveredValue.value || modelValue.value
       }
       return modelValue.value

--- a/packages/ui/src/components/va-rating/components/VaRatingItem/VaRatingItem.vue
+++ b/packages/ui/src/components/va-rating/components/VaRatingItem/VaRatingItem.vue
@@ -1,22 +1,22 @@
 <template>
   <div
-    ref="rootEl"
     class="va-rating-item"
     role="button"
     :tabindex="tabIndexComputed"
     @keyup.enter="onClick"
     @keyup.space="onClick"
-    @mousemove="onMouseMove"
-    @mouseleave="onMouseLeave"
   >
     <slot :props="{ value: visibleValue, onClick }">
       <va-icon
+        ref="itemEl"
         class="va-rating-item__wrapper"
         tabindex="-1"
         tag="button"
         :name="computedIconName"
         :size="$props.size"
         :color="getColor($props.color)"
+        @mousemove="onMouseMove"
+        @mouseleave="onMouseLeave"
         @click="onClick"
       />
     </slot>
@@ -53,7 +53,7 @@ export default defineComponent({
   emits: ['update:modelValue', 'click', 'hover'],
 
   setup (props, { emit }) {
-    const rootEl = ref<HTMLElement>()
+    const itemEl = ref()
     const [modelValue] = useSyncProp('modelValue', props, emit, RatingValue.EMPTY)
     const hoveredValue = ref<number | null>(null)
 
@@ -65,9 +65,10 @@ export default defineComponent({
     })
 
     const onMouseMove = (ev: MouseEvent) => {
-      if (!rootEl.value) { return }
+      if (!itemEl.value) { return }
+      ev.stopPropagation()
       const { offsetX } = ev
-      const iconWidth = rootEl.value.clientWidth
+      const iconWidth = itemEl.value.$el.clientWidth
 
       if (props.halves) {
         hoveredValue.value = offsetX / iconWidth <= RatingValue.HALF ? RatingValue.HALF : RatingValue.FULL
@@ -93,7 +94,7 @@ export default defineComponent({
 
     return {
       ...useColors(),
-      rootEl,
+      itemEl,
       onEnter,
       onClick,
       onMouseMove,

--- a/packages/ui/src/components/va-rating/components/VaRatingItem/VaRatingItem.vue
+++ b/packages/ui/src/components/va-rating/components/VaRatingItem/VaRatingItem.vue
@@ -1,22 +1,22 @@
 <template>
   <div
+    ref="rootEl"
     class="va-rating-item"
     role="button"
     :tabindex="tabIndexComputed"
     @keyup.enter="onClick"
     @keyup.space="onClick"
+    @mousemove="onMouseMove"
+    @mouseleave="onMouseLeave"
   >
     <slot :props="{ value: visibleValue, onClick }">
       <va-icon
-        ref="itemEl"
         class="va-rating-item__wrapper"
         tabindex="-1"
         tag="button"
         :name="computedIconName"
         :size="$props.size"
         :color="getColor($props.color)"
-        @mousemove="onMouseMove"
-        @mouseleave="onMouseLeave"
         @click="onClick"
       />
     </slot>
@@ -53,7 +53,7 @@ export default defineComponent({
   emits: ['update:modelValue', 'click', 'hover'],
 
   setup (props, { emit }) {
-    const itemEl = ref()
+    const rootEl = ref<HTMLElement>()
     const [modelValue] = useSyncProp('modelValue', props, emit, RatingValue.EMPTY)
     const hoveredValue = ref<number | null>(null)
 
@@ -65,10 +65,9 @@ export default defineComponent({
     })
 
     const onMouseMove = (ev: MouseEvent) => {
-      if (!itemEl.value) { return }
-      ev.stopPropagation()
+      if (!rootEl.value) { return }
       const { offsetX } = ev
-      const iconWidth = itemEl.value.$el.clientWidth
+      const iconWidth = rootEl.value.clientWidth
 
       if (props.halves) {
         hoveredValue.value = offsetX / iconWidth <= RatingValue.HALF ? RatingValue.HALF : RatingValue.FULL
@@ -94,7 +93,7 @@ export default defineComponent({
 
     return {
       ...useColors(),
-      itemEl,
+      rootEl,
       onEnter,
       onClick,
       onMouseMove,

--- a/packages/ui/src/components/va-rating/hooks/useRating.ts
+++ b/packages/ui/src/components/va-rating/hooks/useRating.ts
@@ -2,6 +2,7 @@ import clamp from 'lodash/clamp.js'
 import { useHover } from '../../../composables/useHover'
 import { ref, getCurrentInstance, computed, ExtractPropTypes } from 'vue'
 import { useStateful, useStatefulProps } from '../../../composables/useStateful'
+import { useFormProps } from '../../../composables/useForm'
 import { RatingValue } from '../types'
 
 const getContext = <P extends Record<string, any> = Record<string, any>, E extends string = string>() => {
@@ -23,14 +24,13 @@ export const useRatingProps = {
   hover: { type: Boolean, default: false },
 }
 
-export const useRating = (props: ExtractPropTypes<typeof useRatingProps>) => {
+export const useRating = (props: ExtractPropTypes<typeof useRatingProps> & ExtractPropTypes<typeof useFormProps>) => {
   const { emit } = getContext()
   const { isHovered, onMouseEnter, onMouseLeave } = useHover()
   const { valueComputed: modelValue } = useStateful(props, emit)
 
   const hoveredValue = ref(0)
-
-  const visibleValue = computed(() => props.hover && isHovered.value ? hoveredValue.value : modelValue.value)
+  const visibleValue = computed(() => !props.disabled && !props.readonly && props.hover && isHovered.value ? hoveredValue.value : modelValue.value)
 
   const onItemValueUpdate = (itemIndex: number, newValue: number) => {
     const newModelValue = itemIndex + newValue


### PR DESCRIPTION
Closes #1952 

2 points.

1. Disabled and readonly props must take precedance over the `hover` prop. In other words, the component must not change its visual appearance when hovered in cases when it's either disabled or readonly.

Before:
https://user-images.githubusercontent.com/9782236/175301383-cf3f6c59-3481-474e-9cc6-f1752b8974de.mp4

After:
https://user-images.githubusercontent.com/9782236/175301614-d0cde0d0-49f0-4eca-8b4a-363f285c5838.mp4

2. **UPDATED - not a bug in the component, rather an improperly used demo. Reverted the fix.**

The hover-hitbox for a rating-item is somewhat corrupted. Modified it so that all the calculations happen in the context of the rating-item itself, not the wrapper. LGTM

Before:
https://user-images.githubusercontent.com/9782236/175302180-917ad9ad-bd33-44a0-bb63-694a045bad9e.mp4


After:
https://user-images.githubusercontent.com/9782236/175302056-b9552b2b-d16b-426e-8251-d528ed8f7de6.mp4

And it also allows to widen the item's wrapper when needed.
https://user-images.githubusercontent.com/9782236/175302244-2fc8a5b1-5503-45ac-87d4-82200e01607c.mp4
