### PR TITLE
feat: add input type attribute usage example

### DIFF
--- a/packages/docs/src/locales/en/en.json
+++ b/packages/docs/src/locales/en/en.json
@@ -2540,6 +2540,13 @@
       "styles": {
         "title": "Styles",
         "text": "There are tree styles for input: Default (solid), outline, bordered."
+      },
+      "types": {
+        "title": "Input types",
+        "description": [
+          "With a `type` property you can set the type of the input which will render native `<input type=\"text/password/search/etc\" />`.",
+          "Watch available types [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types) (some types aren't supported or have implemented as a Veustic UI component)."
+        ]
       }
     },
     "variables": "[GitHub Variables Page](https://github.com/epicmaxco/vuestic-ui/blob/develop/packages/ui/src/components/va-input/_variables.scss)[[target=_blank]]"

--- a/packages/docs/src/locales/ru/ru.json
+++ b/packages/docs/src/locales/ru/ru.json
@@ -2423,6 +2423,13 @@
       "styles": {
         "title": "Стили",
         "text": "Поддерживаются три свойства для стилизации компонента: `solid` (по умолчанию), `outline`, `bordered`."
+      },
+      "types": {
+        "title": "Типы input",
+        "description": [
+          "С помощью атрибута `type` вы можете задать тип input, который будет отрендерен как нативный элемент`<input type=\"text/password/search/etc\" />`.",
+          "Смотрите доступные типы [здесь](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types) (некоторые не поддерживаются или реализованы как отдельные компоненты Vuestic UI)."
+        ]
       }
     },
     "variables": "[Страница с переменными на GitHub](https://github.com/epicmaxco/vuestic-ui/blob/develop/packages/ui/src/components/va-input/_variables.scss)[[target=_blank]]"

--- a/packages/docs/src/page-configs/ui-elements/input/examples/Mask.vue
+++ b/packages/docs/src/page-configs/ui-elements/input/examples/Mask.vue
@@ -40,7 +40,8 @@
       :returnRaw="false"
       mask="date"
     />
-    Value: {{maskReturnFormattedValue}}
+    <br />
+    Value: {{ maskReturnFormattedValue }}
   </div>
 </template>
 

--- a/packages/docs/src/page-configs/ui-elements/input/examples/Types.vue
+++ b/packages/docs/src/page-configs/ui-elements/input/examples/Types.vue
@@ -1,0 +1,63 @@
+<template>
+  <va-input
+    v-model="email"
+    type="email"
+    label="Email"
+    class="mr-4 mb-4"
+  />
+  <va-input
+    v-model="password"
+    type="password"
+    label="Password"
+    class="mr-4 mb-4"
+  />
+  <va-input
+    v-model="password"
+    :type="isPasswordVisible ? 'text' : 'password'"
+    label="Password with toggle"
+    class="mr-4 mb-4"
+  >
+    <template #appendInner>
+      <va-icon
+        :name="isPasswordVisible ? 'visibility_off' : 'visibility'"
+        size="small"
+        color="--va-primary"
+        @click="isPasswordVisible = !isPasswordVisible"
+      />
+    </template>
+  </va-input>
+  <va-input
+    v-model="phone"
+    type="tel"
+    label="Phone number"
+    class="mr-4 mb-4"
+  />
+  <va-input
+    v-model="search"
+    type="search"
+    label="Search"
+    clearable
+    class="mr-4 mb-4"
+  />
+  <va-input
+    v-model="url"
+    type="url"
+    label="url"
+    class="mr-4 mb-4"
+  />
+</template>
+
+<script>
+export default {
+  name: 'Types',
+
+  data: () => ({
+    isPasswordVisible: false,
+    email: '',
+    password: '',
+    phone: '',
+    search: '',
+    url: '',
+  }),
+}
+</script>

--- a/packages/docs/src/page-configs/ui-elements/input/page-config.ts
+++ b/packages/docs/src/page-configs/ui-elements/input/page-config.ts
@@ -59,6 +59,11 @@ const config: ApiDocsBlock[] = [
     'InputClass',
   ),
 
+  block.headline('input.examples.types.title'),
+  block.paragraph('input.examples.types.description[0]'),
+  block.paragraph('input.examples.types.description[1]'),
+  block.example('Types'),
+
   block.subtitle('all.api'),
   block.api(VaInput, apiOptions),
 

--- a/packages/ui/src/styles/global/reset.scss
+++ b/packages/ui/src/styles/global/reset.scss
@@ -339,3 +339,10 @@ button:-moz-focusring,
 button {
   padding: 0;
 }
+
+input[type="search"]::-webkit-search-decoration,
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-results-button,
+input[type="search"]::-webkit-search-results-decoration {
+  -webkit-appearance:none;
+}


### PR DESCRIPTION
Close #1925

![image](https://user-images.githubusercontent.com/29167241/184533205-836a6790-dd1c-4eb4-93f6-ced4aa9630a8.png)

## Description
Added examples of the input's `type` attribute usage in the `va-input` component.
Added css reset for the `type="search"` input.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
