### PR TITLE
[#1748] Fixed `to` prop issue in Nuxt 3

### DIFF
--- a/packages/ui/src/components/va-button/hooks/useButtonAttributes.ts
+++ b/packages/ui/src/components/va-button/hooks/useButtonAttributes.ts
@@ -5,7 +5,7 @@ import { useRouterLink } from '../../../composables'
 type UseButtonAttributes = (
   props: ButtonPropsTypes,
 ) => ComputedRef<{
-  ariaDisabled: boolean,
+  'aria-disabled': boolean,
   disabled: boolean,
   type?: any,
   tabindex?: number,
@@ -25,7 +25,7 @@ export const useButtonAttributes: UseButtonAttributes = (props) => {
   const typeComputed = computed(() => isLinkTag.value ? undefined : props.type)
   const buttonAttributesComputed = computed(() => {
     const disabledAttributes = {
-      ariaDisabled: !!props.disabled,
+      'aria-disabled': !!props.disabled,
       disabled: !!props.disabled,
     }
 

--- a/packages/ui/src/composables/useRouterLink.ts
+++ b/packages/ui/src/composables/useRouterLink.ts
@@ -26,6 +26,7 @@ export const useRouterLink = (props: ExtractPropTypes<typeof useRouterLinkProps>
 
     // if (props.to) { return isNuxt.value ? 'nuxt-link' : 'router-link' }
     // https://github.com/nuxt/framework/issues/6747
+    // TODO: may be we will be able to resolve NuxtLink component via @vuestic/nuxt and use resolveComponent
     if (props.to) { return 'router-link' }
 
     return props.tag

--- a/packages/ui/src/composables/useRouterLink.ts
+++ b/packages/ui/src/composables/useRouterLink.ts
@@ -24,7 +24,9 @@ export const useRouterLink = (props: ExtractPropTypes<typeof useRouterLinkProps>
 
     if (props.href && !props.to) { return 'a' }
 
-    if (props.to) { return isNuxt.value ? 'nuxt-link' : 'router-link' }
+    // if (props.to) { return isNuxt.value ? 'nuxt-link' : 'router-link' }
+    // https://github.com/nuxt/framework/issues/6747
+    if (props.to) { return 'router-link' }
 
     return props.tag
   })

--- a/packages/ui/src/composables/useRouterLink.ts
+++ b/packages/ui/src/composables/useRouterLink.ts
@@ -26,7 +26,7 @@ export const useRouterLink = (props: ExtractPropTypes<typeof useRouterLinkProps>
 
     // if (props.to) { return isNuxt.value ? 'nuxt-link' : 'router-link' }
     // https://github.com/nuxt/framework/issues/6747
-    // TODO: may be we will be able to resolve NuxtLink component via @vuestic/nuxt and use resolveComponent
+    // TODO: may be we will be able to register NuxtLink component via @vuestic/nuxt and use resolveComponent
     if (props.to) { return 'router-link' }
 
     return props.tag


### PR DESCRIPTION
Close: #1748 

## Description
Partially fixed issue with `to` prop in Nuxt 3 (`nuxt-link` changed to `router-link`).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)