### PR TITLE
[#1940] Fixed filtering and sorting of `VaDataTable` when using `items` with nested objects

### DIFF
--- a/packages/docs/src/locales/en/en.json
+++ b/packages/docs/src/locales/en/en.json
@@ -887,8 +887,8 @@
     },
     "VaDataTable": {
       "props": {
-        "columns": "The property `columns` must be an array, that configures the columns of the table. In this case:\n\n `DataTableColumn` &#123; `key: string;` `label?: string;` `headerTitle?: string;` `sortable?: boolean;` `sortingFn?: (a: any, b: any) => number;` `alignHead?: DataTableColumnAlign;` `verticalAlignHead?: DataTableColumnVerticalAlign;` `align?: DataTableColumnAlign;` `verticalAlign?: DataTableColumnVerticalAlign;` `width?: string`&#124;`number;` `classes?: DataTableColumnClasses;` `headerClasses?: DataTableColumnClasses;` `style?: DataTableColumnStyle;` `headerStyle?: DataTableColumnStyle;` &#125;;\n\n `DataTableColumnAlign: 'left'`&#124;`'center'`&#124;`'right'`;\n\n `DataTableColumnVerticalAlign: 'top'`&#124;`'middle'`&#124;`'bottom'`;\n\n `DataTableColumnClasses: string`&#124;`string[]`&#124;`(() => string`&#124;`string[])`;\n\n `DataTableColumnStyle: Record<string, any>`&#124;`(() => Record<string, any>)`",
-        "items": "Array of objects with table data (`DataTableItem: Record<string, any>`). The `va-data-table` automatically calculates the amount and the titles of columns (if not specified otherwise with the `columns` prop) based on these object's keys. When calculating the columns' names based on the item's objects' keys `va-data-table` uses [Lodash's startCase](https://lodash.com/docs/4.17.15#startCase)[[target=_blank]] internally. Faulty values are replaced with an empty string",
+        "columns": "The property `columns` must be an array, that configures the columns of the table",
+        "items": "Array of objects with table data (`DataTableItem` type). The `va-data-table` automatically calculates the amount and the titles of columns (if not specified otherwise with the `columns` prop) based on these object's keys. When calculating the columns' names based on the item's objects' keys `va-data-table` uses [Lodash's startCase](https://lodash.com/docs/4.17.15#startCase)[[target=_blank]] internally. Faulty values are replaced with an empty string",
         "filter": "If a `filter` is provided, only rows in which at least one cell contains the specified value will be displayed. To disable filtering at runtime (clear `filter`), specify an empty string",
         "filterMethod": "A custom filtering function. The function takes the initial value of the currently checked cell (the `source` is a formal parameter) and should return a `boolean` value, indicating whether to include the row containing this cell or not",
         "sortBy": "Sets the column to sort by. Works through the `v-model`",
@@ -912,7 +912,7 @@
         "stickyHeader": "Enables sticky header (sticky header is achieved through CSS with `position: sticky` for `thead`)",
         "stickyFooter": "Enables sticky footer (sticky footer is achieved through CSS with `position: sticky` for `tfoot`)",
         "height": "Sets the height to the table and enables scrolling",
-        "rowBind": "Adds attributes to a table row using `v-bind`. This can be an object type (with attributes that vue supports) or a function that returns such an object. The function receives a table row element (type `Record<string, any>`) and an index as arguments",
+        "rowBind": "Adds attributes to a table row using `v-bind`. This can be an object type (with attributes that vue supports) or a function that returns such an object. The function receives a table row element (`DataTableItem` type) and an index as arguments",
         "cellBind": "Adds attributes to a table cell using `v-bind`. This can be an object type (with attributes that vue supports) or a function that returns such an object. As arguments, the function receives a table cell element (`any` type), a row (`DataTableItem` type), a column (`TableColumn` type), and a row index"
       },
       "events": {

--- a/packages/docs/src/locales/ru/ru.json
+++ b/packages/docs/src/locales/ru/ru.json
@@ -875,8 +875,8 @@
     },
     "VaDataTable": {
       "props": {
-        "columns": "Свойство `columns` должно быть массивом, который настраивает столбцы таблицы. При этом:\n\n `DataTableColumn` &#123; `key: string;` `label?: string;` `headerTitle?: string;` `sortable?: boolean;` `sortingFn?: (a: any, b: any) => number;` `alignHead?: DataTableColumnAlign;` `verticalAlignHead?: DataTableColumnVerticalAlign;` `align?: DataTableColumnAlign;` `verticalAlign?: DataTableColumnVerticalAlign;` `width?: string`&#124;`number;` `classes?: DataTableColumnClasses;` `headerClasses?: DataTableColumnClasses;` `style?: DataTableColumnStyle;` `headerStyle?: DataTableColumnStyle;` &#125;;\n\n `DataTableColumnAlign: 'left'`&#124;`'center'`&#124;`'right'`;\n\n `DataTableColumnVerticalAlign: 'top'`&#124;`'middle'`&#124;`'bottom'`;\n\n `DataTableColumnClasses: string`&#124;`string[]`&#124;`(() => string`&#124;`string[])`;\n\n `DataTableColumnStyle: Record<string, any>`&#124;`(() => Record<string, any>)`",
-        "items": "Массив объектов с табличными данными (`DataTableItem: Record<string, any>`). Таблица `va-data-table` автоматически вычисляет количество и заголовки столбцов (если не указано иное с помощью свойства `columns`) на основе ключей этих объектов. При вычислении имен столбцов на основе ключей объектов элемента `va-data-table` внутренне использует [Lodash's startCase](https://lodash.com/docs/4.17.15#startCase)[[target=_blank]]. Ошибочные значения заменяются пустой строкой",
+        "columns": "Свойство `columns` должно быть массивом, который настраивает столбцы таблицы",
+        "items": "Массив объектов с табличными данными (тип `DataTableItem`). Таблица `va-data-table` автоматически вычисляет количество и заголовки столбцов (если не указано иное с помощью свойства `columns`) на основе ключей этих объектов. При вычислении имен столбцов на основе ключей объектов элемента `va-data-table` внутренне использует [Lodash's startCase](https://lodash.com/docs/4.17.15#startCase)[[target=_blank]]. Ошибочные значения заменяются пустой строкой",
         "filter": "Если предоставляется `filter`, будут отображаться только те строки, в которых хотя бы одна ячейка содержит указанное значение. Чтобы отключить фильтрацию во время выполнения (очистить `filter`), укажите пустую строку",
         "filterMethod": "Пользовательская функция фильтрации. Функция принимает начальное значение текущей проверяемой ячейки (`source` является формальным параметром) и должна возвращать `boolean` значение, указывающее, включать ли строку, содержащую эту ячейку, или нет",
         "sortBy": "Устанавливает столбец, по которому выполнять сортировку. Работает через `v-model`",
@@ -900,7 +900,7 @@
         "stickyHeader": "Включает закрепление `thead` таблицы (путем установки CSS свойства `position: sticky`)",
         "stickyFooter": "Включает закрепление `tfoot` таблицы (путем установки CSS свойства `position: sticky`)",
         "height": "Устанавливает высоту таблицы и включает прокрутку",
-        "rowBind": "Добавляет атрибуты в строку таблицы с помощью `v-bind`. Это может быть тип объекта (с атрибутами, которые поддерживает vue) или функция, которая возвращает такой объект. Функция получает элемент строки таблицы (тип `Record<string, any>`) и индекс в качестве аргументов",
+        "rowBind": "Добавляет атрибуты в строку таблицы с помощью `v-bind`. Это может быть тип объекта (с атрибутами, которые поддерживает vue) или функция, которая возвращает такой объект. Функция получает элемент строки таблицы (тип `DataTableItem`) и индекс в качестве аргументов",
         "cellBind": "Добавляет атрибуты в ячейку таблицы, используя `v-bind`. Это может быть тип объекта (с атрибутами, которые поддерживает vue) или функция, которая возвращает такой объект. В качестве аргументов функция получает элемент ячейки таблицы (`any` тип), строку (тип `DataTableItem`), столбец (тип `TableColumn`) и индекс строки"
       },
       "events": {

--- a/packages/docs/src/page-configs/ui-elements/data-table/examples/CRUD.vue
+++ b/packages/docs/src/page-configs/ui-elements/data-table/examples/CRUD.vue
@@ -14,7 +14,7 @@
         </th>
         <th colspan="1">
           <va-button
-            @click="addNewItem()"
+            @click="addNewItem"
             :disabled="!isNewData"
           >
             Add
@@ -32,8 +32,8 @@
   <va-modal
     :model-value="!!editedItem"
     message="Edit item"
-    @ok="editItem()"
-    @cancel="resetEditedItem()"
+    @ok="editItem"
+    @cancel="resetEditedItem"
   >
     <slot>
       <va-input
@@ -91,7 +91,6 @@ export default defineComponent({
     return {
       items,
       columns,
-
       editedItemId: null,
       editedItem: null,
       createdItem: { ...defaultItem },

--- a/packages/docs/src/page-configs/ui-elements/data-table/examples/CustomSlots.vue
+++ b/packages/docs/src/page-configs/ui-elements/data-table/examples/CustomSlots.vue
@@ -1,11 +1,8 @@
 <template>
   <va-data-table :items="items" :columns="columns">
-    <template #header(address)>Street</template>
-    <template #header(company)>Company Name</template>
-
-    <template #cell(username)="{ rowData }"><va-chip>{{ rowData.username }}</va-chip></template>
-    <template #cell(address)="{ rowData }">{{ rowData.address.street }}</template>
-    <template #cell(company)="{ rowData }">{{ rowData.company.name }}</template>
+    <template #header(street)="{ label }"><va-chip size="small">{{ label }}</va-chip></template>
+    <template #header(companyName)>Company Name</template>
+    <template #cell(street)="{ value }"><va-chip size="small">{{ value }}</va-chip></template>
   </va-data-table>
 </template>
 
@@ -93,8 +90,8 @@ export default defineComponent({
       { key: 'email' },
       { key: 'phone' },
       { key: 'website' },
-      { key: 'address' },
-      { key: 'company' },
+      { key: 'address.street', name: 'street', label: 'Street' },
+      { key: 'company.name', name: 'companyName', label: 'Company Name' },
     ]
 
     return {

--- a/packages/docs/src/page-configs/ui-elements/data-table/examples/Filtering.vue
+++ b/packages/docs/src/page-configs/ui-elements/data-table/examples/Filtering.vue
@@ -21,7 +21,7 @@
     @filtered="filteredCount = $event.items.length"
   />
 
-  <va-alert class="mt-3" border="left">
+  <va-alert class="mt-3" color="info" outline>
     <span>
       Number of filtered items:
       <va-chip>{{ filteredCount }}</va-chip>
@@ -40,40 +40,115 @@ export default defineComponent({
         name: 'Leanne Graham',
         username: 'Bret',
         email: 'Sincere@april.biz',
+        address: {
+          street: 'Kulas Light',
+          suite: 'Apt. 556',
+          city: 'Gwenborough',
+          zipcode: '92998-3874',
+          geo: {
+            lat: '-37.3159',
+            lng: '81.1496',
+          },
+        },
         phone: '1-770-736-8031 x56442',
         website: 'hildegard.org',
+        company: {
+          name: 'Romaguera-Crona',
+          catchPhrase: 'Multi-layered client-server neural-net',
+          bs: 'harness real-time e-markets',
+        },
       },
       {
         id: 2,
         name: 'Ervin Howell',
         username: 'Antonette',
         email: 'Shanna@melissa.tv',
+        address: {
+          street: 'Victor Plains',
+          suite: 'Suite 879',
+          city: 'Wisokyburgh',
+          zipcode: '90566-7771',
+          geo: {
+            lat: '-43.9509',
+            lng: '-34.4618',
+          },
+        },
         phone: '010-692-6593 x09125',
         website: 'anastasia.net',
+        company: {
+          name: 'Deckow-Crist',
+          catchPhrase: 'Proactive didactic contingency',
+          bs: 'synergize scalable supply-chains',
+        },
       },
       {
         id: 3,
         name: 'Clementine Bauch',
         username: 'Samantha',
         email: 'Nathan@yesenia.net',
+        address: {
+          street: 'Douglas Extension',
+          suite: 'Suite 847',
+          city: 'McKenziehaven',
+          zipcode: '59590-4157',
+          geo: {
+            lat: '-68.6102',
+            lng: '-47.0653',
+          },
+        },
         phone: '1-463-123-4447',
         website: 'ramiro.info',
+        company: {
+          name: 'Romaguera-Jacobson',
+          catchPhrase: 'Face to face bifurcated interface',
+          bs: 'e-enable strategic applications',
+        },
       },
       {
         id: 4,
         name: 'Patricia Lebsack',
         username: 'Karianne',
         email: 'Julianne.OConner@kory.org',
+        address: {
+          street: 'Hoeger Mall',
+          suite: 'Apt. 692',
+          city: 'South Elvis',
+          zipcode: '53919-4257',
+          geo: {
+            lat: '29.4572',
+            lng: '-164.2990',
+          },
+        },
         phone: '493-170-9623 x156',
         website: 'kale.biz',
+        company: {
+          name: 'Robel-Corkery',
+          catchPhrase: 'Multi-tiered zero tolerance productivity',
+          bs: 'transition cutting-edge web services',
+        },
       },
       {
         id: 5,
         name: 'Chelsey Dietrich',
         username: 'Kamren',
         email: 'Lucio_Hettinger@annie.ca',
+        address: {
+          street: 'Skiles Walks',
+          suite: 'Suite 351',
+          city: 'Roscoeview',
+          zipcode: '33263',
+          geo: {
+            lat: '-31.8129',
+            lng: '62.5342',
+          },
+        },
         phone: '(254)954-1289',
         website: 'demarco.info',
+        company: {
+          name: 'Keebler LLC',
+          catchPhrase: 'User-centric fault-tolerant solution',
+          bs: 'revolutionize end-to-end systems',
+        },
       },
     ]
 
@@ -82,7 +157,7 @@ export default defineComponent({
       { key: 'username', sortable: true },
       { key: 'name', sortable: true },
       { key: 'email', sortable: true },
-      { key: 'phone' },
+      { key: 'address.zipcode', label: 'Zipcode' },
     ]
 
     return {

--- a/packages/docs/src/page-configs/ui-elements/data-table/examples/Other.vue
+++ b/packages/docs/src/page-configs/ui-elements/data-table/examples/Other.vue
@@ -109,7 +109,7 @@
     </template>
   </va-data-table>
 
-  <va-alert v-if="isTableRowsClickable" class="mt-3" border="left">
+  <va-alert v-if="isTableRowsClickable" class="mt-3" color="info" outline>
     <span>
       Last row click event (id, event type):
       <va-chip v-if="rowId">{{ rowId }}</va-chip>

--- a/packages/docs/src/page-configs/ui-elements/data-table/examples/Selection.vue
+++ b/packages/docs/src/page-configs/ui-elements/data-table/examples/Selection.vue
@@ -31,7 +31,7 @@
     @selectionChange="selectedItemsEmitted = $event.currentSelectedItems"
   />
 
-  <va-alert class="mt-3" border="left">
+  <va-alert class="mt-3" color="info" outline>
     <span>
       Selected items (click to unselect):
       <va-chip

--- a/packages/docs/src/page-configs/ui-elements/data-table/examples/Sorting.vue
+++ b/packages/docs/src/page-configs/ui-elements/data-table/examples/Sorting.vue
@@ -4,7 +4,7 @@
       class="flex mb-2 md6"
       v-model="sortBy"
       label="Sort by"
-      :options="sortByOptions"
+      :options="sortByOptions()"
     />
 
     <va-select
@@ -195,7 +195,9 @@ export default defineComponent({
 
   methods: {
     sortByOptions () {
-      return this.columns.map(({ name, key }) => name || key)
+      return this.columns
+        .map(({ name, key, sortable }) => sortable && (name || key))
+        .filter(Boolean)
     },
   },
 })

--- a/packages/docs/src/page-configs/ui-elements/data-table/examples/Sorting.vue
+++ b/packages/docs/src/page-configs/ui-elements/data-table/examples/Sorting.vue
@@ -4,7 +4,7 @@
       class="flex mb-2 md6"
       v-model="sortBy"
       label="Sort by"
-      :options="sortByOptions()"
+      :options="sortByOptions"
     />
 
     <va-select
@@ -29,7 +29,7 @@
     "
   />
 
-  <va-alert class="mt-3" border="left">
+  <va-alert class="mt-3" color="info" outline>
     <span v-if="sortingOrder">
       Sorted items order (showing id):
       <va-chip v-show="!!sortedRowsEmitted.length">{{ sortedRowsEmitted.join(' --> ') }}</va-chip>
@@ -55,35 +55,115 @@ export default defineComponent({
         name: 'Leanne Graham',
         username: 'Bret',
         email: 'Sincere@april.biz',
+        address: {
+          street: 'Kulas Light',
+          suite: 'Apt. 556',
+          city: 'Gwenborough',
+          zipcode: '92998-3874',
+          geo: {
+            lat: '-37.3159',
+            lng: '81.1496',
+          },
+        },
         phone: '1-770-736-8031 x56442',
+        website: 'hildegard.org',
+        company: {
+          name: 'Romaguera-Crona',
+          catchPhrase: 'Multi-layered client-server neural-net',
+          bs: 'harness real-time e-markets',
+        },
       },
       {
         id: 2,
         name: 'Ervin Howell',
         username: 'Antonette',
         email: 'Shanna@melissa.tv',
+        address: {
+          street: 'Victor Plains',
+          suite: 'Suite 879',
+          city: 'Wisokyburgh',
+          zipcode: '90566-7771',
+          geo: {
+            lat: '-43.9509',
+            lng: '-34.4618',
+          },
+        },
         phone: '010-692-6593 x09125',
+        website: 'anastasia.net',
+        company: {
+          name: 'Deckow-Crist',
+          catchPhrase: 'Proactive didactic contingency',
+          bs: 'synergize scalable supply-chains',
+        },
       },
       {
         id: 3,
         name: 'Clementine Bauch',
         username: 'Samantha',
         email: 'Nathan@yesenia.net',
+        address: {
+          street: 'Douglas Extension',
+          suite: 'Suite 847',
+          city: 'McKenziehaven',
+          zipcode: '59590-4157',
+          geo: {
+            lat: '-68.6102',
+            lng: '-47.0653',
+          },
+        },
         phone: '1-463-123-4447',
+        website: 'ramiro.info',
+        company: {
+          name: 'Romaguera-Jacobson',
+          catchPhrase: 'Face to face bifurcated interface',
+          bs: 'e-enable strategic applications',
+        },
       },
       {
         id: 4,
         name: 'Patricia Lebsack',
         username: 'Karianne',
         email: 'Julianne.OConner@kory.org',
+        address: {
+          street: 'Hoeger Mall',
+          suite: 'Apt. 692',
+          city: 'South Elvis',
+          zipcode: '53919-4257',
+          geo: {
+            lat: '29.4572',
+            lng: '-164.2990',
+          },
+        },
         phone: '493-170-9623 x156',
+        website: 'kale.biz',
+        company: {
+          name: 'Robel-Corkery',
+          catchPhrase: 'Multi-tiered zero tolerance productivity',
+          bs: 'transition cutting-edge web services',
+        },
       },
       {
         id: 5,
         name: 'Chelsey Dietrich',
         username: 'Kamren',
         email: 'Lucio_Hettinger@annie.ca',
+        address: {
+          street: 'Skiles Walks',
+          suite: 'Suite 351',
+          city: 'Roscoeview',
+          zipcode: '33263',
+          geo: {
+            lat: '-31.8129',
+            lng: '62.5342',
+          },
+        },
         phone: '(254)954-1289',
+        website: 'demarco.info',
+        company: {
+          name: 'Keebler LLC',
+          catchPhrase: 'User-centric fault-tolerant solution',
+          bs: 'revolutionize end-to-end systems',
+        },
       },
     ]
 
@@ -91,7 +171,7 @@ export default defineComponent({
       { key: 'id', sortable: true },
       { key: 'username', sortable: true },
       { key: 'name', sortable: true },
-      { key: 'email', sortable: true },
+      { key: 'address.city', name: 'city', label: 'City', sortable: true },
       { key: 'phone' },
     ]
 
@@ -115,7 +195,7 @@ export default defineComponent({
 
   methods: {
     sortByOptions () {
-      return this.columns.map(({ key }) => key)
+      return this.columns.map(({ name, key }) => name || key)
     },
   },
 })

--- a/packages/ui/src/components/va-data-table/VaDataTable.new.demo.vue
+++ b/packages/ui/src/components/va-data-table/VaDataTable.new.demo.vue
@@ -13,9 +13,6 @@
       >
         <template #header(address)>Street</template>
         <template #header(company)>Company Name</template>
-
-        <template #cell(address)="{ rowData }">{{ rowData.address.street }}</template>
-        <template #cell(company)="{ rowData }">{{ rowData.company.name }}</template>
       </va-data-table>
 
       <va-alert class="mt-3" border="left">
@@ -108,9 +105,9 @@
         <option
           v-for="column in columns"
           :key="column.key"
-          :value="column.key"
+          :value="column.name || column.key"
         >
-          {{ column.key }}
+          {{ column.name || column.key }}
         </option>
       </select><br>
 
@@ -127,11 +124,8 @@
         v-model:sort-by="sortBy"
         v-model:sorting-order="sortingOrder"
       >
-        <template #header(address)>Street</template>
-        <template #header(company)>Company Name</template>
-
-        <template #cell(address)="{ rowData }">{{ rowData.address.street }}</template>
-        <template #cell(company)="{ rowData }">{{ rowData.company.name }}</template>
+        <template #header(street)="{ label }">{{ label }}</template>
+        <template #header(companyName)>Company Name</template>
       </va-data-table>
     </VbCard>
 
@@ -359,8 +353,8 @@ export default defineComponent({
       { key: 'email', sortable: true },
       { key: 'name', sortable: true },
       { key: 'id', sortable: true, sortingFn: () => -1 },
-      { key: 'address', sortable: true },
-      { key: 'company', sortable: true },
+      { key: 'address.street', name: 'street', label: 'Street', sortable: true },
+      { key: 'company.name', name: 'companyName', sortable: true },
     ]
 
     return {

--- a/packages/ui/src/components/va-data-table/VaDataTable.vue
+++ b/packages/ui/src/components/va-data-table/VaDataTable.vue
@@ -44,9 +44,9 @@
 
           <th
             v-for="column in columnsComputed"
-            :key="column.key"
+            :key="column.name"
             scope="col"
-            :aria-sort="getColumnAriaSortOrder(column.key)"
+            :aria-sort="getColumnAriaSortOrder(column.name)"
             :aria-label="column.sortable ? `sort column by ${column.label}` : undefined"
             :title="column.thTitle"
             class="va-data-table__table-th"
@@ -56,11 +56,11 @@
             @keydown.enter.stop="column.sortable && toggleSorting(column)"
           >
             <div class="va-data-table__table-th-wrapper" :tabindex="column.sortable ? 0 : -1">
-              <span v-if="`header(${column.key})` in $slots">
-                <slot :name="`header(${column.key})`" v-bind="column" />
+              <span v-if="`header(${column.name})` in $slots">
+                <slot :name="`header(${column.name})`" v-bind="{ label: column.label, key: column.key }" />
               </span>
 
-              <slot v-else name="header" v-bind="column">
+              <slot v-else name="header" v-bind="{ label: column.label, key: column.key }">
                 <span>{{ column.label }}</span>
               </slot>
 
@@ -74,7 +74,7 @@
                   :name="sortingOrderSync === 'asc' ? 'expand_less' : 'expand_more'"
                   size="small"
                   class="va-data-table__table-th-sorting-icon"
-                  :class="{ active: sortBySync === column.key && sortingOrderSync !== null }"
+                  :class="{ active: sortBySync === column.name && sortingOrderSync !== null }"
                 />
               </div>
             </div>
@@ -145,15 +145,15 @@
 
             <td
               v-for="cell in row.cells"
-              :key="`table-cell_${cell.column.key + cell.rowIndex}`"
+              :key="`table-cell_${cell.column.name + cell.rowIndex}`"
               class="va-data-table__table-td"
               :class="getClass(cell.column.tdClass)"
               :style="[getCellCSSVariables(cell), getStyle(cell.column.tdStyle)]"
               v-bind="getCellBind(cell, row)"
             >
               <slot
-                v-if="`cell(${cell.column.key})` in $slots"
-                :name="`cell(${cell.column.key})`"
+                v-if="`cell(${cell.column.name})` in $slots"
+                :name="`cell(${cell.column.name})`"
                 v-bind="cell"
               />
 
@@ -191,7 +191,7 @@
 
           <th
             v-for="column in columnsComputed"
-            :key="column.key"
+            :key="column.name"
             :title="column.thTitle"
             :aria-label="allowFooterSorting && column.sortable ? `sort column by ${column.label}` : undefined"
             class="va-data-table__table-th"
@@ -201,8 +201,8 @@
             @keydown.enter.stop="allowFooterSorting && column.sortable && toggleSorting(column)"
           >
             <div class="va-data-table__table-th-wrapper" :tabindex="allowFooterSorting && column.sortable ? 0 : -1">
-              <span v-if="`footer(${column.key})` in $slots">
-                <slot :name="`footer(${column.key})`" v-bind="column" />
+              <span v-if="`footer(${column.name})` in $slots">
+                <slot :name="`footer(${column.name})`" v-bind="{ label: column.label, key: column.key }" />
               </span>
 
               <slot v-else name="footer" v-bind="column">
@@ -218,7 +218,7 @@
                   :name="sortingOrderSync === 'asc' ? 'expand_less' : 'expand_more'"
                   size="small"
                   class="va-data-table__table-th-sorting-icon"
-                  :class="{ active: sortBySync === column.key && sortingOrderSync !== null }"
+                  :class="{ active: sortBySync === column.name && sortingOrderSync !== null }"
                 />
               </div>
             </div>
@@ -402,7 +402,7 @@ export default defineComponent({
       class: pick(props, ['striped', 'selectable', 'hoverable', 'clickable']),
     }) as TableHTMLAttributes)
 
-    const getColumnAriaSortOrder = (columnKey: string) => sortingOrderSync.value && sortBySync.value === columnKey
+    const getColumnAriaSortOrder = (columnName: string) => sortingOrderSync.value && sortBySync.value === columnName
       ? sortingOrderSync.value === 'asc' ? 'ascending' : 'descending'
       : 'none'
 

--- a/packages/ui/src/components/va-data-table/hooks/useColumns.ts
+++ b/packages/ui/src/components/va-data-table/hooks/useColumns.ts
@@ -17,6 +17,7 @@ export const buildTableColumn = (source: DataTableColumnSource, initialIndex: nu
     source,
     initialIndex,
     key: input.key,
+    name: input.name || input.key,
     label: input.label || startCase(input.key),
     thTitle: input.thTitle || input.headerTitle || input.label || startCase(input.key),
     sortable: input.sortable || false,

--- a/packages/ui/src/components/va-data-table/hooks/useFilterable.ts
+++ b/packages/ui/src/components/va-data-table/hooks/useFilterable.ts
@@ -27,7 +27,7 @@ export default function useFilterable (
 
     return rawRows.value.filter(row => row.cells.some(cell => {
       return typeof props.filterMethod === 'function'
-        ? props.filterMethod(cell.rowData[cell.column.key])
+        ? props.filterMethod(cell.source)
         : cell.value.toLowerCase().includes(props.filter.toLowerCase())
     }))
   })

--- a/packages/ui/src/components/va-data-table/hooks/useRows.ts
+++ b/packages/ui/src/components/va-data-table/hooks/useRows.ts
@@ -1,5 +1,7 @@
 import { Ref, computed } from 'vue'
 
+import { getValueByPath } from '../../../services/utils'
+
 import { DataTableColumnInternal, DataTableItem, DataTableCell, DataTableRow } from '../types'
 
 interface useRowsProps {
@@ -7,13 +9,16 @@ interface useRowsProps {
   [prop: string]: unknown
 }
 
-const buildTableCell = (rowIndex: number, column: DataTableColumnInternal, rowData: DataTableItem): DataTableCell => ({
-  rowIndex,
-  rowData,
-  column,
-  source: rowData[column.key],
-  value: rowData[column.key]?.toString?.() || '',
-})
+const buildTableCell = (rowIndex: number, column: DataTableColumnInternal, rowData: DataTableItem): DataTableCell => {
+  const source = getValueByPath(rowData, column.key)
+  return {
+    rowIndex,
+    rowData,
+    column,
+    source,
+    value: source?.toString?.() || '',
+  }
+}
 
 const buildTableRow = (source: DataTableItem, initialIndex: number, columns: DataTableColumnInternal[]): DataTableRow => ({
   source,

--- a/packages/ui/src/components/va-data-table/hooks/useSortable.ts
+++ b/packages/ui/src/components/va-data-table/hooks/useSortable.ts
@@ -64,7 +64,7 @@ export default function useSortable (
       return filteredRows.value
     }
 
-    const column = columns.value.find(column => column.key === sortBySync.value)
+    const column = columns.value.find(column => column.name === sortBySync.value)
 
     if (!column || !column.sortable) {
       return filteredRows.value
@@ -73,10 +73,10 @@ export default function useSortable (
     const columnIndex = columns.value.indexOf(column)
 
     return [...filteredRows.value].sort((a, b) => {
-      const firstValString = a.cells[columnIndex].value
-      const secondValString = b.cells[columnIndex].value
-      const firstValInitial = a.cells[columnIndex].rowData[a.cells[columnIndex].column.key]
-      const secondValInitial = b.cells[columnIndex].rowData[a.cells[columnIndex].column.key]
+      const firstValue = a.cells[columnIndex].value
+      const secondValue = b.cells[columnIndex].value
+      const firstSource = a.cells[columnIndex].source
+      const secondSource = b.cells[columnIndex].source
 
       if (sortingOrderSync.value === null) {
         return a.initialIndex - b.initialIndex
@@ -85,8 +85,8 @@ export default function useSortable (
 
         return sortingOrderRatio * (
           typeof column.sortingFn === 'function'
-            ? column.sortingFn(firstValInitial, secondValInitial)
-            : firstValString.localeCompare(secondValString)
+            ? column.sortingFn(firstSource, secondSource)
+            : firstValue.localeCompare(secondValue)
         )
       }
     })
@@ -107,7 +107,7 @@ export default function useSortable (
   // Sets the clicked heading's column as a one to sort by and toggles the sorting order from "asc" to "desc" to `null`
   // (un-sorted) if the same column is clicked again or sets sorting order to "asc" if some other column is chosen.
   function toggleSorting (column: DataTableColumnInternal) {
-    if (column.key === sortBySync.value) {
+    if (column.name === sortBySync.value) {
       if (sortingOrderSync.value === null) {
         sortingOrderSync.value = 'asc'
       } else if (sortingOrderSync.value === 'asc') {
@@ -116,7 +116,7 @@ export default function useSortable (
         sortingOrderSync.value = null
       }
     } else {
-      sortBySync.value = column.key
+      sortBySync.value = column.name
       sortingOrderSync.value = 'asc'
     }
   }

--- a/packages/ui/src/components/va-data-table/types.ts
+++ b/packages/ui/src/components/va-data-table/types.ts
@@ -8,7 +8,7 @@ export type DataTableColumnStyle = unknown | (() => unknown)
 // should look like an array of the following objects (and/or strings)
 export type DataTableColumn = {
   [key: string]: any
-  key: string // name of an item's property
+  key: string // name of an item's property: 'userName', 'address.zipCode'
   name?: string // column unique name (used in slots)
   label?: string // what to display in the respective heading
   thTitle?: string // <th>'s `title` attribute's value

--- a/packages/ui/src/components/va-data-table/types.ts
+++ b/packages/ui/src/components/va-data-table/types.ts
@@ -9,6 +9,7 @@ export type DataTableColumnStyle = unknown | (() => unknown)
 export type DataTableColumn = {
   [key: string]: any
   key: string // name of an item's property
+  name?: string // column unique name (used in slots)
   label?: string // what to display in the respective heading
   thTitle?: string // <th>'s `title` attribute's value
   sortable?: boolean // whether the table can be sorted by that column
@@ -59,6 +60,7 @@ export interface DataTableColumnInternal {
   source: DataTableColumnSource
   initialIndex: number
   key: string
+  name: string
   label: string
   thTitle: string
   sortable: boolean
@@ -79,9 +81,9 @@ export type DataTableItem = Record<string, any>
 // the inner representation of table cells
 export interface DataTableCell {
   rowIndex: number
-  rowData: DataTableItem;
+  rowData: DataTableItem
   column: DataTableColumnInternal
-  source: any;
+  source: any
   value: string
 }
 


### PR DESCRIPTION
## Description
close #1940

changes:
- [x] add `name` key to `columns`
- [x] update `key` key in `columns`
- [x] update examples

![chrome-capture-2022-5-23](https://user-images.githubusercontent.com/55198465/175236633-5a6ae457-06da-46b3-968b-f68c07adc6ee.gif)

![chrome-capture-2022-5-23 (1)](https://user-images.githubusercontent.com/55198465/175236977-563d5f59-b516-4ffb-9700-97101a45f22c.gif)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
