### PR TITLE
Fix/input field layout

### DIFF
--- a/packages/docs/src/page-configs/ui-elements/date-input/examples/View.vue
+++ b/packages/docs/src/page-configs/ui-elements/date-input/examples/View.vue
@@ -1,26 +1,25 @@
 <template>
   <div class="row">
-    <div class="mr-4">
-      <va-date-input
-        v-model="value"
-        v-model:view="dayView"
-        label="Day"
-      />
-    </div>
-    <div class="mr-4">
-      <va-date-input
-        v-model="value"
-        v-model:view="monthView"
-        label="Month"
-      />
-    </div>
-    <div class="mr-4">
-      <va-date-input
-        v-model="value"
-        v-model:view="yearView"
-        label="Year"
-      />
-    </div>
+    <va-date-input
+      class="mb-4 mr-4"
+      v-model="value"
+      v-model:view="dayView"
+      label="Day"
+    />
+
+    <va-date-input
+      class="mb-4 mr-4"
+      v-model="value"
+      v-model:view="monthView"
+      label="Month"
+    />
+
+    <va-date-input
+      class="mb-4 mr-4"
+      v-model="value"
+      v-model:view="yearView"
+      label="Year"
+    />
   </div>
 </template>
 

--- a/packages/docs/src/page-configs/ui-elements/date-input/examples/inputProps.vue
+++ b/packages/docs/src/page-configs/ui-elements/date-input/examples/inputProps.vue
@@ -1,42 +1,43 @@
 <template>
   <va-date-input
-    class="mb-4"
+    class="mb-4 mr-4"
     label="readonly"
     readonly
   />
 
   <va-date-input
-    class="mb-4"
+    class="mb-4 mr-4"
     label="disabled"
     disabled
   />
 
   <va-date-input
-    class="mb-4"
+    class="mb-4 mr-4"
     label="color"
     color="#ff00ff"
   />
 
   <va-date-input
-    class="mb-4"
+    class="mb-4 mr-4"
     label="placeholder"
     placeholder="Custom placeholder"
   />
 
   <va-date-input
-    class="mb-4"
+    class="mb-4 mr-4"
     label="clearable"
     stateful
     clearable
   />
 
   <va-date-input
-    class="mb-4"
+    class="mb-4 mr-4"
     label="outline"
     outline
   />
 
   <va-date-input
+    class="mb-4 mr-4"
     label="bordered"
     bordered
   />

--- a/packages/docs/src/page-configs/ui-elements/date-input/examples/validation.vue
+++ b/packages/docs/src/page-configs/ui-elements/date-input/examples/validation.vue
@@ -1,20 +1,20 @@
 <template>
   <va-date-input
-    class="mb-2"
+    class="mb-4 mr-4"
     label="Success"
     v-model="value"
     success
   />
 
   <va-date-input
-    class="mb-2"
+    class="mb-4 mr-4"
     label="Error"
     v-model="value"
     error
   />
 
   <va-date-input
-    class="mb-2"
+    class="mb-4 mr-4"
     label="With rules"
     v-model="value"
     :rules="validationRules"

--- a/packages/ui/src/components/va-date-input/VaDateInput.vue
+++ b/packages/ui/src/components/va-date-input/VaDateInput.vue
@@ -15,7 +15,7 @@
   >
     <template #anchor>
       <slot name="input" v-bind="{ valueText, inputAttributes: inputAttributesComputed, inputWrapperProps, inputListeners }">
-        <va-input-wrapper v-bind="inputWrapperProps">
+        <va-input-wrapper v-bind="inputWrapperProps" class="va-date-input__anchor">
           <template #default>
             <input
               ref="input"
@@ -395,8 +395,7 @@ export default defineComponent({
   font-family: var(--va-font-family);
 
   &__anchor {
-    min-width: auto;
-    width: 100%;
+    flex: 1;
   }
 
   &__icon {

--- a/packages/ui/src/components/va-dropdown/VaDropdown.vue
+++ b/packages/ui/src/components/va-dropdown/VaDropdown.vue
@@ -263,6 +263,7 @@ export default defineComponent({
   display: var(--va-dropdown-display);
   position: relative;
   max-width: 100%;
+  vertical-align: middle;
 
   &--disabled {
     @include va-disabled;

--- a/packages/ui/src/components/va-dropdown/VaDropdown.vue
+++ b/packages/ui/src/components/va-dropdown/VaDropdown.vue
@@ -262,6 +262,7 @@ export default defineComponent({
   font-family: var(--va-font-family);
   display: var(--va-dropdown-display);
   position: relative;
+  max-width: 100%;
 
   &--disabled {
     @include va-disabled;

--- a/packages/ui/src/components/va-dropdown/_variables.scss
+++ b/packages/ui/src/components/va-dropdown/_variables.scss
@@ -1,5 +1,5 @@
 :root {
   --va-dropdown-line-height: 1;
   --va-dropdown-content-wrapper-z-index: var(--va-z-index-teleport-overlay, 9);
-  --va-dropdown-display: inline-block;
+  --va-dropdown-display: inline-flex;
 }

--- a/packages/ui/src/components/va-input/components/VaInputWrapper/VaInputWrapper.vue
+++ b/packages/ui/src/components/va-input/components/VaInputWrapper/VaInputWrapper.vue
@@ -198,6 +198,7 @@ export default defineComponent({
   display: var(--va-input-wrapper-display);
   vertical-align: var(--va-input-wrapper-vertical-align);
   min-width: var(--va-input-wrapper-min-width);
+  max-width: 100%;
 
   &__field {
     position: relative;
@@ -243,11 +244,12 @@ export default defineComponent({
   }
 
   &__text {
-    width: 100%;
-    position: relative;
+    width: var(--va-form-element-default-width);
     min-height: var(--va-input-line-height);
-    display: flex;
+    position: relative;
+    display: inline-flex;
     align-items: center;
+    flex: 1;
 
     input,
     textarea {

--- a/packages/ui/src/components/va-input/components/VaInputWrapper/VaInputWrapper.vue
+++ b/packages/ui/src/components/va-input/components/VaInputWrapper/VaInputWrapper.vue
@@ -204,8 +204,9 @@ export default defineComponent({
     position: relative;
     display: flex;
     align-items: center;
-    width: 100%;
+    flex: 1;
     min-height: var(--va-input-min-height);
+    width: var(--va-form-element-default-width);
     border-color: var(--va-input-wrapper-border-color);
     border-style: solid;
     border-width: var(--va-input-border-width);
@@ -244,7 +245,6 @@ export default defineComponent({
   }
 
   &__text {
-    width: var(--va-form-element-default-width);
     min-height: var(--va-input-line-height);
     position: relative;
     display: inline-flex;

--- a/packages/ui/src/components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/va-select/VaSelect.vue
@@ -702,8 +702,7 @@ export default defineComponent({
 .va-select-anchor {
   &__input {
     cursor: var(--va-select-cursor);
-    min-width: auto;
-    width: 100%;
+    flex: 1;
   }
 
   &__placeholder {

--- a/packages/ui/src/components/va-time-input/VaTimeInput.vue
+++ b/packages/ui/src/components/va-time-input/VaTimeInput.vue
@@ -346,8 +346,7 @@ export default defineComponent({
   min-width: var(--va-time-input-min-width);
 
   &__anchor {
-    min-width: auto;
-    width: 100%;
+    flex: 1;
   }
 }
 

--- a/packages/ui/src/styles/global/css-variables.scss
+++ b/packages/ui/src/styles/global/css-variables.scss
@@ -98,5 +98,6 @@
   --va-z-index-teleport-overlay: 1000;
 
   /* Sizes */
-  --va-form-element-min-width: 240px;
+  --va-form-element-min-width: 50px;
+  --va-form-element-default-width: 150px;
 }

--- a/packages/ui/src/styles/global/css-variables.scss
+++ b/packages/ui/src/styles/global/css-variables.scss
@@ -99,5 +99,5 @@
 
   /* Sizes */
   --va-form-element-min-width: 50px;
-  --va-form-element-default-width: 150px;
+  --va-form-element-default-width: 250px;
 }


### PR DESCRIPTION
closes https://github.com/epicmaxco/vuestic-ui/issues/2168

# Cool hack

I assume it works like this:
```scss
.parent {
  max-width: 100%;
  display: inline-flex;
  
  .child {
     width: var(--va-default-width);
     flex: 1;
  }
}
```

flex: 1 makes child to follow parent width. But, if parent doesn't have width or `auto`, then child width will be used.

# Before/after

![image](https://user-images.githubusercontent.com/23530004/181766889-c0417a8f-6514-4ef5-8e38-ec9358191d0a.png)
![image](https://user-images.githubusercontent.com/23530004/181766854-03933d48-b4e4-403c-9629-b4eb72d7ff14.png)

---

![image](https://user-images.githubusercontent.com/23530004/181767118-13b33f41-b729-4389-8d11-35884d43078e.png)

We still have the same width for inputs in form even with icon like we had with min-width, but we are able to make them smaller

Set .va-input width 100px before:
![image](https://user-images.githubusercontent.com/23530004/181767511-c99df75d-0edd-4729-87ee-551e8b14b2c2.png)

Now: (last two inputs have margin-top - it's OK in this demo)
![image](https://user-images.githubusercontent.com/23530004/181768172-de81a413-24d2-46be-9e43-3c8f62cca493.png)