### PR TITLE
[#2339] Fix `VaDataTable` css variables (for `sticky` and `scrolled` table)

### DIFF
--- a/packages/docs/src/page-configs/ui-elements/data-table/examples/Sticky.vue
+++ b/packages/docs/src/page-configs/ui-elements/data-table/examples/Sticky.vue
@@ -16,8 +16,8 @@
     <va-data-table
       :items="items"
       :style="{
-        '--va-data-table-scrolled-table-height': '300px',
-        '--va-data-table-sticky-background-color': 'orange',
+        '--va-data-table-height': '300px',
+        '--va-data-table-header-background': 'linear-gradient(0deg, #ddd, #eff8ff)',
       }"
       sticky-header
       footer-clone
@@ -137,8 +137,9 @@ export default defineComponent({
     }
 
     .my-custom-table-class {
-      --va-data-table-sticky-background-color: black;
-      --va-data-table-scrolled-table-height: 250px;
+      --va-data-table-thead-background: black;
+      --va-data-table-tfoot-background: gray;
+      --va-data-table-height: 250px;
 
       .va-data-table__table-th {
         color: white;

--- a/packages/docs/src/page-configs/ui-elements/data-table/examples/Sticky.vue
+++ b/packages/docs/src/page-configs/ui-elements/data-table/examples/Sticky.vue
@@ -16,8 +16,8 @@
     <va-data-table
       :items="items"
       :style="{
-        '--va-data-table-scroll-table-height': '300px',
-        '--va-data-table-scroll-table-color': 'orange',
+        '--va-data-table-scrolled-table-height': '300px',
+        '--va-data-table-sticky-background-color': 'orange',
       }"
       sticky-header
       footer-clone
@@ -43,7 +43,6 @@
       sticky-header
       footer-clone
       sticky-footer
-      selected-color="warning"
     />
   </div>
 </template>
@@ -138,16 +137,11 @@ export default defineComponent({
     }
 
     .my-custom-table-class {
-      &.va-data-table--sticky {
-        height: 220px;
+      --va-data-table-sticky-background-color: black;
+      --va-data-table-scrolled-table-height: 250px;
 
-        .va-data-table__table-thead--sticky {
-          background-color: gray;
-
-          .va-data-table__table-th {
-            color: white;
-          }
-        }
+      .va-data-table__table-th {
+        color: white;
       }
     }
   }

--- a/packages/ui/src/components/va-data-table/VaDataTable.vue
+++ b/packages/ui/src/components/va-data-table/VaDataTable.vue
@@ -84,10 +84,7 @@
         <slot name="headerAppend" />
       </thead>
 
-      <tbody
-        class="va-data-table__table-tbody"
-        :style="rowCSSVariables"
-      >
+      <tbody class="va-data-table__table-tbody">
         <slot name="bodyPrepend" />
 
         <transition-group
@@ -403,7 +400,8 @@ export default defineComponent({
         { 'va-data-table--scroll': !!props.height },
         attrs.class,
       ],
-      style: [stickyCSSVariables.value, attrs.style],
+      style: [attrs.style],
+      // style: [stickyCSSVariables.value, attrs.style],
     }) as HTMLAttributes)
 
     const computedTableAttributes = computed(() => ({
@@ -428,6 +426,7 @@ export default defineComponent({
       sortingOrderSync,
       toggleSorting,
       sortingOrderIconName,
+      stickyCSSVariables,
       rowCSSVariables,
       getHeaderCSSVariables,
       getCellCSSVariables,
@@ -454,6 +453,12 @@ export default defineComponent({
   // The calculated variables are taken from a respective element's `style` attribute. See the `useStylable` hook
 
   .va-data-table {
+    --va-data-table-selected-color: v-bind(rowCSSVariables.selectedColor);
+    --va-data-table-hover-color: v-bind(rowCSSVariables.hoverColor);
+    --va-data-table-sticky-thead-background-color: v-bind(stickyCSSVariables.stickyBg);
+    --va-data-table-sticky-tfoot-background-color: v-bind(stickyCSSVariables.stickyBg);
+    --va-data-table-scrolled-table-height: v-bind(stickyCSSVariables.tableHeight);
+
     overflow-x: auto;
     overflow-y: hidden;
     min-width: unset;
@@ -462,7 +467,7 @@ export default defineComponent({
     &--sticky,
     &--scroll {
       overflow-y: auto;
-      height: var(--va-data-table-scroll-table-height);
+      height: var(--va-data-table-scrolled-table-height);
 
       // 1) doesn't work in Firefox
       // 2) doesn't disappear on mac (the standard one does)
@@ -487,7 +492,7 @@ export default defineComponent({
           position: sticky;
           top: 0;
           z-index: 1;
-          background-color: var(--va-data-table-scroll-table-color);
+          background-color: var(--va-data-table-sticky-thead-background-color);
         }
       }
 
@@ -511,7 +516,7 @@ export default defineComponent({
           position: sticky;
           bottom: 0;
           z-index: 1;
-          background-color: var(--va-data-table-scroll-table-color);
+          background-color: var(--va-data-table-sticky-tfoot-background-color);
         }
       }
 

--- a/packages/ui/src/components/va-data-table/VaDataTable.vue
+++ b/packages/ui/src/components/va-data-table/VaDataTable.vue
@@ -401,7 +401,6 @@ export default defineComponent({
         attrs.class,
       ],
       style: [attrs.style],
-      // style: [stickyCSSVariables.value, attrs.style],
     }) as HTMLAttributes)
 
     const computedTableAttributes = computed(() => ({
@@ -455,9 +454,9 @@ export default defineComponent({
   .va-data-table {
     --va-data-table-selected-color: v-bind(rowCSSVariables.selectedColor);
     --va-data-table-hover-color: v-bind(rowCSSVariables.hoverColor);
-    --va-data-table-sticky-thead-background-color: v-bind(stickyCSSVariables.stickyBg);
-    --va-data-table-sticky-tfoot-background-color: v-bind(stickyCSSVariables.stickyBg);
-    --va-data-table-scrolled-table-height: v-bind(stickyCSSVariables.tableHeight);
+    --va-data-table-thead-background: v-bind(stickyCSSVariables.stickyBg);
+    --va-data-table-tfoot-background: v-bind(stickyCSSVariables.stickyBg);
+    --va-data-table-height: v-bind(stickyCSSVariables.tableHeight);
 
     overflow-x: auto;
     overflow-y: hidden;
@@ -467,7 +466,7 @@ export default defineComponent({
     &--sticky,
     &--scroll {
       overflow-y: auto;
-      height: var(--va-data-table-scrolled-table-height);
+      height: var(--va-data-table-height);
 
       // 1) doesn't work in Firefox
       // 2) doesn't disappear on mac (the standard one does)
@@ -492,7 +491,7 @@ export default defineComponent({
           position: sticky;
           top: 0;
           z-index: 1;
-          background-color: var(--va-data-table-sticky-thead-background-color);
+          background: var(--va-data-table-thead-background);
         }
       }
 
@@ -516,7 +515,7 @@ export default defineComponent({
           position: sticky;
           bottom: 0;
           z-index: 1;
-          background-color: var(--va-data-table-sticky-tfoot-background-color);
+          background: var(--va-data-table-tfoot-background);
         }
       }
 

--- a/packages/ui/src/components/va-data-table/_variables.scss
+++ b/packages/ui/src/components/va-data-table/_variables.scss
@@ -11,7 +11,7 @@
   --va-data-table-thead-color: var(--va-dark);
 
   /* Sticky */
-  --va-data-table-sticky-background-color: var(--va-white);
+  --va-data-table-header-background: var(--va-white);
 
   /* hover */
   --va-data-table-hover-th-opacity: 0.3;

--- a/packages/ui/src/components/va-data-table/_variables.scss
+++ b/packages/ui/src/components/va-data-table/_variables.scss
@@ -1,4 +1,4 @@
-:root {
+.va-data-table {
   --va-data-table-cell-padding: 0.625rem;
   --va-data-table-thead-line-height: 1.6;
   --va-data-table-thead-font-size: 0.625rem;
@@ -9,6 +9,9 @@
   --va-data-table-thead-border-top-shadow: inset 0 1px 0 0 var(--va-dark);
   --va-data-table-thead-border-bottom-shadow: inset 0 -1px 0 0 var(--va-dark);
   --va-data-table-thead-color: var(--va-dark);
+
+  /* Sticky */
+  --va-data-table-sticky-background-color: var(--va-white);
 
   /* hover */
   --va-data-table-hover-th-opacity: 0.3;

--- a/packages/ui/src/components/va-data-table/hooks/useStylable.ts
+++ b/packages/ui/src/components/va-data-table/hooks/useStylable.ts
@@ -37,7 +37,7 @@ export default function useStyleable (props: useStylableProps) {
   }))
 
   const stickyCSSVariables = computed(() => ({
-    stickyBg: (props.stickyHeader || props.stickyFooter) ? 'var(--va-data-table-sticky-background-color)' : undefined,
+    stickyBg: (props.stickyHeader || props.stickyFooter) ? 'var(--va-data-table-header-background)' : undefined,
     tableHeight: props.height ? safeCSSLength(props.height) : undefined,
   }))
 

--- a/packages/ui/src/components/va-data-table/hooks/useStylable.ts
+++ b/packages/ui/src/components/va-data-table/hooks/useStylable.ts
@@ -27,18 +27,18 @@ const getClass = (classes: DataTableColumnClass) => isFunction(classes) ? classe
 const getStyle = (styles: DataTableColumnStyle) => isFunction(styles) ? styles() : styles
 
 export default function useStyleable (props: useStylableProps) {
-  const { getColor, getFocusColor, getHoverColor, shiftHSLAColor } = useColors()
+  const { getColor, getFocusColor, getHoverColor } = useColors()
 
   const color = computed(() => getColor(props.selectedColor))
 
   const rowCSSVariables = computed(() => ({
-    [`${prefix}-hover-color`]: getHoverColor(color.value),
-    [`${prefix}-selected-color`]: props.selectable ? getFocusColor(color.value) : undefined,
+    hoverColor: getHoverColor(color.value),
+    selectedColor: props.selectable ? getFocusColor(color.value) : undefined,
   }))
 
   const stickyCSSVariables = computed(() => ({
-    [`${prefix}-scroll-table-color`]: (props.height || props.stickyHeader || props.stickyFooter) && shiftHSLAColor(color.value, { l: 40 }),
-    [`${prefix}-scroll-table-height`]: props.height ? safeCSSLength(props.height) : undefined,
+    stickyBg: (props.stickyHeader || props.stickyFooter) ? 'var(--va-data-table-sticky-background-color)' : undefined,
+    tableHeight: props.height ? safeCSSLength(props.height) : undefined,
   }))
 
   const getHeaderCSSVariables = (column: DataTableColumnInternal) => ({


### PR DESCRIPTION
## Description
close #2339 

changes:
- [x] add css variable for sticky background-color
- [x] update docs example

![chrome-capture-2022-8-12 (1)](https://user-images.githubusercontent.com/55198465/189727363-a953d57d-26bc-4326-91e9-18f40d92f13f.gif)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
