### PR TITLE
[#1995] Added `VaRating` item focus outline

### DIFF
--- a/packages/ui/src/components/va-rating/components/VaRatingItem/VaRatingItem.vue
+++ b/packages/ui/src/components/va-rating/components/VaRatingItem/VaRatingItem.vue
@@ -133,9 +133,6 @@ export default defineComponent({
 
   &:focus {
     @include focus-outline();
-    // in purpose outline not to touch closest rating items
-    outline-offset: -2px;
-    transform: scale(1.1);
   }
 
   &__wrapper {

--- a/packages/ui/src/components/va-rating/components/VaRatingItem/VaRatingItem.vue
+++ b/packages/ui/src/components/va-rating/components/VaRatingItem/VaRatingItem.vue
@@ -132,6 +132,9 @@ export default defineComponent({
   display: inline-block;
 
   &:focus {
+    @include focus-outline();
+    // in purpose outline not to touch closest rating items
+    outline-offset: -2px;
     transform: scale(1.1);
   }
 


### PR DESCRIPTION
Close: #1995 

## Description
Added outline for rating items focus state.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
