### PR TITLE
feat: add markdown support to the doc pages

### DIFF
--- a/packages/docs/src/components/DocsContent.vue
+++ b/packages/docs/src/components/DocsContent.vue
@@ -83,6 +83,13 @@
         :key="block.type + index"
         :value="block.content"
       />
+      <VaCollapse
+        v-else-if="block.type === BlockType.COLLAPSE"
+        :key="block.type + index"
+        :header="block.header"
+      >
+        <DocsContent :config="block.blocks" />
+      </VaCollapse>
     </template>
   </va-content>
 </template>

--- a/packages/docs/src/components/DocsContent.vue
+++ b/packages/docs/src/components/DocsContent.vue
@@ -78,6 +78,11 @@
         :key="block.type + index"
         :file="block.file"
       />
+      <MarkdownView
+        v-else-if="block.type === BlockType.MARKDOWN"
+        :key="block.type + index"
+        :value="block.content"
+      />
     </template>
   </va-content>
 </template>

--- a/packages/docs/src/helpers/DocsHelper.ts
+++ b/packages/docs/src/helpers/DocsHelper.ts
@@ -138,6 +138,21 @@ export class PageGenerationHelper {
     }
   }
 
+  collapse (header: string, ...blocks: ApiDocsBlock[]): ApiDocsBlock {
+    return {
+      type: BlockType.COLLAPSE,
+      header,
+      blocks: blocks,
+    }
+  }
+
+  markdown (content: string): ApiDocsBlock {
+    return {
+      type: BlockType.MARKDOWN,
+      content,
+    }
+  }
+
   // ********** Higher level helpers ****************
   exampleBlock (title: TranslationString, description: TranslationString, example: string, exampleOptions: ExampleOptions = {}): ApiDocsBlock[] {
     return [
@@ -151,13 +166,6 @@ export class PageGenerationHelper {
     return {
       type: BlockType.FILE,
       file,
-    }
-  }
-
-  markdown (content: string): ApiDocsBlock {
-    return {
-      type: BlockType.MARKDOWN,
-      content,
     }
   }
 }

--- a/packages/docs/src/helpers/DocsHelper.ts
+++ b/packages/docs/src/helpers/DocsHelper.ts
@@ -153,4 +153,11 @@ export class PageGenerationHelper {
       file,
     }
   }
+
+  markdown (content: string): ApiDocsBlock {
+    return {
+      type: BlockType.MARKDOWN,
+      content,
+    }
+  }
 }

--- a/packages/docs/src/page-configs/ui-elements/dropdown/page-config.ts
+++ b/packages/docs/src/page-configs/ui-elements/dropdown/page-config.ts
@@ -3,6 +3,8 @@ import { PageGenerationHelper } from '@/helpers/DocsHelper'
 import VaDropdown from 'vuestic-ui/src/components/va-dropdown/VaDropdown.vue'
 import apiOptions from './api-options'
 
+import specs from './specs.md'
+
 const block = new PageGenerationHelper(__dirname)
 
 const config: ApiDocsBlock[] = [
@@ -41,6 +43,11 @@ const config: ApiDocsBlock[] = [
   ),
 
   block.api(VaDropdown, apiOptions),
+
+  block.collapse(
+    'useDropdown hook specs',
+    block.markdown(specs),
+  ),
 ]
 
 export default config

--- a/packages/docs/src/page-configs/ui-elements/dropdown/specs.md
+++ b/packages/docs/src/page-configs/ui-elements/dropdown/specs.md
@@ -1,0 +1,44 @@
+### Map
+![Example how to get `content.left`](https://user-images.githubusercontent.com/23530004/181629414-5e40211a-7a3c-4d3c-8e78-8808b956d98b.png)
+_Example how to get `content.left`_
+
+### Blocks
+
+- browser window - edge from where `getBoundingClientRect` returns `.left`
+- viewport - container with overflow hidden. Content shouldn't be visible outside the viewport. Used in auto-placement, if overflows viewport - flip placement.
+- root - a container relative to which content will be positioned. We need to set content `.left` which is relative to `root.left`.
+- anchor - content must be directly near anchor, but then offset can be added.
+- content - block which we need to position.
+
+### Placement
+All placement names the same as in CSS.
+
+- verical - cross direction `left`, main:
+    - `bottom`
+    - `auto` the same as `bottom` (activates `auto-placement`)
+    - `top`
+- horizontal - cross direction `bottom`, main:
+    - `left`
+    - `right`
+
+Sub placement
+
+`*-start`
+`*-center` - (default), for example `bottom-center` can be just `bottom`, `left-center` - just `left`.
+`*-end`
+
+### Terms
+
+- offset - contains main and cross line. For:
+    - `'top' | 'bottom'` the main line is `vertical` outside of anchor. Cross will be `horizontal` to the BOTTOM.
+    - `'left' | 'right'` the main line is `horizontal` outside of anchor. Cross will be `vertical` to the LEFT.
+
+- auto-placement - makes content always visible if viewport big enough.
+- stick-to-edges - makes content stick to edge if auto-placement is off and moves content outside of viewport.
+
+
+### Behavior
+
+If `preventOverflow` is false, then `root` the same as `anchor`. So we position `content` relative to `anchor`. `anchor` must have `position: relative` css. `viewport` stay the same, cuz we need it for `auto-placement` feature.
+
+If `preventOverflow` is true, we teleport content to be a `root` child. This way `root` is `viewport`'s first relative parent.

--- a/packages/docs/src/shims-vue.d.ts
+++ b/packages/docs/src/shims-vue.d.ts
@@ -4,3 +4,5 @@ declare module '*.vue' {
   const component: DefineComponent<any, any, any>
   export default component
 }
+
+declare module '*.md'

--- a/packages/docs/src/types/configTypes.ts
+++ b/packages/docs/src/types/configTypes.ts
@@ -49,7 +49,8 @@ export enum BlockType {
   ALERT = 'ALERT',
   LIST = 'LIST',
   FILE = 'FILE',
-  MARKDOWN = 'MARKDOWN'
+  MARKDOWN = 'MARKDOWN',
+  COLLAPSE = 'COLLAPSE',
 }
 
 export type TextBlockType =
@@ -116,4 +117,9 @@ export type ApiDocsBlock =
   | {
     type: BlockType.MARKDOWN,
     content: string,
+  }
+  | {
+    type: BlockType.COLLAPSE,
+    header: string,
+    blocks: ApiDocsBlock[]
   }

--- a/packages/docs/src/types/configTypes.ts
+++ b/packages/docs/src/types/configTypes.ts
@@ -49,6 +49,7 @@ export enum BlockType {
   ALERT = 'ALERT',
   LIST = 'LIST',
   FILE = 'FILE',
+  MARKDOWN = 'MARKDOWN'
 }
 
 export type TextBlockType =
@@ -112,3 +113,7 @@ export type ApiDocsBlock =
       type: BlockType.FILE,
       file: Promise<Record<string, any>>
     }
+  | {
+    type: BlockType.MARKDOWN,
+    content: string,
+  }

--- a/packages/docs/vue.config.js
+++ b/packages/docs/vue.config.js
@@ -26,5 +26,13 @@ module.exports = {
         'vuestic-ui': resolve('../ui'),
       },
     },
+    module: {
+      rules: [
+        {
+          test: /\.md$/,
+          type: 'asset/source',
+        },
+      ],
+    },
   },
 }


### PR DESCRIPTION
Close #2112
## Description
Added markdown files support for the documentation pages.

You can import whole markdown file to the `PageGenerationHelper.markdown` method:

```ts
import { ApiDocsBlock } from '@/types/configTypes'
import { PageGenerationHelper } from '@/helpers/DocsHelper'

// import example markdown file:
import docs from './docs.md'

const block = new PageGenerationHelper(__dirname)

const config: ApiDocsBlock[] = [
  block.markdown(docs),
]

export default config
```

Or you can provide markdown code directly:

```ts
import { ApiDocsBlock } from '@/types/configTypes'
import { PageGenerationHelper } from '@/helpers/DocsHelper'

const block = new PageGenerationHelper(__dirname)

// markdown string:
const docs = `
# Hello, World!
Example text
|Column|Column|
|---|---|
|Text|Text|
`

const config: ApiDocsBlock[] = [
  block.markdown(docs),
]

export default config
```

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

