### PR TITLE
[#2018] usePopover - add default position

### DIFF
--- a/packages/ui/src/composables/useDomRect.ts
+++ b/packages/ui/src/composables/useDomRect.ts
@@ -24,6 +24,14 @@ export const useDomRect = (target: Ref<HTMLElement | undefined>) => {
     prev = rect
   })
 
+  watch(target, (newVal) => {
+    if (newVal) {
+      domRect.value = newVal.getBoundingClientRect()
+    } else {
+      domRect.value = null
+    }
+  })
+
   return {
     domRect,
   }

--- a/packages/ui/src/composables/usePopover.ts
+++ b/packages/ui/src/composables/usePopover.ts
@@ -144,6 +144,8 @@ export const usePopover = (
   const css = {
     width: 'max-content',
     position: 'absolute',
+    top: 0,
+    left: 0,
   }
 
   const updateContentCSS = () => {

--- a/packages/ui/src/composables/usePopover.ts
+++ b/packages/ui/src/composables/usePopover.ts
@@ -15,7 +15,7 @@ type AlignCoords = { main: number, cross: number }
 export const placementsPositions = ['top', 'bottom', 'left', 'right']
   .reduce((acc, position) => [...acc, position, `${position}-start`, `${position}-end`, `${position}-center`], ['auto'] as string[])
 
-const coordsToCss = ({ x, y }: Coords) => ({ transform: `translate(${x}px, ${y}px)` })
+const coordsToCss = ({ x, y }: Coords) => ({ left: `${x}px`, top: `${y}px` })
 
 const parsePlacement = (placement: Placement) => {
   const [position, align] = placement.split('-') as [PlacementPosition, PlacementAlignment | undefined]
@@ -144,8 +144,6 @@ export const usePopover = (
   const css = {
     width: 'max-content',
     position: 'absolute',
-    top: 0,
-    left: 0,
   }
 
   const updateContentCSS = () => {


### PR DESCRIPTION
Close https://github.com/epicmaxco/vuestic-ui/issues/2018

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail -->
va-dropdown__content-wrapper without `top` and `left` properties might position wrongly, which causes the original issue

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
