### PR TITLE
fix: broken icons on landing

### DIFF
--- a/packages/docs/src/assets/main.scss
+++ b/packages/docs/src/assets/main.scss
@@ -1,5 +1,5 @@
 @import "~vuestic-ui/src/styles/global/reset.scss";
-@import "~vuestic-ui/src/styles/index.scss";
+@import "~vuestic-ui/src/styles/resources";
 @import "./smart-grid.scss";
 @import "./colors.scss";
 @import "./fonts.scss";


### PR DESCRIPTION
in-depth problem was that font was applied globally on typography.css include