### PR TITLE
fix: align popover examples horizontally

### DIFF
--- a/packages/docs/src/page-configs/ui-elements/popover/examples/Color.vue
+++ b/packages/docs/src/page-configs/ui-elements/popover/examples/Color.vue
@@ -40,6 +40,7 @@
   </va-popover>
 
   <va-popover
+    class="mb-2"
     message="Popover text"
     color="#9f03e0"
   >

--- a/packages/docs/src/page-configs/ui-elements/popover/examples/Placement.vue
+++ b/packages/docs/src/page-configs/ui-elements/popover/examples/Placement.vue
@@ -23,6 +23,7 @@
   </va-popover>
 
   <va-popover
+    class="mb-2"
     placement="right"
     message="Placement Right"
   >

--- a/packages/docs/src/page-configs/ui-elements/popover/examples/Trigger.vue
+++ b/packages/docs/src/page-configs/ui-elements/popover/examples/Trigger.vue
@@ -7,6 +7,7 @@
     <va-button>Click me</va-button>
   </va-popover>
   <va-popover
+    class="mb-2"
     message="popover text (doesn't hide when clicked outside)"
     trigger="click"
     :auto-hide="false"


### PR DESCRIPTION
## Description
A little popover examples fixes. Horizontally aligned examples.

## Types of changes
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
