### PR TITLE
[#2190] Fix `VaButtonDropdown` dropdown appearance and alignment for `split` and `left-icon`

### DIFF
--- a/packages/docs/src/page-configs/ui-elements/button-dropdown/examples/Colors.vue
+++ b/packages/docs/src/page-configs/ui-elements/button-dropdown/examples/Colors.vue
@@ -16,6 +16,7 @@
     Content
   </va-button-dropdown>
   <va-button-dropdown
+    class="mr-2 mb-2"
     color="#525252"
     label="#525252"
     split

--- a/packages/docs/src/page-configs/ui-elements/button-dropdown/examples/Disabled.vue
+++ b/packages/docs/src/page-configs/ui-elements/button-dropdown/examples/Disabled.vue
@@ -15,6 +15,7 @@
     Content
   </va-button-dropdown>
   <va-button-dropdown
+    class="mr-2 mb-2"
     split
     disable-dropdown
     label="disable-dropdown"

--- a/packages/docs/src/page-configs/ui-elements/button-dropdown/examples/Events.vue
+++ b/packages/docs/src/page-configs/ui-elements/button-dropdown/examples/Events.vue
@@ -7,6 +7,7 @@
     Content
   </va-button-dropdown>
   <va-button-dropdown
+    class="mr-2 mb-2"
     @main-button-click="mainButtonClick"
     @click="click"
     split

--- a/packages/docs/src/page-configs/ui-elements/button-dropdown/examples/Icons.vue
+++ b/packages/docs/src/page-configs/ui-elements/button-dropdown/examples/Icons.vue
@@ -21,6 +21,7 @@
     Content
   </va-button-dropdown>
   <va-button-dropdown
+    class="mr-2 mb-2"
     label="custom icon && icon-open"
     icon="info"
     opened-icon="check_circle"

--- a/packages/ui/src/components/va-button-dropdown/VaButtonDropdown.vue
+++ b/packages/ui/src/components/va-button-dropdown/VaButtonDropdown.vue
@@ -210,6 +210,7 @@ export default defineComponent({
 .va-button-dropdown {
   display: inline-block;
   font-family: var(--va-font-family);
+  vertical-align: middle;
 
   .va-button {
     margin: var(--va-button-dropdown-button-margin);

--- a/packages/ui/src/components/va-button-dropdown/VaButtonDropdown.vue
+++ b/packages/ui/src/components/va-button-dropdown/VaButtonDropdown.vue
@@ -50,6 +50,8 @@
         :placement="$props.placement"
         :offset="$props.offset"
         :stateful="$props.stateful"
+        :close-on-content-click="$props.closeOnContentClick"
+        prevent-overflow
         v-model="valueComputed"
       >
         <template #anchor>


### PR DESCRIPTION
## Description
close #2190 

changes:
- [x] set `prevent-overflow` to `VaDropdown`
- [x] set `vertical-align: middle`
- [x] update examples

![chrome-capture-2022-7-3](https://user-images.githubusercontent.com/55198465/182561281-f4b9b077-97b8-4aef-8b9f-015975486d36.gif)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
