### PR TITLE
[#2423] `VaModal` cancel button preset fix

### DIFF
--- a/packages/ui/src/components/va-modal/VaModal.vue
+++ b/packages/ui/src/components/va-modal/VaModal.vue
@@ -90,9 +90,9 @@
                   >
                     <va-button
                       v-if="$props.cancelText"
+                      preset="plain"
                       color="gray"
-                      class="mr-2"
-                      flat
+                      class="mr-3"
                       @click="cancel"
                     >
                       {{ $props.cancelText }}


### PR DESCRIPTION
Closes: #2423 

## Description
Minor `VaModal` cancel button fix - changed preset (to plain > was also plain before `VaButton` reimplementation).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)