### PR TITLE
fix(#2336): proxy image props to carousel

### DIFF
--- a/packages/docs/src/locales/en/en.json
+++ b/packages/docs/src/locales/en/en.json
@@ -4396,6 +4396,14 @@
       "swipe": {
         "title": "Swipe",
         "text": "The `swipable` prop enables swipe behaviour for the component."
+      },
+      "Ratio": {
+        "title": "Ratio",
+        "text": "The `ratio` prop allows you to set the aspect ratio of the carousel."
+      },
+      "Height": {
+        "title": "Height",
+        "text": "If you need specific height instead of ratio, you can use `height` prop."
       }
     },
     "variables": "[GitHub Variables Page](https://github.com/epicmaxco/vuestic-ui/blob/develop/packages/ui/src/components/va-carousel/_variables.scss)[[target=_blank]]"

--- a/packages/docs/src/page-configs/ui-elements/carousel/examples/Height.vue
+++ b/packages/docs/src/page-configs/ui-elements/carousel/examples/Height.vue
@@ -1,0 +1,20 @@
+<template>
+  <va-carousel :items="items" v-model="value" height="222px" />
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      value: 0,
+      items: [
+        'https://picsum.photos/1500',
+        'https://picsum.photos/1501',
+        'https://picsum.photos/1502',
+        'https://picsum.photos/1503',
+        'https://picsum.photos/1504',
+      ],
+    }
+  },
+}
+</script>

--- a/packages/docs/src/page-configs/ui-elements/carousel/examples/Ratio.vue
+++ b/packages/docs/src/page-configs/ui-elements/carousel/examples/Ratio.vue
@@ -1,0 +1,25 @@
+<template>
+  <div>
+    <va-carousel :items="items" v-model="value" :ratio="1/1" />
+  </div>
+  <div>
+    <va-carousel :items="items" v-model="value" :ratio="21/9" />
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      value: 0,
+      items: [
+        'https://picsum.photos/1500',
+        'https://picsum.photos/1501',
+        'https://picsum.photos/1502',
+        'https://picsum.photos/1503',
+        'https://picsum.photos/1504',
+      ],
+    }
+  },
+}
+</script>

--- a/packages/docs/src/page-configs/ui-elements/carousel/page-config.ts
+++ b/packages/docs/src/page-configs/ui-elements/carousel/page-config.ts
@@ -69,6 +69,18 @@ const config: ApiDocsBlock[] = [
     'Swipe',
   ),
 
+  ...block.exampleBlock(
+    'carousel.examples.Ratio.title',
+    'carousel.examples.Ratio.text',
+    'Ratio',
+  ),
+
+  ...block.exampleBlock(
+    'carousel.examples.Height.title',
+    'carousel.examples.Height.text',
+    'Height',
+  ),
+
   block.api(VaCarousel, apiOptions),
 
   block.subtitle('all.cssVariables'),

--- a/packages/ui/src/components/va-carousel/VaCarousel.vue
+++ b/packages/ui/src/components/va-carousel/VaCarousel.vue
@@ -83,6 +83,7 @@
         >
           <slot v-bind="{ item, index, goTo, isActive: isCurrentSlide(index) }">
             <va-image
+              v-bind="vaImageProps"
               :src="isObjectSlides ? item.src : item"
               :alt="isObjectSlides ? item.alt : ''"
               :draggable="false"
@@ -110,6 +111,10 @@ import { VaHover } from '../va-hover'
 
 import type { SwipeState } from '../../composables'
 
+import { extractComponentProps, filterComponentProps } from '../../utils/child-props'
+
+const VaImageProps = extractComponentProps(VaImage, ['src', 'alt'])
+
 export default defineComponent({
   name: 'VaCarousel',
 
@@ -119,6 +124,7 @@ export default defineComponent({
     ...useSwipeProps,
     ...useStatefulProps,
     ...useComponentPresetProp,
+    ...VaImageProps,
 
     modelValue: { type: Number, default: 0 },
     items: { type: Array as PropType<any[]>, required: true },
@@ -139,13 +145,14 @@ export default defineComponent({
       validator: (value: string) => ['click', 'hover'].includes(value),
     },
     vertical: { type: Boolean, default: false },
-    height: { type: String, default: '300px' },
+    height: { type: String, default: 'auto' },
     effect: {
       type: String as PropType<'fade' | 'transition'>,
       default: 'transition',
       validator: (value: string) => ['fade', 'transition'].includes(value),
     },
     color: { type: String, default: 'primary' },
+    ratio: { type: Number, default: 16 / 9 },
   },
 
   emits: useStatefulEmits,
@@ -184,6 +191,7 @@ export default defineComponent({
     useSwipe(props, slidesContainer, onSwipe)
 
     return {
+      vaImageProps: filterComponentProps(props, VaImageProps),
       doShowNextButton,
       doShowPrevButton,
       computedSlidesStyle,
@@ -219,6 +227,8 @@ export default defineComponent({
     display: flex;
     width: 100%;
     height: 100%;
+    max-height: 100%;
+    min-height: 100px;
     background: var(--va-carousel-background);
     box-shadow: var(--va-carousel-box-shadow);
     border-radius: var(--va-carousel-border-radius);


### PR DESCRIPTION
Proxy props for VaImage, so now user can specify ratio.

Previously it has 300px height by default, but now it has 16/9 ratio by default instead. You still can specify height BTW.

It will break current carousel layout for some people.

![image](https://user-images.githubusercontent.com/23530004/194778559-6c1a060d-2191-437c-8d8c-037795ad3f60.png)
![image](https://user-images.githubusercontent.com/23530004/194778548-6c0de1f6-b69a-43c9-9271-8e3c73fd1764.png)
