### PR TITLE
Fixing issue: On hover - "Open in Github" button is barely visible #2282

### DIFF
--- a/packages/ui/src/styles/typography/_mixins.scss
+++ b/packages/ui/src/styles/typography/_mixins.scss
@@ -180,6 +180,6 @@ $va-display-margins: (
 
   &:hover {
     color: var(--va-link-color);
-    filter: brightness(125%);
+    filter: brightness(103%);
   }
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail -->

So as in the description of the issue, the 'Open in GitHub' button becomes barely visible on hover.

**Actual Issue**: The actual issue was that the value of 'brightness' filter was way to much high(125%) which was making the button barely visible on hover

**Fix**: The value of 103% for the 'brightness' filter should fix the issue and makes the 'Open in GitHub' button decently visible on hover.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
