### PR TITLE
[#2163] Fix `VaInputWrapper` `min-width`

### DIFF
--- a/packages/ui/src/components/va-counter/VaCounter.vue
+++ b/packages/ui/src/components/va-counter/VaCounter.vue
@@ -1,5 +1,5 @@
 <template>
-  <VaInputWrapper
+  <va-input-wrapper
     class="va-counter"
     v-bind="{ ...fieldListeners, ...inputWrapperPropsComputed }"
     :class="classComputed"
@@ -79,7 +79,7 @@
       @input="setCountInput"
       @change="setCountChange"
     >
-  </VaInputWrapper>
+  </va-input-wrapper>
 </template>
 
 <script lang="ts">

--- a/packages/ui/src/components/va-date-input/VaDateInput.vue
+++ b/packages/ui/src/components/va-date-input/VaDateInput.vue
@@ -14,6 +14,7 @@
     <template #anchor>
       <slot name="input" v-bind="{ valueText, inputAttributes: inputAttributesComputed, inputWrapperProps, inputListeners }">
         <va-input-wrapper
+          class="va-date-input__anchor"
           v-bind="inputWrapperProps"
           @click="toggleDropdown"
           @keydown.enter.stop="toggleDropdown"
@@ -399,8 +400,13 @@ export default defineComponent({
 .va-date-input {
   --va-date-picker-cell-size: 28px;
 
-  display: flex;
+  min-width: var(--va-date-input-min-width);
   font-family: var(--va-font-family);
+
+  &__anchor {
+    min-width: auto;
+    width: 100%;
+  }
 
   &__icon {
     cursor: pointer;

--- a/packages/ui/src/components/va-date-input/_variables.scss
+++ b/packages/ui/src/components/va-date-input/_variables.scss
@@ -1,0 +1,3 @@
+:root {
+  --va-date-input-min-width: var(--va-form-element-min-width);
+}

--- a/packages/ui/src/components/va-input/VaInput.vue
+++ b/packages/ui/src/components/va-input/VaInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <VaInputWrapper
+  <va-input-wrapper
     v-bind="fieldListeners"
     :class="$attrs.class"
     :style="$attrs.style"
@@ -66,7 +66,7 @@
       v-bind="{ ...computedInputAttributes, ...inputEvents }"
       :value="computedValue"
     >
-  </VaInputWrapper>
+  </va-input-wrapper>
 </template>
 
 <script lang="ts">

--- a/packages/ui/src/components/va-input/components/VaInputWrapper/VaInputWrapper.vue
+++ b/packages/ui/src/components/va-input/components/VaInputWrapper/VaInputWrapper.vue
@@ -192,12 +192,12 @@ export default defineComponent({
   font-family: var(--va-font-family);
   display: var(--va-input-wrapper-display);
   vertical-align: var(--va-input-wrapper-vertical-align);
+  min-width: var(--va-input-wrapper-min-width);
 
   &__field {
     position: relative;
     display: flex;
     align-items: center;
-    min-width: var(--va-input-wrapper-min-width);
     width: 100%;
     min-height: var(--va-input-min-height);
     border-color: var(--va-input-wrapper-border-color);

--- a/packages/ui/src/components/va-input/components/VaInputWrapper/VaInputWrapper.vue
+++ b/packages/ui/src/components/va-input/components/VaInputWrapper/VaInputWrapper.vue
@@ -275,26 +275,6 @@ export default defineComponent({
     }
   }
 
-  &__icons {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    & > * {
-      margin-right: calc(var(--va-input-content-items-gap) / 4);
-
-      &:last-child {
-        margin-right: 0;
-      }
-    }
-
-    &__reset {
-      &:focus {
-        @include focus-outline;
-      }
-    }
-  }
-
   &__required-mark {
     transform: translate(0, -2px);
     color: var(--va-danger);

--- a/packages/ui/src/components/va-input/components/VaInputWrapper/_variables.scss
+++ b/packages/ui/src/components/va-input/components/VaInputWrapper/_variables.scss
@@ -3,7 +3,7 @@
   --va-input-wrapper-background: var(--va-background, #f5f9fb);
   --va-input-wrapper-background-opacity: 1;
   --va-input-wrapper-border-color: var(--va-input-bordered-color);
-  --va-input-wrapper-min-width: 240px;
+  --va-input-wrapper-min-width: var(--va-form-element-min-width);
   --va-input-wrapper-display: inline-block;
   --va-input-wrapper-vertical-align: middle;
 

--- a/packages/ui/src/components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/va-select/VaSelect.vue
@@ -702,6 +702,8 @@ export default defineComponent({
 
 .va-select {
   cursor: var(--va-select-cursor);
+  min-width: auto;
+  width: 100%;
 
   &__placeholder {
     color: var(--va-input-placeholder-text-color);
@@ -709,6 +711,8 @@ export default defineComponent({
 }
 
 .va-select-dropdown {
+  min-width: var(--va-select-min-width);
+
   .va-dropdown__anchor {
     display: block;
   }

--- a/packages/ui/src/components/va-select/_variables.scss
+++ b/packages/ui/src/components/va-select/_variables.scss
@@ -3,4 +3,5 @@
   --va-select-dropdown-border-radius: 4px;
   --va-select-dropdown-background: var(--va-white);
   --va-select-box-shadow: 0 4px 8px rgba(59, 63, 73, 0.15);
+  --va-select-min-width: var(--va-form-element-min-width);
 }

--- a/packages/ui/src/components/va-time-input/VaTimeInput.vue
+++ b/packages/ui/src/components/va-time-input/VaTimeInput.vue
@@ -19,6 +19,7 @@
   >
     <template #anchor>
       <va-input-wrapper
+        class="va-time-input__anchor"
         v-bind="computedInputWrapperProps"
         @click="toggleDropdown"
         @keydown.enter.stop="toggleDropdown"
@@ -78,7 +79,6 @@
           <va-icon
             v-else-if="!$props.leftIcon"
             role="button"
-            class="va-dropdown__icons__reset"
             aria-label="toggle dropdown"
             aria-hidden="false"
             :tabindex="iconTabindexComputed"
@@ -354,3 +354,17 @@ export default defineComponent({
   },
 })
 </script>
+
+<style lang="scss">
+@import "variables";
+
+.va-time-input {
+  min-width: var(--va-time-input-min-width);
+
+  &__anchor {
+    min-width: auto;
+    width: 100%;
+  }
+}
+
+</style>

--- a/packages/ui/src/components/va-time-input/_variables.scss
+++ b/packages/ui/src/components/va-time-input/_variables.scss
@@ -1,0 +1,3 @@
+:root {
+  --va-time-input-min-width: var(--va-form-element-min-width);
+}

--- a/packages/ui/src/styles/global/css-variables.scss
+++ b/packages/ui/src/styles/global/css-variables.scss
@@ -96,4 +96,7 @@
 
   /* Z-indexes */
   --va-z-index-teleport-overlay: 1000;
+
+  /* Sizes */
+  --va-form-element-min-width: 240px;
 }


### PR DESCRIPTION
## Description
close #2163 

changes:
- [x] add global css-variable for the form-elements `min-width`
- [x] update `min-width` rule for components
- [x] change `display: flex` with `display: inline-block` for the `va-date-input` (according to other "input" components)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
