### PR TITLE
Fix#2028/fix sidebar color

### DIFF
--- a/packages/docs/src/components/sidebar/Sidebar.vue
+++ b/packages/docs/src/components/sidebar/Sidebar.vue
@@ -213,14 +213,6 @@ export default defineComponent({
       font-size: 16px;
       line-height: 20px;
     }
-
-    .va-sidebar-item--active {
-      color: var(--va-dark, #323742) !important;
-
-      .va-sidebar-item-title {
-        color: var(--va-dark, #323742) !important;
-      }
-    }
   }
 
   .va-sidebar__child {

--- a/packages/docs/src/page-configs/ui-elements/sidebar/examples/Color.vue
+++ b/packages/docs/src/page-configs/ui-elements/sidebar/examples/Color.vue
@@ -13,7 +13,6 @@
         :key="item.title"
         :active="item.active"
         active-color="background"
-        text-color="white"
       >
         <va-sidebar-item-content>
           <va-icon :name="item.icon" />

--- a/packages/docs/src/page-configs/ui-elements/sidebar/examples/Gradient.vue
+++ b/packages/docs/src/page-configs/ui-elements/sidebar/examples/Gradient.vue
@@ -13,7 +13,6 @@
         :key="item.title"
         :active="item.active"
         active-color="background"
-        text-color="background"
       >
         <va-sidebar-item-content>
           <va-icon :name="item.icon" />

--- a/packages/ui/src/components/va-collapse/VaCollapse.vue
+++ b/packages/ui/src/components/va-collapse/VaCollapse.vue
@@ -1,13 +1,7 @@
 <template>
   <div class="va-collapse" :class="computedClasses">
     <div
-      class="va-collapse__header"
-      role="button"
-      :tabindex="tabIndexComputed"
-      :aria-expanded="computedModelValue"
-      :id="headerIdComputed"
-      :aria-controls="panelIdComputed"
-      :aria-disabled="$props.disabled"
+      class="va-collapse__header-wrapper"
       v-on="keyboardFocusListeners"
       @focus="$emit('focus')"
       @click="toggle"
@@ -19,10 +13,13 @@
         v-bind="{
           value: computedModelValue,
           hasKeyboardFocus: hasKeyboardFocus,
+          bind: headerAttributes,
+          attributes: headerAttributes,
         }"
       >
         <div
-          class="va-collapse__header__content"
+          v-bind="headerAttributes"
+          class="va-collapse__header"
           :style="headerStyle"
         >
           <va-icon
@@ -133,6 +130,15 @@ export default defineComponent({
     const panelIdComputed = computed(() => `panel-${uniqueId.value}`)
     const tabIndexComputed = computed(() => props.disabled ? -1 : 0)
 
+    const headerAttributes = computed(() => ({
+      id: headerIdComputed.value,
+      tabIndexComputed: tabIndexComputed.value,
+      ariaControls: panelIdComputed.value,
+      ariaExpanded: computedModelValue.value,
+      ariaDisabled: props.disabled,
+      role: 'button',
+    }))
+
     return {
       body,
       height,
@@ -146,6 +152,7 @@ export default defineComponent({
       textColorComputed,
 
       headerIdComputed,
+      headerAttributes,
       panelIdComputed,
       tabIndexComputed,
 
@@ -193,18 +200,16 @@ export default defineComponent({
   }
 
   &__header {
-    &__content {
-      display: var(--va-collapse-header-content-display);
-      justify-content: var(--va-collapse-header-content-justify-content);
-      cursor: var(--va-collapse-header-content-cursor);
-      background-color: var(--va-collapse-header-content-background-color);
-      box-shadow: var(--va-collapse-header-content-box-shadow, var(--va-block-box-shadow));
-      border-radius: var(--va-collapse-header-content-border-radius, var(--va-block-border-radius));
-      align-items: var(--va-collapse-header-content-align-items);
-      padding-top: var(--va-collapse-header-content-padding-top);
-      padding-bottom: var(--va-collapse-header-content-padding-bottom);
-      padding-left: var(--va-collapse-header-content-padding-left);
-    }
+    display: var(--va-collapse-header-content-display);
+    justify-content: var(--va-collapse-header-content-justify-content);
+    cursor: var(--va-collapse-header-content-cursor);
+    background-color: var(--va-collapse-header-content-background-color);
+    box-shadow: var(--va-collapse-header-content-box-shadow, var(--va-block-box-shadow));
+    border-radius: var(--va-collapse-header-content-border-radius, var(--va-block-border-radius));
+    align-items: var(--va-collapse-header-content-align-items);
+    padding-top: var(--va-collapse-header-content-padding-top);
+    padding-bottom: var(--va-collapse-header-content-padding-bottom);
+    padding-left: var(--va-collapse-header-content-padding-left);
 
     &__text {
       width: var(--va-collapse-header-content-text-width);
@@ -230,12 +235,10 @@ export default defineComponent({
 
     .va-collapse {
       &__header {
-        &__content {
-          border-radius: var(--va-collapse-solid-header-content-border-radius, var(--va-block-border-radius));
-          transition: var(--va-collapse-solid-header-content-transition);
-          box-shadow: var(--va-collapse-solid-header-content-box-shadow, var(--va-block-box-shadow));
-          background-color: var(--va-collapse-solid-header-content-background-color);
-        }
+        border-radius: var(--va-collapse-solid-header-content-border-radius, var(--va-block-border-radius));
+        transition: var(--va-collapse-solid-header-content-transition);
+        box-shadow: var(--va-collapse-solid-header-content-box-shadow, var(--va-block-box-shadow));
+        background-color: var(--va-collapse-solid-header-content-background-color);
       }
 
       &__body {

--- a/packages/ui/src/components/va-collapse/_variables.scss
+++ b/packages/ui/src/components/va-collapse/_variables.scss
@@ -26,7 +26,7 @@
   --va-collapse-solid-header-content-background-color: #f5f8f9;
   --va-collapse-solid-header-content-box-shadow: none;
   --va-collapse-solid-header-content-border-radius: 0.375rem;
-  --va-collapse-solid-header-content-transition: ease-in 0.3s;
+  --va-collapse-solid-header-content-transition: background-color ease-in 0.3s;
   --va-collapse-solid-body-border-radius: 0 0 0.375rem 0.375rem;
   --va-collapse-solid-body-margin-top: 0;
 }

--- a/packages/ui/src/components/va-sidebar/VaSidebar.vue
+++ b/packages/ui/src/components/va-sidebar/VaSidebar.vue
@@ -28,9 +28,9 @@ export default defineComponent({
     minimized: { type: Boolean, default: false },
     hoverable: { type: Boolean, default: false },
     position: {
-      type: String as PropType<'top' | 'bottom' | 'left' | 'right'>,
+      type: String as PropType<'left' | 'right'>,
       default: 'left',
-      validator: (v: string) => ['top', 'bottom', 'left', 'right'].includes(v),
+      validator: (v: string) => ['left', 'right'].includes(v),
     },
     width: { type: String, default: '16rem' },
     minimizedWidth: { type: String, default: '4rem' },

--- a/packages/ui/src/components/va-sidebar/VaSidebar.vue
+++ b/packages/ui/src/components/va-sidebar/VaSidebar.vue
@@ -33,7 +33,7 @@ export default defineComponent({
       validator: (v: string) => ['top', 'bottom', 'left', 'right'].includes(v),
     },
     width: { type: String, default: '16rem' },
-    minimizedWidth: { type: String, default: '2.5rem' },
+    minimizedWidth: { type: String, default: '4rem' },
     modelValue: { type: Boolean, default: true },
   },
   setup (props) {
@@ -100,6 +100,8 @@ export default defineComponent({
   font-family: var(--va-font-family);
 
   &__menu {
+    display: flex;
+    flex-direction: column;
     max-height: var(--va-sidebar-menu-max-height);
     margin-bottom: var(--va-sidebar-menu-margin-bottom);
     list-style: var(--va-sidebar-menu-list-style);
@@ -112,7 +114,7 @@ export default defineComponent({
     left: 0;
 
     .va-sidebar__title {
-      opacity: 0;
+      display: none;
     }
   }
 

--- a/packages/ui/src/components/va-sidebar/VaSidebarItem/VaSidebarItem.vue
+++ b/packages/ui/src/components/va-sidebar/VaSidebarItem/VaSidebarItem.vue
@@ -99,9 +99,8 @@ export default defineComponent({
 .va-sidebar__item {
   border-left: var(--va-sidebar-item-active-border-size) solid transparent;
   padding-right: var(--va-sidebar-item-active-border-size);
-  display: inline-block;
-  width: 100%;
   font-family: var(--va-font-family);
+  box-sizing: border-box;
 
   &:visited {
     color: currentColor;

--- a/packages/ui/src/components/va-sidebar/VaSidebarItem/VaSidebarItem.vue
+++ b/packages/ui/src/components/va-sidebar/VaSidebarItem/VaSidebarItem.vue
@@ -107,9 +107,5 @@ export default defineComponent({
   &:visited {
     color: currentColor;
   }
-
-  &:focus {
-    @include focus-outline();
-  }
 }
 </style>

--- a/packages/ui/src/components/va-sidebar/VaSidebarItem/VaSidebarItem.vue
+++ b/packages/ui/src/components/va-sidebar/VaSidebarItem/VaSidebarItem.vue
@@ -99,6 +99,8 @@ export default defineComponent({
 .va-sidebar__item {
   border-left: var(--va-sidebar-item-active-border-size) solid transparent;
   padding-right: var(--va-sidebar-item-active-border-size);
+  display: inline-block;
+  width: 100%;
   font-family: var(--va-font-family);
   box-sizing: border-box;
 

--- a/packages/ui/src/components/va-sidebar/VaSidebarItem/VaSidebarItem.vue
+++ b/packages/ui/src/components/va-sidebar/VaSidebarItem/VaSidebarItem.vue
@@ -47,16 +47,8 @@ export default defineComponent({
     const { sidebarColor } = useSidebarItem()
 
     const backgroundColorComputed = computed(() => {
-      if (isHovered.value) {
-        return getHoverColor(getColor(props.hoverColor || props.activeColor))
-      }
-
-      if (props.active) {
-        return getColor(props.activeColor)
-      }
-
-      if (hasKeyboardFocus.value) {
-        return getFocusColor(getColor(props.hoverColor || props.activeColor))
+      if (props.active && !isHovered.value && !hasKeyboardFocus.value) {
+        return getColor(getColor(props.activeColor))
       }
 
       return getColor(sidebarColor.value)
@@ -65,16 +57,22 @@ export default defineComponent({
     const { textColorComputed } = useTextColor(backgroundColorComputed)
 
     const computedStyle = computed(() => {
-      const style: StyleValue = {}
-
-      style.color = textColorComputed.value
-
-      if (isHovered.value || props.active || hasKeyboardFocus.value) {
-        style.backgroundColor = backgroundColorComputed.value
+      const style: StyleValue = {
+        color: props.textColor,
       }
 
       if (props.active) {
+        style.backgroundColor = backgroundColorComputed.value
+        style.color = textColorComputed.value
         style.borderColor = getColor(props.borderColor || props.activeColor)
+      }
+
+      if (hasKeyboardFocus.value) {
+        style.backgroundColor = getFocusColor(getColor(props.hoverColor || props.activeColor))
+      }
+
+      if (isHovered.value) {
+        style.backgroundColor = getHoverColor(getColor(props.hoverColor || props.activeColor))
       }
 
       return style
@@ -96,6 +94,7 @@ export default defineComponent({
 
 <style lang="scss">
 @import "../variables";
+@import "../../../styles/resources";
 
 .va-sidebar__item {
   border-left: var(--va-sidebar-item-active-border-size) solid transparent;
@@ -103,5 +102,13 @@ export default defineComponent({
   display: inline-block;
   width: 100%;
   font-family: var(--va-font-family);
+
+  &:visited {
+    color: currentColor;
+  }
+
+  &:focus {
+    @include focus-outline();
+  }
 }
 </style>

--- a/packages/ui/src/components/va-sidebar/VaSidebarItem/VaSidebarItem.vue
+++ b/packages/ui/src/components/va-sidebar/VaSidebarItem/VaSidebarItem.vue
@@ -48,7 +48,7 @@ export default defineComponent({
 
     const backgroundColorComputed = computed(() => {
       if (props.active && !isHovered.value && !hasKeyboardFocus.value) {
-        return getColor(getColor(props.activeColor))
+        return getColor(props.activeColor)
       }
 
       return getColor(sidebarColor.value)

--- a/packages/ui/src/components/va-sidebar/VaSidebarItem/VaSidebarItemContent.vue
+++ b/packages/ui/src/components/va-sidebar/VaSidebarItem/VaSidebarItemContent.vue
@@ -20,6 +20,7 @@ export default defineComponent({
   display: flex;
   align-items: center;
   padding: var(--va-sidebar-item-content-padding);
+  min-height: 58px;
 
   & > * {
     margin-right: var(--va-sidebar-item-content-gap);


### PR DESCRIPTION
closes #2028
closes https://github.com/epicmaxco/vuestic-ui/issues/1959

Fix sidebar item colors until 1.5.0. 

Also, hide sidebar title if minimized, instead of making it opacity: 0.

Another breaking change is minimizedWidth set to 4rem from 2.5rem.

This changes looks like Okay? 