### PR TITLE
[#2057] `VaDateInput` & `VaTimeInput` moved to `VaInputWrapper`, refactoring, bugfix

### DIFF
--- a/packages/docs/src/page-configs/ui-elements/date-input/examples/inputProps.vue
+++ b/packages/docs/src/page-configs/ui-elements/date-input/examples/inputProps.vue
@@ -44,6 +44,6 @@
 
 <style>
 .va-date-input {
-  max-width: 240px;
+  max-width: 280px;
 }
 </style>

--- a/packages/ui/src/components/va-checkbox/VaCheckbox.vue
+++ b/packages/ui/src/components/va-checkbox/VaCheckbox.vue
@@ -100,6 +100,7 @@ export default defineComponent({
       computedError,
       isIndeterminate,
       computedErrorMessages,
+      validationAriaAttributes,
       toggleSelection,
       onBlur,
       onFocus,
@@ -161,10 +162,7 @@ export default defineComponent({
       ariaDisabled: props.disabled,
       ariaReadOnly: props.readonly,
       ariaChecked: isActive.value,
-      'aria-invalid': !!computedErrorMessages.value.length,
-      'aria-errormessage': typeof computedErrorMessages.value === 'string'
-        ? computedErrorMessages.value
-        : computedErrorMessages.value.join(', '),
+      ...validationAriaAttributes.value,
     }))
 
     return {

--- a/packages/ui/src/components/va-date-input/VaDateInput.demo.vue
+++ b/packages/ui/src/components/va-date-input/VaDateInput.demo.vue
@@ -71,7 +71,7 @@
 
       <va-date-input v-model="value">
         <template #input="{ valueText }">
-          <input :value="valueText" />
+          <input :value="valueText" aria-hidden="true" />
         </template>
       </va-date-input>
     </VbCard>

--- a/packages/ui/src/components/va-date-input/VaDateInput.vue
+++ b/packages/ui/src/components/va-date-input/VaDateInput.vue
@@ -332,15 +332,19 @@ export default defineComponent({
       focus: () => {
         if (props.disabled) { return }
 
-        onFocus()
         focusListener()
+
+        if (props.readonly) { return }
+        onFocus()
         listeners.onFocus()
       },
       blur: () => {
         if (props.disabled) { return }
 
-        onBlur()
         blurListener()
+
+        if (props.readonly) { return }
+        onBlur()
         listeners.onBlur()
       },
     }))

--- a/packages/ui/src/components/va-date-input/VaDateInput.vue
+++ b/packages/ui/src/components/va-date-input/VaDateInput.vue
@@ -125,7 +125,7 @@ import { VaDropdown, VaDropdownContent } from '../va-dropdown'
 import { VaInputWrapper } from '../va-input'
 import { VaIcon } from '../va-icon'
 
-const VaInputWrapperProps = extractComponentProps(VaInputWrapper, ['requiredMark', 'focused', 'maxLength', 'counterValue'])
+const VaInputWrapperProps = extractComponentProps(VaInputWrapper, ['focused', 'maxLength', 'counterValue'])
 const VaDatePickerProps = extractComponentProps(VaDatePicker)
 
 export default defineComponent({
@@ -324,7 +324,6 @@ export default defineComponent({
       error: hasError.value,
       errorMessages: computedErrorMessages.value,
       readonly: props.readonly || !props.manualInput,
-      requiredMark: Object.keys(attrs).includes('required-mark'),
     }))
 
     const computedInputListeners = computed(() => ({

--- a/packages/ui/src/components/va-date-input/VaDateInput.vue
+++ b/packages/ui/src/components/va-date-input/VaDateInput.vue
@@ -339,6 +339,8 @@ export default defineComponent({
     }))
 
     const inputAttributesComputed = computed(() => ({
+      readonly: props.readonly || !props.manualInput,
+      tabindex: tabindexComputed.value,
       value: valueText.value,
       ariaLabel: props.label || 'selected date',
       ariaRequired: props.requiredMark,
@@ -348,8 +350,6 @@ export default defineComponent({
       'aria-errormessage': typeof computedErrorMessages.value === 'string'
         ? computedErrorMessages.value
         : computedErrorMessages.value.join(', '),
-      readonly: props.readonly || !props.manualInput,
-      tabindex: tabindexComputed.value,
     }))
 
     return {

--- a/packages/ui/src/components/va-date-input/VaDateInput.vue
+++ b/packages/ui/src/components/va-date-input/VaDateInput.vue
@@ -283,7 +283,7 @@ export default defineComponent({
       event.preventDefault()
     }
 
-    const { computedError, computedErrorMessages, listeners } = useValidation(props, emit, reset, focus)
+    const { computedError, computedErrorMessages, listeners, validationAriaAttributes } = useValidation(props, emit, reset, focus)
 
     const hasError = computed(() => (!isValid.value && valueComputed.value !== props.clearValue) || computedError.value)
 
@@ -346,10 +346,7 @@ export default defineComponent({
       ariaRequired: props.requiredMark,
       ariaDisabled: props.disabled,
       ariaReadOnly: props.readonly,
-      'aria-invalid': !!computedErrorMessages.value.length,
-      'aria-errormessage': typeof computedErrorMessages.value === 'string'
-        ? computedErrorMessages.value
-        : computedErrorMessages.value.join(', '),
+      ...validationAriaAttributes.value,
     }))
 
     return {

--- a/packages/ui/src/components/va-date-input/VaDateInput.vue
+++ b/packages/ui/src/components/va-date-input/VaDateInput.vue
@@ -76,8 +76,8 @@
       >
         <va-date-picker
             ref="datePicker"
-            v-model="valueWithoutText"
             v-bind="datePickerProps"
+            v-model="valueWithoutText"
             @click:day="$emit('click:day', $event)"
             @click:month="$emit('click:month', $event)"
             @click:year="$emit('click:year', $event)"
@@ -371,7 +371,7 @@ export default defineComponent({
       inputWrapperProps: computedInputWrapperProps,
       inputListeners: computedInputListeners,
       inputAttributesComputed,
-      datePickerProps: filterComponentProps(props, extractComponentProps(VaDatePicker)),
+      datePickerProps: filterComponentProps(props, VaDatePickerProps),
 
       filterSlots,
       canBeCleared,

--- a/packages/ui/src/components/va-date-input/VaDateInput.vue
+++ b/packages/ui/src/components/va-date-input/VaDateInput.vue
@@ -21,9 +21,7 @@
               <input
                 ref="input"
                 class="va-date-input__input"
-                :value="valueText"
-                :readonly="$props.readonly || !$props.manualInput"
-                :tabindex="tabindexComputed"
+                v-bind="inputAttributesComputed"
                 v-on="inputListeners"
                 @change="onInputTextChanged"
               />
@@ -340,6 +338,20 @@ export default defineComponent({
       },
     }))
 
+    const inputAttributesComputed = computed(() => ({
+      value: valueText.value,
+      ariaLabel: props.label || 'selected date',
+      ariaRequired: props.requiredMark,
+      ariaDisabled: props.disabled,
+      ariaReadOnly: props.readonly,
+      'aria-invalid': !!computedErrorMessages.value.length,
+      'aria-errormessage': typeof computedErrorMessages.value === 'string'
+        ? computedErrorMessages.value
+        : computedErrorMessages.value.join(', '),
+      readonly: props.readonly || !props.manualInput,
+      tabindex: tabindexComputed.value,
+    }))
+
     return {
       datePicker,
       valueText,
@@ -353,6 +365,7 @@ export default defineComponent({
       input,
       inputWrapperProps: computedInputWrapperProps,
       inputListeners: computedInputListeners,
+      inputAttributesComputed,
       datePickerProps: filterComponentProps(props, extractComponentProps(VaDatePicker)),
 
       filterSlots,

--- a/packages/ui/src/components/va-date-input/VaDateInput.vue
+++ b/packages/ui/src/components/va-date-input/VaDateInput.vue
@@ -125,7 +125,7 @@ import { VaDropdown, VaDropdownContent } from '../va-dropdown'
 import { VaInputWrapper } from '../va-input'
 import { VaIcon } from '../va-icon'
 
-const VaInputWrapperProps = extractComponentProps(VaInputWrapper, ['focused', 'maxLength', 'counterValue'])
+const VaInputWrapperProps = extractComponentProps(VaInputWrapper, ['requiredMark', 'focused', 'maxLength', 'counterValue'])
 const VaDatePickerProps = extractComponentProps(VaDatePicker)
 
 export default defineComponent({
@@ -160,7 +160,6 @@ export default defineComponent({
     delimiter: { type: String, default: ', ' },
     rangeDelimiter: { type: String, default: ' ~ ' },
     manualInput: { type: Boolean, default: false },
-    placeholder: { type: String, default: '' },
 
     color: { type: String, default: 'primary' },
     leftIcon: { type: Boolean, default: false },
@@ -288,7 +287,7 @@ export default defineComponent({
       if (props.disabled || props.readonly) { return }
 
       isOpenSync.value = true
-      nextTick(focusInputOrPicker)
+      nextTick(focusDatePicker)
     }
 
     const { computedError, computedErrorMessages, listeners, validationAriaAttributes } = useValidation(props, emit, reset, focus)
@@ -325,7 +324,7 @@ export default defineComponent({
       error: hasError.value,
       errorMessages: computedErrorMessages.value,
       readonly: props.readonly || !props.manualInput,
-      ...omit(attrs, ['class', 'style']),
+      requiredMark: Object.keys(attrs).includes('required-mark'),
     }))
 
     const computedInputListeners = computed(() => ({
@@ -350,7 +349,6 @@ export default defineComponent({
     }))
 
     const inputAttributesComputed = computed(() => ({
-      placeholder: props.placeholder,
       readonly: props.readonly || !props.manualInput,
       tabindex: props.disabled ? -1 : 0,
       value: valueText.value,
@@ -359,6 +357,7 @@ export default defineComponent({
       ariaDisabled: props.disabled,
       ariaReadOnly: props.readonly,
       ...validationAriaAttributes.value,
+      ...omit(attrs, ['class', 'style']),
     }))
 
     return {

--- a/packages/ui/src/components/va-date-input/hooks/input-text-parser.ts
+++ b/packages/ui/src/components/va-date-input/hooks/input-text-parser.ts
@@ -18,7 +18,14 @@ export const useDateParser = (props: {
   const isValid = ref(true)
 
   const parseDate = (text: string) => {
-    const date = (props.parseDate || defaultParseDateFunction)(text)
+    /**
+     * for american locales 01.02.2000 will be parsed as 02 Jan 2000 (not 01 Feb 2000)
+     * iso 8601 (YYYY-MM-DD) solves this problem
+     */
+    const splitDate = text.split('.')
+    const valueToParse = splitDate?.length === 3 ? splitDate.reverse().join('-') : text
+
+    const date = (props.parseDate || defaultParseDateFunction)(valueToParse)
 
     isValid.value = isValidDate(date)
 

--- a/packages/ui/src/components/va-input/VaInput.vue
+++ b/packages/ui/src/components/va-input/VaInput.vue
@@ -77,7 +77,7 @@ import pick from 'lodash/pick.js'
 import { extractComponentProps, filterComponentProps } from '../../utils/child-props'
 
 import {
-  useForm, useFormProps,
+  useFormProps,
   useValidation, useValidationProps, useValidationEmits, ValidationProps,
   useEmitProxy,
   useClearable, useClearableProps, useClearableEmits,

--- a/packages/ui/src/components/va-input/VaInput.vue
+++ b/packages/ui/src/components/va-input/VaInput.vue
@@ -77,7 +77,7 @@ import pick from 'lodash/pick.js'
 import { extractComponentProps, filterComponentProps } from '../../utils/child-props'
 
 import {
-  useFormProps,
+  useForm, useFormProps,
   useValidation, useValidationProps, useValidationEmits, ValidationProps,
   useEmitProxy,
   useClearable, useClearableProps, useClearableEmits,
@@ -175,6 +175,7 @@ export default defineComponent({
       computedError,
       computedErrorMessages,
       listeners: validationListeners,
+      validationAriaAttributes,
     } = useValidation(props, emit, reset, focus)
 
     const { modelValue } = toRefs(props)
@@ -215,14 +216,11 @@ export default defineComponent({
     const computedChildAttributes = computed(() => ({
       ariaLabel: props.ariaLabel || props.label,
       ariaRequired: props.requiredMark,
-      ariaDisabled: props.disabled,
-      ariaReadOnly: props.readonly,
-      'aria-invalid': !!computedErrorMessages.value.length,
-      'aria-errormessage': typeof computedErrorMessages.value === 'string'
-        ? computedErrorMessages.value
-        : computedErrorMessages.value.join(', '),
       tabindex: tabIndexComputed.value,
       class: props.inputClass,
+      ariaDisabled: props.disabled,
+      ariaReadonly: props.readonly,
+      ...validationAriaAttributes.value,
       ...omit(attrs, ['class', 'style']),
     }) as InputHTMLAttributes)
 

--- a/packages/ui/src/components/va-input/components/VaInputWrapper/VaInputWrapper.vue
+++ b/packages/ui/src/components/va-input/components/VaInputWrapper/VaInputWrapper.vue
@@ -97,7 +97,7 @@
 import { computed, defineComponent } from 'vue'
 import pick from 'lodash/pick.js'
 
-import { useBem, useFormProps, useValidationProps, useColors, useCSSVariables } from '../../../../composables'
+import { useBem, useFormProps, useValidationProps, useColors, useCSSVariables, useClearableProps } from '../../../../composables'
 
 import { VaMessageList } from '../VaMessageList'
 import { VaIcon } from '../../../va-icon'
@@ -108,6 +108,7 @@ export default defineComponent({
   components: { VaMessageList, VaIcon },
 
   props: {
+    ...useClearableProps,
     ...useFormProps,
     ...useValidationProps,
     counterValue: { type: Number, default: undefined },

--- a/packages/ui/src/components/va-input/components/VaInputWrapper/VaInputWrapper.vue
+++ b/packages/ui/src/components/va-input/components/VaInputWrapper/VaInputWrapper.vue
@@ -97,7 +97,7 @@
 import { computed, defineComponent } from 'vue'
 import pick from 'lodash/pick.js'
 
-import { useBem, useFormProps, useValidationProps, useColors, useCSSVariables, useClearableProps } from '../../../../composables'
+import { useBem, useFormProps, useValidationProps, useColors, useCSSVariables } from '../../../../composables'
 
 import { VaMessageList } from '../VaMessageList'
 import { VaIcon } from '../../../va-icon'
@@ -108,7 +108,6 @@ export default defineComponent({
   components: { VaMessageList, VaIcon },
 
   props: {
-    ...useClearableProps,
     ...useFormProps,
     ...useValidationProps,
     counterValue: { type: Number, default: undefined },

--- a/packages/ui/src/components/va-switch/VaSwitch.vue
+++ b/packages/ui/src/components/va-switch/VaSwitch.vue
@@ -133,6 +133,7 @@ export default defineComponent({
       computedError,
       isIndeterminate,
       computedErrorMessages,
+      validationAriaAttributes,
       ...selectable
     } = useSelectable(props, emit, elements)
 
@@ -202,10 +203,7 @@ export default defineComponent({
       ariaReadOnly: props.readonly,
       ariaChecked: !!props.modelValue,
       ariaLabelledby: ariaLabelIdComputed.value,
-      'aria-invalid': !!computedErrorMessages.value.length,
-      'aria-errormessage': typeof computedErrorMessages.value === 'string'
-        ? computedErrorMessages.value
-        : computedErrorMessages.value.join(', '),
+      ...validationAriaAttributes.value,
     }))
 
     return {

--- a/packages/ui/src/components/va-time-input/VaTimeInput.vue
+++ b/packages/ui/src/components/va-time-input/VaTimeInput.vue
@@ -119,7 +119,7 @@ import { VaInputWrapper } from '../va-input'
 import VaIcon from '../va-icon/VaIcon.vue'
 import { VaDropdown, VaDropdownContent } from '../va-dropdown'
 
-const VaInputWrapperProps = extractComponentProps(VaInputWrapper, ['focused', 'maxLength', 'counterValue'])
+const VaInputWrapperProps = extractComponentProps(VaInputWrapper, ['requiredMark', 'focused', 'maxLength', 'counterValue'])
 
 export default defineComponent({
   name: 'VaTimeInput',
@@ -148,7 +148,6 @@ export default defineComponent({
     manualInput: { type: Boolean, default: false },
     leftIcon: { type: Boolean, default: false },
     icon: { type: String, default: 'schedule' },
-    placeholder: { type: String, default: '' },
   },
 
   inheritAttrs: false,
@@ -229,7 +228,7 @@ export default defineComponent({
       error: computedError.value,
       errorMessages: computedErrorMessages.value,
       readonly: props.readonly || !props.manualInput,
-      ...omit(attrs, ['class', 'style']),
+      requiredMark: Object.keys(attrs).includes('required-mark'),
     }))
 
     const computedInputListeners = computed(() => ({
@@ -292,12 +291,11 @@ export default defineComponent({
       if (props.disabled || props.readonly) { return }
 
       isOpenSync.value = true
-      nextTick(focusInputOrPicker)
+      nextTick(focusTimePicker)
     }
 
     const iconTabindexComputed = computed(() => props.disabled || props.readonly ? -1 : 0)
     const inputAttributesComputed = computed(() => ({
-      placeholder: props.placeholder,
       readonly: props.readonly || !props.manualInput,
       tabindex: props.disabled ? -1 : 0,
       value: valueText.value,
@@ -306,6 +304,7 @@ export default defineComponent({
       ariaDisabled: props.disabled,
       ariaReadOnly: props.readonly,
       ...validationAriaAttributes.value,
+      ...omit(attrs, ['class', 'style']),
     }))
 
     return {

--- a/packages/ui/src/components/va-time-input/VaTimeInput.vue
+++ b/packages/ui/src/components/va-time-input/VaTimeInput.vue
@@ -236,15 +236,19 @@ export default defineComponent({
       focus: () => {
         if (props.disabled) { return }
 
-        onFocus()
         focusListener()
+
+        if (props.readonly) { return }
+        onFocus()
         listeners.onFocus()
       },
       blur: () => {
         if (props.disabled) { return }
 
-        onBlur()
         blurListener()
+
+        if (props.readonly) { return }
+        onBlur()
         listeners.onBlur()
       },
     }))

--- a/packages/ui/src/components/va-time-input/VaTimeInput.vue
+++ b/packages/ui/src/components/va-time-input/VaTimeInput.vue
@@ -68,7 +68,7 @@
           <va-icon
             v-if="canBeClearedComputed"
             role="button"
-            aria-label="reset"
+            aria-label="reset time"
             aria-hidden="false"
             :tabindex="iconTabindexComputed"
             v-bind="clearIconProps"
@@ -79,9 +79,9 @@
           <va-icon
             v-else-if="!$props.leftIcon"
             role="button"
+            class="va-dropdown__icons__reset"
             aria-label="toggle dropdown"
             aria-hidden="false"
-            class="va-dropdown__icons__reset"
             :tabindex="iconTabindexComputed"
             v-bind="iconProps"
             @click.stop="showDropdown"

--- a/packages/ui/src/components/va-time-input/VaTimeInput.vue
+++ b/packages/ui/src/components/va-time-input/VaTimeInput.vue
@@ -119,7 +119,7 @@ import { VaInputWrapper } from '../va-input'
 import VaIcon from '../va-icon/VaIcon.vue'
 import { VaDropdown, VaDropdownContent } from '../va-dropdown'
 
-const VaInputWrapperProps = extractComponentProps(VaInputWrapper, ['requiredMark', 'focused', 'maxLength', 'counterValue'])
+const VaInputWrapperProps = extractComponentProps(VaInputWrapper, ['focused', 'maxLength', 'counterValue'])
 
 export default defineComponent({
   name: 'VaTimeInput',
@@ -228,7 +228,6 @@ export default defineComponent({
       error: computedError.value,
       errorMessages: computedErrorMessages.value,
       readonly: props.readonly || !props.manualInput,
-      requiredMark: Object.keys(attrs).includes('required-mark'),
     }))
 
     const computedInputListeners = computed(() => ({

--- a/packages/ui/src/components/va-time-input/VaTimeInput.vue
+++ b/packages/ui/src/components/va-time-input/VaTimeInput.vue
@@ -5,6 +5,8 @@
     placement="bottom-start"
     trigger="none"
     anchorSelector=".va-input-wrapper__field"
+    :class="$attrs.class"
+    :style="$attrs.style"
     :offset="[2, 0]"
     :close-on-content-click="false"
     :stateful="false"
@@ -54,7 +56,7 @@
             role="button"
             aria-label="toggle dropdown"
             aria-hidden="false"
-            :tabindex="tabindexComputed"
+            :tabindex="iconTabindexComputed"
             v-bind="iconProps"
             @click.stop="toggleDropdown"
             @keydown.enter.stop="toggleDropdown"
@@ -68,7 +70,7 @@
             role="button"
             aria-label="reset"
             aria-hidden="false"
-            :tabindex="tabindexComputed"
+            :tabindex="iconTabindexComputed"
             v-bind="clearIconProps"
             @click.stop="reset"
             @keydown.enter.stop="reset"
@@ -80,7 +82,7 @@
             aria-label="toggle dropdown"
             aria-hidden="false"
             class="va-dropdown__icons__reset"
-            :tabindex="tabindexComputed"
+            :tabindex="iconTabindexComputed"
             v-bind="iconProps"
             @click.stop="toggleDropdown"
             @keydown.enter.stop="toggleDropdown"
@@ -120,6 +122,7 @@ import VaTimePicker from '../va-time-picker/VaTimePicker.vue'
 import { VaInputWrapper } from '../va-input'
 import VaIcon from '../va-icon/VaIcon.vue'
 import { VaDropdown, VaDropdownContent } from '../va-dropdown'
+import omit from 'lodash/omit'
 
 const VaInputWrapperProps = extractComponentProps(VaInputWrapper, ['focused', 'maxLength', 'counterValue'])
 
@@ -145,7 +148,9 @@ export default defineComponent({
     icon: { type: String, default: 'schedule' },
   },
 
-  setup (props, { emit, slots }) {
+  inheritAttrs: false,
+
+  setup (props, { emit, slots, attrs }) {
     const input = shallowRef<HTMLInputElement>()
     const timePicker = shallowRef<typeof VaTimePicker>()
 
@@ -223,6 +228,7 @@ export default defineComponent({
       error: computedError.value,
       errorMessages: computedErrorMessages.value,
       readonly: props.readonly || !props.manualInput,
+      ...omit(attrs, ['class', 'style']),
     }))
 
     const computedInputListeners = computed(() => ({
@@ -256,6 +262,8 @@ export default defineComponent({
     }
 
     const showDropdownWithoutFocus = () => {
+      if (props.disabled || props.readonly) { return }
+
       isOpenSync.value = true
     }
 
@@ -268,6 +276,8 @@ export default defineComponent({
     }
 
     const toggleDropdown = () => {
+      if (props.disabled || props.readonly) { return }
+
       isOpenSync.value ? hideDropdown() : showDropdown()
     }
 
@@ -275,6 +285,7 @@ export default defineComponent({
       isOpenSync.value ? hideDropdown() : showDropdownWithoutFocus()
     }
 
+    const iconTabindexComputed = computed(() => props.disabled || props.readonly ? -1 : 0)
     const tabindexComputed = computed(() => props.disabled ? -1 : 0)
     const inputAttributesComputed = computed(() => ({
       readonly: props.readonly || !props.manualInput,
@@ -304,6 +315,7 @@ export default defineComponent({
       filteredSlots,
       inputAttributesComputed,
       tabindexComputed,
+      iconTabindexComputed,
 
       hideDropdown,
       showDropdown,

--- a/packages/ui/src/components/va-time-input/VaTimeInput.vue
+++ b/packages/ui/src/components/va-time-input/VaTimeInput.vue
@@ -196,7 +196,7 @@ export default defineComponent({
       emit('clear')
     }
 
-    const { computedError, computedErrorMessages, listeners } = useValidation(props, emit, reset, focus)
+    const { computedError, computedErrorMessages, listeners, validationAriaAttributes } = useValidation(props, emit, reset, focus)
 
     const {
       canBeCleared,
@@ -284,10 +284,7 @@ export default defineComponent({
       ariaRequired: props.requiredMark,
       ariaDisabled: props.disabled,
       ariaReadOnly: props.readonly,
-      'aria-invalid': !!computedErrorMessages.value.length,
-      'aria-errormessage': typeof computedErrorMessages.value === 'string'
-        ? computedErrorMessages.value
-        : computedErrorMessages.value.join(', '),
+      ...validationAriaAttributes.value,
     }))
 
     return {

--- a/packages/ui/src/composables/useSelectable.ts
+++ b/packages/ui/src/composables/useSelectable.ts
@@ -66,7 +66,7 @@ export const useSelectable = (
   const reset = () => emit('update:modelValue', false)
   const focus = () => input.value?.focus()
 
-  const { computedError, computedErrorMessages, validate } = useValidation(props, emit, reset, focus)
+  const { computedError, computedErrorMessages, validate, validationAriaAttributes } = useValidation(props, emit, reset, focus)
   const { valueComputed } = useStateful(props, emit)
   const { isFocused } = useFocus()
 
@@ -143,5 +143,6 @@ export const useSelectable = (
     focus,
     computedError,
     computedErrorMessages,
+    validationAriaAttributes,
   }
 }

--- a/packages/ui/src/composables/useValidation.ts
+++ b/packages/ui/src/composables/useValidation.ts
@@ -1,4 +1,4 @@
-import { inject, onBeforeUnmount, onMounted, PropType, watch, ExtractPropTypes } from 'vue'
+import { inject, onBeforeUnmount, onMounted, PropType, watch, ExtractPropTypes, computed } from 'vue'
 import flatten from 'lodash/flatten.js'
 import isFunction from 'lodash/isFunction.js'
 import isString from 'lodash/isString.js'
@@ -90,6 +90,13 @@ export const useValidation = <V, P extends ExtractPropTypes<typeof useValidation
 
   const form = inject(FormServiceKey, undefined)
 
+  const validationAriaAttributes = computed(() => ({
+    'aria-invalid': !!computedErrorMessages.value.length,
+    'aria-errormessage': typeof computedErrorMessages.value === 'string'
+      ? computedErrorMessages.value
+      : computedErrorMessages.value.join(', '),
+  }))
+
   onMounted(() => {
     form?.onChildMounted(context as any)
   })
@@ -104,5 +111,6 @@ export const useValidation = <V, P extends ExtractPropTypes<typeof useValidation
     listeners: { onFocus, onBlur },
     validate,
     resetValidation,
+    validationAriaAttributes,
   }
 }


### PR DESCRIPTION
Close: #2057 

## Description
- [x] `VaDateInput` & `VaTimeInput` moved to `VaInputWrapper` from `VaInput`.
- [x] Fixed related tabindex problems (for example, user was able to focus icons-buttons despite of readonly state).
- [x] Fixed manual date input bug. In case of American locale on the computer, string `02.01.2000` will be parsed (via `Date.parse`) as `01 Feb 2000` (not `02 Jan 2000`) and string `15.07.2000` will throw an error (there is no 15 month).
- [x] Fixed readonly/disabled/manual-input state issues (for example, user was able to open date/time picker despite of disabled state or user was't able to focus component by click for manual input - dropdown was opening).
- [x] Accessibility fixes.
- [x] Related minor refactoring.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)