### PR TITLE
[#2324] Fix `VaDataTable` inputs width in CRUD example

### DIFF
--- a/packages/docs/src/page-configs/ui-elements/data-table/examples/CRUD.vue
+++ b/packages/docs/src/page-configs/ui-elements/data-table/examples/CRUD.vue
@@ -1,18 +1,23 @@
 <template>
-  <va-data-table :items="items" :columns="columns" striped>
+  <va-data-table
+    class="table-crud-example"
+    :items="items"
+    :columns="columns"
+    striped
+  >
     <template #headerAppend>
-      <tr class="table-example__slot">
+      <tr class="table-crud-example__slot">
         <th
           v-for="key in Object.keys(createdItem)"
           :key="key"
-          colspan="1"
+          class="pa-1"
         >
           <va-input
             :placeholder="key"
             v-model="createdItem[key]"
           />
         </th>
-        <th colspan="1">
+        <th class="pa-1">
           <va-button
             @click="addNewItem"
             :disabled="!isNewData"
@@ -30,21 +35,20 @@
   </va-data-table>
 
   <va-modal
+    class="modal-crud-example"
     :model-value="!!editedItem"
     title="Edit item"
     size="small"
     @ok="editItem"
     @cancel="resetEditedItem"
   >
-    <div class="table-example__modal-content">
-      <va-input
-        v-for="key in Object.keys(editedItem)"
-        :key="key"
-        class="my-3"
-        :label="key"
-        v-model="editedItem[key]"
-      />
-    </div>
+    <va-input
+      v-for="key in Object.keys(editedItem)"
+      :key="key"
+      class="my-3"
+      :label="key"
+      v-model="editedItem[key]"
+    />
   </va-modal>
 </template>
 
@@ -139,28 +143,23 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-  .table-example {
-    &__slot {
-      th {
-        padding-top: 5px;
-        padding-bottom: 5px;
-        vertical-align: middle;
-      }
+  .table-crud-example {
+    --va-form-element-default-width: 0;
 
-      .va-input {
-        --va-form-element-default-width: 80px;
-
-        width: 100%;
-      }
+    .va-input {
+      display: block;
     }
 
-    &__modal-content {
-      display: flex;
-      flex-direction: column;
-
-      .va-input {
-        width: 100%;
+    &__slot {
+      th {
+        vertical-align: middle;
       }
+    }
+  }
+
+  .modal-crud-example {
+    .va-input {
+      display: block;
     }
   }
 </style>

--- a/packages/docs/src/page-configs/ui-elements/data-table/examples/CRUD.vue
+++ b/packages/docs/src/page-configs/ui-elements/data-table/examples/CRUD.vue
@@ -1,7 +1,7 @@
 <template>
   <va-data-table :items="items" :columns="columns" striped>
     <template #headerAppend>
-      <tr class="table-example--slot">
+      <tr class="table-example__slot">
         <th
           v-for="key in Object.keys(createdItem)"
           :key="key"
@@ -31,11 +31,12 @@
 
   <va-modal
     :model-value="!!editedItem"
-    message="Edit item"
+    title="Edit item"
+    size="small"
     @ok="editItem"
     @cancel="resetEditedItem"
   >
-    <slot>
+    <div class="table-example__modal-content">
       <va-input
         v-for="key in Object.keys(editedItem)"
         :key="key"
@@ -43,7 +44,7 @@
         :label="key"
         v-model="editedItem[key]"
       />
-    </slot>
+    </div>
   </va-modal>
 </template>
 
@@ -138,11 +139,28 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-  .table-example--slot {
-    th {
-      padding-top: 5px;
-      padding-bottom: 5px;
-      vertical-align: middle;
+  .table-example {
+    &__slot {
+      th {
+        padding-top: 5px;
+        padding-bottom: 5px;
+        vertical-align: middle;
+      }
+
+      .va-input {
+        --va-form-element-default-width: 80px;
+
+        width: 100%;
+      }
+    }
+
+    &__modal-content {
+      display: flex;
+      flex-direction: column;
+
+      .va-input {
+        width: 100%;
+      }
     }
   }
 </style>


### PR DESCRIPTION
## Description
close #2324 

changes:
- [x] tweak `va-input` components styles within table

![chrome-capture-2022-8-12](https://user-images.githubusercontent.com/55198465/189659680-3d27c6a1-be41-4118-808c-a2a2158618ee.gif)


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
