### PR TITLE
Updated Fixing issue: On hover - "Open in Github" button is barely vi…

### DIFF
--- a/packages/ui/src/styles/typography/_mixins.scss
+++ b/packages/ui/src/styles/typography/_mixins.scss
@@ -180,6 +180,6 @@ $va-display-margins: (
 
   &:hover {
     color: var(--va-link-color);
-    filter: brightness(125%);
+    filter: brightness(115%);
   }
 }


### PR DESCRIPTION
…sible #2282

So as in the description of the issue, the 'Open in GitHub' button becomes barely visible on hover.

Issue file location
File - https://github.com/epicmaxco/vuestic-ui/blob/develop/packages/ui/src/styles/typography/_mixins.scss
Line number - 183

Actual Issue: The actual issue was that the value of 'brightness' filter was way to much high(125%) which was making the button barely visible on hover

Fix: The value of **115%** for the 'brightness' filter should fix the issue and makes the 'Open in GitHub' button decently visible on hover.

**Note**
Hey @aluarius , this is a new PR with changes that you suggested in the brightness value from **103% -> 115%**
Kindly review the changes and I think we can go for merging it then.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
