### PR TITLE
[#2047] `VaAccordion`  border radius & outline border radius fix

### DIFF
--- a/packages/ui/src/components/va-accordion/VaAccordion.vue
+++ b/packages/ui/src/components/va-accordion/VaAccordion.vue
@@ -37,28 +37,28 @@ export default defineComponent({
 
   .va-collapse {
     &:not(:first-child, :last-child) {
-      .va-collapse__header__content {
+      .va-collapse__header {
         border-radius: 0;
       }
     }
 
     &.va-collapse--expanded {
       &:last-child {
-        .va-collapse__header__content {
+        .va-collapse__header {
           border-radius: 0;
         }
       }
     }
 
     &:first-child {
-      .va-collapse__header__content {
+      .va-collapse__header {
         border-bottom-left-radius: 0;
         border-bottom-right-radius: 0;
       }
     }
 
     &:last-child {
-      .va-collapse__header__content {
+      .va-collapse__header {
         border-top-left-radius: 0;
         border-top-right-radius: 0;
       }

--- a/packages/ui/src/components/va-collapse/VaCollapse.vue
+++ b/packages/ui/src/components/va-collapse/VaCollapse.vue
@@ -55,10 +55,11 @@
 <script lang="ts">
 import { computed, defineComponent, shallowRef } from 'vue'
 
-import { useKeyboardOnlyFocus, useColors, useSyncProp, useTextColor } from '../../composables'
+import { useKeyboardOnlyFocus, useColors, useSyncProp, useTextColor, useBem } from '../../composables'
 import { useAccordionItem } from '../va-accordion/hooks/useAccordion'
 
 import { generateUniqueId } from '../../services/utils'
+import pick from 'lodash/pick.js'
 
 import { VaIcon } from '../va-icon'
 
@@ -139,6 +140,14 @@ export default defineComponent({
       role: 'button',
     }))
 
+    const computedClasses = useBem('va-collapse', () => ({
+      ...pick(props, ['disabled', 'solid']),
+      expanded: computedModelValue.value,
+      active: props.solid && computedModelValue.value,
+      popout: !!(accordionProps.value.popout && computedModelValue.value),
+      inset: !!(accordionProps.value.inset && computedModelValue.value),
+    }))
+
     return {
       body,
       height,
@@ -156,14 +165,7 @@ export default defineComponent({
       panelIdComputed,
       tabIndexComputed,
 
-      computedClasses: computed(() => ({
-        'va-collapse--expanded': computedModelValue.value,
-        'va-collapse--disabled': props.disabled,
-        'va-collapse--solid': props.solid,
-        'va-collapse--active': props.solid && computedModelValue.value,
-        'va-collapse--popout': accordionProps.value.popout && computedModelValue.value,
-        'va-collapse--inset': accordionProps.value.inset && computedModelValue.value,
-      })),
+      computedClasses,
 
       headerStyle: computed(() => ({
         paddingLeft: props.icon && 0,
@@ -258,8 +260,6 @@ export default defineComponent({
 
   &--disabled {
     @include va-disabled();
-
-    pointer-events: none;
   }
 }
 </style>


### PR DESCRIPTION
Close: #2047 

## Description
`VaAccordion` border radius fix (were broken because of `VaCollapse` classes renaming), `VaAccordion` focus outline border radius fix (should inherit current `VaCollapse` border radius).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)