### PR TITLE
Fix `VaDataTable` filtering animation

### DIFF
--- a/packages/ui/src/components/va-data-table/VaDataTable.vue
+++ b/packages/ui/src/components/va-data-table/VaDataTable.vue
@@ -93,7 +93,6 @@
           :name="animationName"
           appear
         >
-
           <tr
             v-if="showNoDataHtml"
             key="showNoDataHtml"

--- a/packages/ui/src/components/va-data-table/hooks/useAnimationName.ts
+++ b/packages/ui/src/components/va-data-table/hooks/useAnimationName.ts
@@ -1,31 +1,35 @@
-
 import { computed, Ref, ref, watch } from 'vue'
 import type { DataTableRow } from '../types'
 
-interface useSelectableProps {
+interface useAnimationNameProps {
   currentPage: number | undefined
   animated: boolean
 }
 
-export default function usePaginatedRows (
-  props: useSelectableProps,
+export default function useAnimationName (
+  props: useAnimationNameProps,
   rows: Ref<DataTableRow[]>,
 ) {
-  const animationName = ref('table-transition-shuffle')
+  const animationType = ref('shuffle')
+
+  const animationName = computed(() => props.animated ? `table-transition-${animationType.value}` : '')
+
   const oldRowsLength = ref(rows.value.length)
   const isDifferentRowLength = computed(() => rows.value.length !== oldRowsLength.value)
 
-  watch(rows, (newRows) => {
-    const animationType = isDifferentRowLength.value || newRows.length > 50 ? 'fade' : 'shuffle'
+  watch(rows, (newRows, oldRows) => {
+    const hasRows = !!(newRows.length && oldRows.length)
 
-    animationName.value = props.animated ? `table-transition-${animationType}` : ''
+    animationType.value = newRows.length > 50 || (isDifferentRowLength.value && hasRows)
+      ? 'fade'
+      : 'shuffle'
 
     oldRowsLength.value = newRows.length
   })
 
   watch(() => props.currentPage, () => {
     if (!isDifferentRowLength.value) {
-      animationName.value = props.animated ? 'table-transition-shuffle' : ''
+      animationType.value = 'shuffle'
     }
   })
 

--- a/packages/ui/src/components/va-data-table/hooks/useAnimationName.ts
+++ b/packages/ui/src/components/va-data-table/hooks/useAnimationName.ts
@@ -1,5 +1,8 @@
 import { computed, Ref, ref, watch } from 'vue'
+
 import type { DataTableRow } from '../types'
+
+type AnimationName = 'shuffle' | 'fade'
 
 interface useAnimationNameProps {
   currentPage: number | undefined
@@ -10,7 +13,7 @@ export default function useAnimationName (
   props: useAnimationNameProps,
   rows: Ref<DataTableRow[]>,
 ) {
-  const animationType = ref('shuffle')
+  const animationType = ref<AnimationName>('shuffle')
 
   const animationName = computed(() => props.animated ? `table-transition-${animationType.value}` : '')
 


### PR DESCRIPTION
## Description
close #1202 

change:
- [x] change transition-group animation name when filter result is empty

![chrome-capture-2022-9-1](https://user-images.githubusercontent.com/55198465/193420959-59a77660-e361-488e-8dae-93af330a2a65.gif)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
