### PR TITLE
[#2349] Focus outline only keyboard update

### DIFF
--- a/packages/ui/src/components/AccessibilityGuide.md
+++ b/packages/ui/src/components/AccessibilityGuide.md
@@ -55,7 +55,7 @@ Some other ground rules:
 Every interactive item should be accessible via `Tab` button (should have `tabindex="0"` attribute).
 
 Some other ground rules:
-- `focused` state should be highlighted via `focus-outline` SCSS mixin;
+- `focused` state should be highlighted via `keyboard-focus-outline` SCSS mixin;
 - `tabindex` attribute can be `-1` (excluded from tab navigation) or `0`, no other values;
 - elements with `tabindex="0"` shouldn't be hidden via `aria-hidden="true"` attribute;
 - interaction with an element should be reachable via the `enter`, `space` or other keys (list of them is specified in the source of truth for each role).

--- a/packages/ui/src/components/va-alert/VaAlert.vue
+++ b/packages/ui/src/components/va-alert/VaAlert.vue
@@ -225,9 +225,7 @@ export default defineComponent({
         align-items: center;
         cursor: pointer;
 
-        &:focus {
-          @include focus-outline;
-        }
+        @include keyboard-focus-outline;
       }
     }
 

--- a/packages/ui/src/components/va-chip/VaChip.vue
+++ b/packages/ui/src/components/va-chip/VaChip.vue
@@ -206,10 +206,6 @@ export default defineComponent({
     &__close-icon {
       cursor: pointer;
 
-      &:focus {
-        @include focus-outline;
-      }
-
       @at-root {
         .va-chip--disabled {
           .va-chip__close-icon {

--- a/packages/ui/src/components/va-collapse/VaCollapse.vue
+++ b/packages/ui/src/components/va-collapse/VaCollapse.vue
@@ -218,9 +218,7 @@ export default defineComponent({
         color: var(--va-collapse-header-content-icon-color);
       }
 
-      &:focus {
-        @include focus-outline(var(--va-collapse-header-content-border-radius));
-      }
+      @include keyboard-focus-outline(var(--va-collapse-header-content-border-radius));
     }
 
     &--solid {

--- a/packages/ui/src/components/va-data-table/VaDataTable.vue
+++ b/packages/ui/src/components/va-data-table/VaDataTable.vue
@@ -532,9 +532,7 @@ export default defineComponent({
           display: flex;
           align-items: center;
 
-          &:focus {
-            @include focus-outline($offset: 2px);
-          }
+          @include keyboard-focus-outline($offset: 2px);
         }
 
         .va-data-table__table-th-sorting {

--- a/packages/ui/src/components/va-icon/VaIcon.vue
+++ b/packages/ui/src/components/va-icon/VaIcon.vue
@@ -101,9 +101,7 @@ export default defineComponent({
     &[role^="button"][tabindex]:not([tabindex^="-"]) {
       cursor: pointer;
 
-      &:focus {
-        @include focus-outline;
-      }
+      @include keyboard-focus-outline;
     }
 
     &#{&} {

--- a/packages/ui/src/components/va-list/VaListItem.vue
+++ b/packages/ui/src/components/va-list/VaListItem.vue
@@ -64,8 +64,8 @@ export default defineComponent({
       @include va-disabled;
     }
 
-    &:focus:not(.va-list-item--disabled) {
-      @include focus-outline;
+    &:not(.va-list-item--disabled) {
+      @include keyboard-focus-outline;
     }
 
     &__inner {

--- a/packages/ui/src/components/va-modal/VaModal.vue
+++ b/packages/ui/src/components/va-modal/VaModal.vue
@@ -525,10 +525,6 @@ export default defineComponent({
       font-style: normal;
       color: var(--va-secondary);
       z-index: 1;
-
-      &:focus {
-        @include focus-outline;
-      }
     }
 
     &__footer {

--- a/packages/ui/src/components/va-rating/components/VaRatingItem/VaRatingItem.vue
+++ b/packages/ui/src/components/va-rating/components/VaRatingItem/VaRatingItem.vue
@@ -132,9 +132,7 @@ export default defineComponent({
   .va-rating-item {
     display: inline-block;
 
-    &:focus {
-      @include focus-outline();
-    }
+    @include keyboard-focus-outline;
 
     &__wrapper {
       @include normalize-button();

--- a/packages/ui/src/components/va-toast/VaToast.vue
+++ b/packages/ui/src/components/va-toast/VaToast.vue
@@ -240,10 +240,6 @@ export default defineComponent({
       &:hover {
         color: var(--va-toast-hover-color);
       }
-
-      &:focus {
-        @include focus-outline;
-      }
     }
   }
 

--- a/packages/ui/src/styles/resources/_mixins.scss
+++ b/packages/ui/src/styles/resources/_mixins.scss
@@ -207,6 +207,6 @@
 
 @mixin keyboard-focus-outline($radius: 2px, $width: 2px, $offset: null, $style: solid) {
   &:focus-visible {
-    @include focus-outline($radius, $width, $offset, $style)
+    @include focus-outline($radius, $width, $offset, $style);
   }
 }

--- a/packages/ui/src/styles/resources/_mixins.scss
+++ b/packages/ui/src/styles/resources/_mixins.scss
@@ -204,3 +204,9 @@
   border-radius: $radius;
   outline-offset: $offset;
 }
+
+@mixin keyboard-focus-outline($radius: 2px, $width: 2px, $offset: null, $style: solid) {
+  &:focus-visible {
+    @include focus-outline($radius, $width, $offset, $style)
+  }
+}


### PR DESCRIPTION
Related to: #2349 

## Description
Focus-outline for only keyboard selection.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)