### PR TITLE
Fix: Types. VaRadio option prop type is missing [#2303]

### DIFF
--- a/packages/ui/src/components/va-radio/VaRadio.vue
+++ b/packages/ui/src/components/va-radio/VaRadio.vue
@@ -52,7 +52,7 @@ export default defineComponent({
   props: {
     ...useFormProps,
     modelValue: { type: [Boolean, Array, String, Object] as PropType<boolean | null | string | number | Record<any, unknown> | unknown[]>, default: null },
-    option: { default: null },
+    option: { type: [String, Boolean] as PropType<boolean | string> },
     name: { type: String, default: '' },
     label: { type: String, default: '' },
     leftLabel: { type: Boolean, default: false },

--- a/packages/ui/src/components/va-radio/VaRadio.vue
+++ b/packages/ui/src/components/va-radio/VaRadio.vue
@@ -52,7 +52,7 @@ export default defineComponent({
   props: {
     ...useFormProps,
     modelValue: { type: [Boolean, Array, String, Object] as PropType<boolean | null | string | number | Record<any, unknown> | unknown[]>, default: null },
-    option: { type: [String, Boolean] as PropType<boolean | string> },
+    option: { type: [String, Boolean] },
     name: { type: String, default: '' },
     label: { type: String, default: '' },
     leftLabel: { type: Boolean, default: false },


### PR DESCRIPTION
## Description
Added a propType to option in vaRadio.vue

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)