### PR TITLE
[#2243] tagging state select documentation, minor bugfixes

### DIFF
--- a/packages/docs/src/locales/en/en.json
+++ b/packages/docs/src/locales/en/en.json
@@ -3061,10 +3061,11 @@
       },
       "slots": {
         "title": "Slots",
-        "text": [
-          "Includes `content`, `prepend`, `prepend-inner`, `append` and `append-inner` slots.",
-          "The content of the `content` slot replaces the `input` element in the component."
-        ]
+        "text": "Includes `content`, `prepend`, `prepend-inner`, `append` and `append-inner` slots."
+      },
+      "tagging": {
+        "title": "Tagging",
+        "text": "`content` slot allows you to overwrite default `input` element with custom one. So you are able to set tagging state via adding `VaChip` component:"
       },
       "state": {
         "title": "State",

--- a/packages/docs/src/locales/ru/ru.json
+++ b/packages/docs/src/locales/ru/ru.json
@@ -2947,10 +2947,11 @@
       },
       "slots": {
         "title": "Слоты",
-        "text": [
-          "Поддерживаемые слоты: `content`, `prepend`, `prepend-inner`, `append` и `append-inner`.",
-          "Содержимое слота `content` заменяет собой элемент `input` в компоненте."
-        ]
+        "text": "Поддерживаемые слоты: `content`, `prepend`, `prepend-inner`, `append` и `append-inner`."
+      },
+      "tagging": {
+        "title": "Теггирование",
+        "text": "Слот `content` позволяет заменить элемент `input` в компоненте на любой другой. Таким образом, используя `VaChip`, вы получите `select` с теггированием выбранных значений:"
       },
       "state": {
         "title": "Состояния",

--- a/packages/docs/src/page-configs/ui-elements/select/examples/Slots.vue
+++ b/packages/docs/src/page-configs/ui-elements/select/examples/Slots.vue
@@ -2,6 +2,17 @@
   <div style="max-width: 300px;">
     <va-select
       class="mb-4"
+      label="Content slot"
+      :options="options"
+      v-model="value"
+      multiple
+    >
+      <template #content="{ valueString }">
+        {{ valueString }}
+      </template>
+    </va-select>
+    <va-select
+      class="mb-4"
       label="Prepend slot"
       :options="options"
       v-model="value"
@@ -37,7 +48,6 @@
       </template>
     </va-select>
     <va-select
-      class="mb-4"
       label="Append slot"
       :options="options"
       v-model="value"

--- a/packages/docs/src/page-configs/ui-elements/select/examples/Tagging.vue
+++ b/packages/docs/src/page-configs/ui-elements/select/examples/Tagging.vue
@@ -2,18 +2,6 @@
   <div style="max-width: 300px;">
     <va-select
       class="mb-4"
-      label="String"
-      :options="options"
-      v-model="value"
-      multiple
-    >
-      <template #content="{ valueString }">
-        {{ valueString }}
-      </template>
-    </va-select>
-
-    <va-select
-      class="mb-4"
       label="Custom chips (first 3)"
       :options="options"
       v-model="value"
@@ -32,7 +20,6 @@
     </va-select>
 
     <va-select
-      class="mb-4"
       label="Removable chips"
       :options="options"
       v-model="value"

--- a/packages/docs/src/page-configs/ui-elements/select/page-config.ts
+++ b/packages/docs/src/page-configs/ui-elements/select/page-config.ts
@@ -40,13 +40,16 @@ const config: ApiDocsBlock[] = [
     'select.examples.trackBy.text',
     'TrackBy',
   ),
-
-  block.headline('select.examples.slots.title'),
-  block.paragraph('select.examples.slots.text[0]'),
-  block.example('Slots'),
-  block.paragraph('select.examples.slots.text[1]'),
-  block.example('ContentSlot'),
-
+  ...block.exampleBlock(
+    'select.examples.slots.title',
+    'select.examples.slots.text',
+    'Slots',
+  ),
+  ...block.exampleBlock(
+    'select.examples.tagging.title',
+    'select.examples.tagging.text',
+    'Tagging',
+  ),
   ...block.exampleBlock(
     'select.examples.state.title',
     'select.examples.state.text',

--- a/packages/ui/src/components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/va-select/VaSelect.vue
@@ -696,6 +696,11 @@ export default defineComponent({
 
   .va-select {
     min-width: var(--va-select-min-width);
+
+    & .va-input-wrapper__text {
+      line-height: normal;
+      flex-wrap: wrap;
+    }
   }
 
   .va-select-anchor {


### PR DESCRIPTION
Closes: #2243 

## Description
- [x] Highlighted `VaSelect` tagging state documentation.
- [x] Fixed several bugs:

<img width="347" alt="image" src="https://user-images.githubusercontent.com/64714442/192742062-fee4e950-f591-45eb-b6ba-087a0d97b348.png">
 ->
<img width="293" alt="image" src="https://user-images.githubusercontent.com/64714442/192742346-980c288f-aa00-4876-b4e0-9da84d401d08.png">

<img width="279" alt="image" src="https://user-images.githubusercontent.com/64714442/192742227-ae23bd8f-b0d8-48a8-bc4d-be63f6618f6f.png">
(was like this before but was broken) ->
<img width="271" alt="image" src="https://user-images.githubusercontent.com/64714442/192742292-0b8e1c6a-4d7c-4999-b45c-a118fb051327.png">
 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)