### PR TITLE
[#2073] `VaSlider` range static `modelValue` fix

### DIFF
--- a/packages/ui/src/components/va-slider/VaSlider.vue
+++ b/packages/ui/src/components/va-slider/VaSlider.vue
@@ -205,8 +205,7 @@ export default defineComponent({
     const size = ref(0)
 
     // setting up initial value, don't change to `ref(props.modelValue)` because of https://github.com/epicmaxco/vuestic-ui/issues/2073
-    const currentValue = ref()
-    currentValue.value = Array.isArray(props.modelValue) ? [...props.modelValue] : props.modelValue
+    const currentValue = ref(Array.isArray(props.modelValue) ? [...props.modelValue] : props.modelValue)
 
     const currentSliderDotIndex = ref(0)
     const hasMouseDown = ref(false)

--- a/packages/ui/src/components/va-slider/VaSlider.vue
+++ b/packages/ui/src/components/va-slider/VaSlider.vue
@@ -203,7 +203,11 @@ export default defineComponent({
     const flag = ref(false)
     const offset = ref(0)
     const size = ref(0)
-    const currentValue = ref(props.modelValue)
+
+    // setting up initial value, don't change to `ref(props.modelValue)` because of https://github.com/epicmaxco/vuestic-ui/issues/2073
+    const currentValue = ref()
+    currentValue.value = Array.isArray(props.modelValue) ? [...props.modelValue] : props.modelValue
+
     const currentSliderDotIndex = ref(0)
     const hasMouseDown = ref(false)
 


### PR DESCRIPTION
Close: #2073

## Description
It wasn't trivial at all :)

For some reason first update emit, even in case it's static, changed `modelValue`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)