### PR TITLE
fix:vaRadio option propType and added default null #2303

### DIFF
--- a/packages/ui/src/components/va-radio/VaRadio.vue
+++ b/packages/ui/src/components/va-radio/VaRadio.vue
@@ -52,7 +52,7 @@ export default defineComponent({
   props: {
     ...useFormProps,
     modelValue: { type: [Boolean, Array, String, Object] as PropType<boolean | null | string | number | Record<any, unknown> | unknown[]>, default: null },
-    option: { type: [String, Boolean] },
+    option: { type: [String, Boolean, Object] as PropType<any>, default: null },
     name: { type: String, default: '' },
     label: { type: String, default: '' },
     leftLabel: { type: Boolean, default: false },

--- a/packages/ui/src/components/va-radio/VaRadio.vue
+++ b/packages/ui/src/components/va-radio/VaRadio.vue
@@ -51,8 +51,8 @@ export default defineComponent({
   emits: ['update:modelValue', 'focus'],
   props: {
     ...useFormProps,
-    modelValue: { type: [Boolean, Array, String, Object] as PropType<boolean | null | string | number | Record<any, unknown> | unknown[]>, default: null },
-    option: { type: [String, Boolean, Object] as PropType<any>, default: null },
+    modelValue: { type: [Boolean, Array, String, Object, Number] as PropType<boolean | null | string | number | Record<any, unknown> | unknown[]>, default: null },
+    option: { type: [String, Boolean, Object, Number] as PropType<any>, default: null },
     name: { type: String, default: '' },
     label: { type: String, default: '' },
     leftLabel: { type: Boolean, default: false },


### PR DESCRIPTION
## Description

- Added PropType to options in vaRadio, now it has 4 types String, Boolean, Object and Number and default value will be null.
- Added type Number to modelValue, as passing any number dataType in options , causing a warning of type mismatch.

## Types of changes
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
