### PR TITLE
Fix/vue cli plugin split css

### DIFF
--- a/packages/bundlers-tests/src/main.ts
+++ b/packages/bundlers-tests/src/main.ts
@@ -2,7 +2,7 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import { createVuesticEssential, VaInput, VaTimePicker, VaTimeInput, VaButton  } from "vuestic-ui";
 import 'vuestic-ui/styles/essential.css'
-import 'vuestic-ui/styles/global/typography.css'
+import 'vuestic-ui/styles/typography.css'
 
 const app = createApp(App)
 

--- a/packages/vue-cli-plugin/generator/configs/treeshaking.js
+++ b/packages/vue-cli-plugin/generator/configs/treeshaking.js
@@ -2,22 +2,20 @@ module.exports = {
   importStrings: (answers) => {
     const strings = [
       "import { createVuesticEssential, VaButton } from 'vuestic-ui'",
-      "import 'vuestic-ui/css'",
-      // "import 'vuestic-ui/styles/essential.css'",
+      "import 'vuestic-ui/styles/essential.css'",
     ]
 
-    // TODO: Move back when CSS code split will work good
-    // if (answers.treeshakingOptions.includes('grid')) {
-    //   strings.push("import 'vuestic-ui/styles/grid/grid.css'")
-    // }
+    if (answers.treeshakingOptions.includes('grid')) {
+      strings.push("import 'vuestic-ui/styles/grid.css'")
+    }
 
-    // if (answers.treeshakingOptions.includes('normalize')) {
-    //   strings.push("import 'vuestic-ui/styles/global/normalize.css'")
-    // }
+    if (answers.treeshakingOptions.includes('normalize')) {
+      strings.push("import 'vuestic-ui/styles/reset.css'")
+    }
 
-    // if (answers.treeshakingOptions.includes('typography')) {
-    //   strings.push("import 'vuestic-ui/styles/global/typography.css'")
-    // }
+    if (answers.treeshakingOptions.includes('typography')) {
+      strings.push("import 'vuestic-ui/styles/typography.css'")
+    }
 
     return strings
   },

--- a/packages/vue-cli-plugin/package.json
+++ b/packages/vue-cli-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-vuestic-ui",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Vuestic UI plugin for Vue CLI v4+",
   "homepage": "https://vuestic.dev",
   "main": "index.js",

--- a/packages/vue-cli-plugin/prompts.js
+++ b/packages/vue-cli-plugin/prompts.js
@@ -9,32 +9,32 @@ module.exports = pkg => {
       message: 'Use treeshaking? You can configure it later.',
       default: true
     },
-    // {
-    //   type: 'checkbox',
-    //   name: 'treeshakingOptions',
-    //   message: 'Select features that you want to use',
-    //   default: [
-    //     'grid', 'normalize', 'typography'
-    //   ],
-    //   when: (answers) => answers.treeshaking,
-    //   choices: [
-    //     {
-    //       name: 'CSS Grid',
-    //       value: 'grid',
-    //       short: 'CSS Grid'
-    //     },
-    //     {
-    //       name: 'Vuestic Normalize CSS module',
-    //       value: 'normalize',
-    //       short: 'Normalize CSS'
-    //     },
-    //     {
-    //       name: 'Vuestic Typography module',
-    //       value: 'typography',
-    //       short: 'Typography'
-    //     }
-    //   ]
-    // },
+    {
+      type: 'checkbox',
+      name: 'treeshakingOptions',
+      message: 'Select features that you want to use',
+      default: [
+        'grid', 'normalize', 'typography'
+      ],
+      when: (answers) => answers.treeshaking,
+      choices: [
+        {
+          name: 'CSS Grid',
+          value: 'grid',
+          short: 'CSS Grid'
+        },
+        {
+          name: 'Vuestic Normalize CSS module',
+          value: 'normalize',
+          short: 'Normalize CSS'
+        },
+        {
+          name: 'Vuestic Typography module',
+          value: 'typography',
+          short: 'Typography'
+        }
+      ]
+    },
     {
       type: 'confirm',
       name: 'agGrid',


### PR DESCRIPTION
Since we ship separately CSS now, we can turn back prompts in vue-cli-plugin.