### PR TITLE
Use defineNuxtPlugin. Improve TS types in plugin.

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -1,11 +1,12 @@
+import type { Import } from 'unimport'
+import type { GlobalConfig } from 'vuestic-ui'
+import type { NuxtOptions } from '@nuxt/schema'
 import {
   defineNuxtModule,
   addPluginTemplate,
-  addAutoImport
+  addAutoImport,
 } from '@nuxt/kit'
-import { GlobalConfig } from 'vuestic-ui'
 import { resolve } from 'pathe'
-import { NuxtOptions } from '@nuxt/schema'
 import { distDir } from './dirs'
 
 export interface VuesticOptions {
@@ -53,9 +54,8 @@ export default defineNuxtModule<VuesticOptions>({
 
       // Use JSON.stringify() here, because it will be inserted in ejs template as string. Then we will JSON.parse it.
       options: {
-        config: JSON.stringify(options.config),
-        // withoutComponents: JSON.stringify(options.withoutComponents)
-      }
+        value: JSON.stringify(options),
+      },
     })
 
     /**
@@ -68,7 +68,7 @@ export default defineNuxtModule<VuesticOptions>({
       'useToast',
       'useModal',
     ]
-    const autoImportsList = []
+    const autoImportsList: Import[] = []
     for (const item of composablesNamesList) {
       autoImportsList.push({ name: item, as: item, from: composablesFrom })
     }

--- a/packages/nuxt/src/runtime/plugin.ts
+++ b/packages/nuxt/src/runtime/plugin.ts
@@ -1,16 +1,19 @@
 import { createVuestic, createVuesticEssential } from 'vuestic-ui'
 import { ref } from 'vue'
+import { defineNuxtPlugin } from 'nuxt/app'
+import type { VuesticOptions } from '../module'
 
 function getGlobalProperty (app, key) {
   return app.config.globalProperties[key]
 }
 
-// @ts-ignore: ts isn't working in proper way into plugin templates
-export default (nuxtApp) => {
+export default defineNuxtPlugin((nuxtApp) => {
   const { vueApp: app } = nuxtApp
 
-  const config = JSON.parse('<%= options.config %>')
-  const withoutComponents = JSON.parse('<%= options.withoutComponents %>' || 'false')
+  // It's important to use `, because TS will compile qoutes to " and JSON will not be parsed...
+  const { config }: VuesticOptions = JSON.parse(`<%= options.value %>`)
+  // TODO: Deal with tree-shaking later
+  const withoutComponents = false
 
   app.use(withoutComponents ? createVuesticEssential({ config }) : createVuestic({ config }))
 
@@ -32,4 +35,4 @@ export default (nuxtApp) => {
       }))
     }
   }
-}
+})


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23530004/179048568-050e7674-4552-409a-88f2-1d4c00e34eb3.png)

<details>
<summary>plugin.mjs</summary>

```js
import { createVuestic, createVuesticEssential } from "vuestic-ui";
import { ref } from "vue";
import { defineNuxtPlugin } from "nuxt/app";
function getGlobalProperty(app, key) {
  return app.config.globalProperties[key];
}
export default defineNuxtPlugin((nuxtApp) => {
  const { vueApp: app } = nuxtApp;
  const { config } = JSON.parse(`<%= options.value %>`);
  const withoutComponents = false;
  app.use(withoutComponents ? createVuesticEssential({ config }) : createVuestic({ config }));
  const head = getGlobalProperty(app, "$head");
  if (head) {
    const colorConfig = getGlobalProperty(app, "$vaColorConfig");
    if (colorConfig) {
      head.addHeadObjs(ref({
        htmlAttrs: {
          style: colorConfig.renderCSSVarialbes()
        }
      }));
    }
  }
});

```
</details>

Improved ts typings as well.