### PR TITLE
[#2304] fixed problems with buttons in docs for 1.5.0

### DIFF
--- a/packages/docs/src/components/DocsNavigation.vue
+++ b/packages/docs/src/components/DocsNavigation.vue
@@ -2,7 +2,7 @@
   <div class="docs-navigation">
     <va-button
       v-if="!hideShowCodeButton"
-      flat
+      preset="secondary"
       size="small"
       class="docs-navigation__button"
       color="gray"
@@ -13,7 +13,7 @@
     </va-button>
 
     <va-button
-      preset="plain"
+      preset="secondary"
       size="small"
       class="docs-navigation__button"
       color="gray"
@@ -24,7 +24,7 @@
     </va-button>
 
     <va-button
-      preset="plain"
+      preset="secondary"
       size="small"
       class="docs-navigation__button"
       color="gray"
@@ -38,7 +38,7 @@
     <form :action="sandboxDefineUrl" method="POST" target="_blank">
       <input type="hidden" name="parameters" :value="sandboxParams" />
       <va-button
-        preset="plain"
+        preset="secondary"
         type="submit"
         size="small"
         class="docs-navigation__button"

--- a/packages/docs/src/page-configs/styles/css-variables/examples/profile.vue
+++ b/packages/docs/src/page-configs/styles/css-variables/examples/profile.vue
@@ -16,10 +16,10 @@
         </div>
 
         <va-card-action class="d-flex pt-2">
-          <va-button flat color="white" style="margin-left: -0.5rem;">Follow</va-button>
+          <va-button preset="plain" color="white" style="margin-left: -0.5rem;">Follow</va-button>
           <va-spacer />
-          <va-button flat color="white" icon="message"></va-button>
-          <va-button flat color="white" icon="play_arrow"></va-button>
+          <va-button preset="plain" color="white" icon="message"></va-button>
+          <va-button preset="plain" color="white" icon="play_arrow"></va-button>
         </va-card-action>
       </div>
     </va-card-content>

--- a/packages/docs/src/page-configs/styles/css-variables/examples/profile.vue
+++ b/packages/docs/src/page-configs/styles/css-variables/examples/profile.vue
@@ -16,10 +16,10 @@
         </div>
 
         <va-card-action class="d-flex pt-2">
-          <va-button preset="plain" color="white" style="margin-left: -0.5rem;">Follow</va-button>
+          <va-button preset="secondary" color="white" style="margin-left: -0.5rem;">Follow</va-button>
           <va-spacer />
-          <va-button preset="plain" color="white" icon="message"></va-button>
-          <va-button preset="plain" color="white" icon="play_arrow"></va-button>
+          <va-button preset="secondary" color="white" icon="message"></va-button>
+          <va-button preset="secondary" color="white" icon="play_arrow"></va-button>
         </va-card-action>
       </div>
     </va-card-content>

--- a/packages/ui/src/styles/typography/_mixins.scss
+++ b/packages/ui/src/styles/typography/_mixins.scss
@@ -164,22 +164,24 @@ $va-display-margins: (
 }
 
 @mixin link {
-  color: var(--va-link-color);
-  cursor: pointer;
-  font-family: var(--va-font-family);
-
-  &:active {
+  &:not(.va-button) {
     color: var(--va-link-color);
-    filter: brightness(150%);
-  }
+    cursor: pointer;
+    font-family: var(--va-font-family);
 
-  &:visited {
-    color: var(--va-link-color);
-    filter: brightness(90%);
-  }
+    &:active {
+      color: var(--va-link-color);
+      filter: brightness(150%);
+    }
 
-  &:hover {
-    color: var(--va-link-color);
-    filter: brightness(125%);
+    &:visited {
+      color: var(--va-link-color);
+      filter: brightness(90%);
+    }
+
+    &:hover {
+      color: var(--va-link-color);
+      filter: brightness(125%);
+    }
   }
 }


### PR DESCRIPTION
Closes: #2304 
Fixes in the more proper way: #2282

## Description
- [x] Fixed problems with buttons in `/styles/css-variables` docs page.
<img width="504" alt="image" src="https://user-images.githubusercontent.com/64714442/187703207-519b10af-1225-429a-b17f-fcf74941a984.png">

- [x] Fixed problems with buttons in docs code examples block. 
<img width="414" alt="image" src="https://user-images.githubusercontent.com/64714442/187703303-10dc789a-ac06-45ae-a09f-978d486a44e1.png">

- [x] Refixed 2282 issue.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)