### PR TITLE
fix(#2460): merge icons config

### DIFF
--- a/packages/ui/src/services/global-config/global-config.ts
+++ b/packages/ui/src/services/global-config/global-config.ts
@@ -1,4 +1,3 @@
-import merge from 'lodash/merge.js'
 import cloneDeep from 'lodash/cloneDeep.js'
 import { ref, inject, Ref, getCurrentInstance } from 'vue'
 import { GlobalConfig, GlobalConfigUpdater } from './types'
@@ -7,6 +6,7 @@ import { createIconsConfig } from '../icon-config/icon-config-helpers'
 import { colorsPresets } from '../color-config/color-theme-presets'
 import { getBreakpointDefaultConfig } from '../breakpoint'
 import { getGlobalProperty } from '../../vuestic-plugin/utils'
+import { mergeDeep } from '../../utils/merge-deep'
 
 export type ProvidedGlobalConfig = {
   globalConfig: Ref<GlobalConfig>,
@@ -37,7 +37,7 @@ export const createGlobalConfig = () => {
 
   const mergeGlobalConfig = (updater: GlobalConfig | GlobalConfigUpdater) => {
     const config = typeof updater === 'function' ? updater(globalConfig.value) : updater
-    globalConfig.value = merge(cloneDeep(globalConfig.value), config)
+    globalConfig.value = mergeDeep(cloneDeep(globalConfig.value), config)
   }
 
   return {

--- a/packages/ui/src/utils/merge-deep.ts
+++ b/packages/ui/src/utils/merge-deep.ts
@@ -1,0 +1,24 @@
+const isObject = (obj: any) => obj && typeof obj === 'object' && !Array.isArray(obj)
+
+/**
+ * Merge objects deep
+ * If property is array, it will replace target value
+ */
+export const mergeDeep = (target: any, source: any): any => {
+  if (!isObject(target) || !isObject(source)) {
+    return source
+  }
+
+  Object.keys(source).forEach(key => {
+    const targetValue = target[key]
+    const sourceValue = source[key]
+
+    if (isObject(targetValue) && isObject(sourceValue)) {
+      target[key] = mergeDeep(Object.assign({}, targetValue), sourceValue)
+    } else {
+      target[key] = sourceValue
+    }
+  })
+
+  return target
+}

--- a/packages/ui/src/utils/tests/merge-deep.spec.ts
+++ b/packages/ui/src/utils/tests/merge-deep.spec.ts
@@ -1,0 +1,16 @@
+import { mergeDeep } from './../merge-deep'
+import { describe, it, expect } from 'vitest'
+
+describe('test-utils', () => {
+  it('Objects', () => {
+    expect(mergeDeep({ a: 1 }, { b: 2 })).toEqual({ a: 1, b: 2 })
+  })
+
+  it('Object with array', () => {
+    expect(mergeDeep({ a: [1], b: [1] }, { b: [2] })).toEqual({ a: [1], b: [2] })
+  })
+
+  it('Objects deep', () => {
+    expect(mergeDeep({ a: { a: 1 } }, { a: { b: 2 } })).toEqual({ a: { a: 1, b: 2 } })
+  })
+})


### PR DESCRIPTION
closes https://github.com/epicmaxco/vuestic-ui/issues/2460

Fix icons config merge method. For some reason lodash merge trying to merge objects in array and makes it wrong. This is why in https://github.com/epicmaxco/vuestic-ui/issues/2460 for `'mdi-{name}'` object was added class from `'{icon}'` object.
![image](https://user-images.githubusercontent.com/23530004/194327353-75576925-1acc-4cbf-b2aa-c21f94f26355.png)


Looks like if lodash merge first objects with name key.

![image](https://user-images.githubusercontent.com/23530004/194329786-e5bb9214-ef5b-44b6-b26f-12e73ef5b401.png)


So I made my own merge.