### PR TITLE
`VaButton` background color state should rely on CSS, no on JS

### DIFF
--- a/packages/docs/src/page-configs/ui-elements/button/examples/Behaviour.vue
+++ b/packages/docs/src/page-configs/ui-elements/button/examples/Behaviour.vue
@@ -1,6 +1,6 @@
 <template>
   <div style="display: flex; align-items: center;">
-    <va-button class="mr-4 mb-2" hover-behaviour="opacity" :hover-opacity="0.1">Hover me</va-button>
+    <va-button class="mr-4 mb-2" preset="secondary" hover-behaviour="opacity" :hoverOpacity="0.4">Hover me</va-button>
     <va-button class="mr-4 mb-2" pressed-behaviour="mask" :pressed-opacity="1" pressed-mask-color="warning">Press me</va-button>
   </div>
 </template>

--- a/packages/docs/src/page-configs/ui-elements/button/examples/WithOutline.vue
+++ b/packages/docs/src/page-configs/ui-elements/button/examples/WithOutline.vue
@@ -1,7 +1,6 @@
 <template>
   <div style="display: flex; align-items: center;">
     <va-button preset="secondary" border-color="primary" class="mr-4 mb-2">Label</va-button>
-    <va-button preset="plain" border-color="primary" class="mr-4 mb-2" icon="close" />
     <va-button preset="primary" class="mr-4 mb-2" round icon="close" border-color="primary">Label</va-button>
   </div>
 </template>

--- a/packages/ui/src/components/va-button-group/VaButtonGroup.vue
+++ b/packages/ui/src/components/va-button-group/VaButtonGroup.vue
@@ -73,34 +73,25 @@ export default defineComponent({
     .va-button {
       margin: var(--va-button-group-button-margin);
       box-shadow: none;
+      outline: none;
 
-      @include keyboard-focus-outline($offset: -2px);
+      &:focus-visible {
+        outline: none !important;
+
+        &::before {
+          @include focus-outline($offset: -2px, $radius: 'inherit');
+        }
+      }
     }
 
     & > .va-button:last-child {
       width: var(--va-button-group-button-width);
       padding-right: var(--va-button-group-button-padding);
-
-      &.va-button--small {
-        padding-right: var(--va-button-group-sm-button-padding);
-      }
-
-      &.va-button--large {
-        padding-right: var(--va-button-group-lg-button-padding);
-      }
     }
 
     & > .va-button:first-child {
       width: var(--va-button-group-button-width);
       padding-left: var(--va-button-group-button-padding);
-
-      &.va-button--small {
-        padding-left: var(--va-button-group-sm-button-padding);
-      }
-
-      &.va-button--large {
-        padding-left: var(--va-button-group-lg-button-padding);
-      }
     }
 
     & > .va-button:not(:last-child) {

--- a/packages/ui/src/components/va-button-group/_variables.scss
+++ b/packages/ui/src/components/va-button-group/_variables.scss
@@ -2,12 +2,10 @@
   --va-button-group-display: flex;
   --va-button-group-justify-content: stretch;
   --va-button-group-border-radius: 999px;
-  --va-button-group-gap: 0.5rem;
+  --va-button-group-gap: 0.25rem;
 
   /* Button */
   --va-button-group-button-margin: 0;
   --va-button-group-button-width: auto;
-  --va-button-group-button-padding: 0.5rem;
-  --va-button-group-sm-button-padding: 0.25rem;
-  --va-button-group-lg-button-padding: 1rem;
+  --va-button-group-button-padding: 0.25rem;
 }

--- a/packages/ui/src/components/va-button/VaButton.vue
+++ b/packages/ui/src/components/va-button/VaButton.vue
@@ -240,7 +240,7 @@ export default defineComponent({
     }
 
     &::before {
-      background-color: v-bind(backgroundColor);
+      background: v-bind(backgroundColor);
       opacity: v-bind(backgroundColorOpacity);
     }
 

--- a/packages/ui/src/components/va-button/VaButton.vue
+++ b/packages/ui/src/components/va-button/VaButton.vue
@@ -169,12 +169,16 @@ export default defineComponent({
     const isTransparentBg = computed(() => props.plain || props.backgroundOpacity < 0.5)
     const { textColorComputed } = useTextColor(colorComputed, isTransparentBg)
 
-    const backgroundComputed = useButtonBackground(colorComputed, isPressed, isHovered)
+    const {
+      backgroundColor,
+      backgroundColorOpacity,
+      backgroundMaskOpacity,
+      backgroundMaskColor,
+    } = useButtonBackground(colorComputed, isPressed, isHovered)
     const contentColorComputed = useButtonTextColor(textColorComputed, colorComputed, isPressed, isHovered)
 
     const computedStyle = computed(() => ({
       borderColor: props.borderColor ? getColor(props.borderColor) : 'transparent',
-      ...backgroundComputed.value,
       ...contentColorComputed.value,
     }))
 
@@ -190,6 +194,11 @@ export default defineComponent({
       attributesComputed,
       wrapperClassComputed,
       iconAttributesComputed,
+
+      backgroundColor,
+      backgroundMaskColor,
+      backgroundMaskOpacity,
+      backgroundColorOpacity,
 
       ...publicMethods,
     }
@@ -221,10 +230,30 @@ export default defineComponent({
     box-sizing: border-box;
     cursor: var(--va-button-cursor);
 
+    &::after,
+    &::before {
+      content: '';
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      border-radius: inherit;
+    }
+
+    &::before {
+      background-color: v-bind(backgroundColor);
+      opacity: v-bind(backgroundColorOpacity);
+    }
+
+    &::after {
+      background-color: v-bind(backgroundMaskColor);
+      opacity: v-bind(backgroundMaskOpacity);
+    }
+
     &__content {
       height: 100%;
       display: flex;
       align-items: center;
+      z-index: 1;
 
       &__title,
       &__icon {
@@ -372,6 +401,7 @@ export default defineComponent({
 
       & .va-button__content {
         padding: 0;
+        z-index: unset;
       }
     }
 

--- a/packages/ui/src/components/va-button/hooks/useButtonTextColor.ts
+++ b/packages/ui/src/components/va-button/hooks/useButtonTextColor.ts
@@ -31,10 +31,10 @@ export const useButtonTextColor: UseButtonTextColor = (
   const { getColor, colorToRgba, getStateMaskGradientBackground } = useColors()
 
   const plainColorStyles = computed(() => ({
+    background: 'transparent',
     color: 'transparent',
     '-webkit-background-clip': 'text',
     'background-clip': 'text',
-    background: textColorComputed.value,
     opacity: getPlainTextOpacity.value,
   }))
 
@@ -64,9 +64,10 @@ export const useButtonTextColor: UseButtonTextColor = (
   return computed(() => {
     const defaultColorStyles = {
       color: textColorComputed.value,
+      background: 'transparent',
     }
 
-    props.plain && Object.assign(defaultColorStyles, plainColorStyles.value)
+    props.plain && Object.assign(defaultColorStyles, plainColorStyles.value, { background: textColorComputed.value })
 
     if (!props.plain) { return defaultColorStyles }
     if (isPressed.value) { return pressedTextColorComputed.value }

--- a/packages/ui/src/styles/global/reset.scss
+++ b/packages/ui/src/styles/global/reset.scss
@@ -344,5 +344,5 @@ input[type="search"]::-webkit-search-decoration,
 input[type="search"]::-webkit-search-cancel-button,
 input[type="search"]::-webkit-search-results-button,
 input[type="search"]::-webkit-search-results-decoration {
-  -webkit-appearance:none;
+  -webkit-appearance: none;
 }


### PR DESCRIPTION
## Description
`VaButton` background state colors now relies on CSS, not JS. Related minor fixes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)