### PR TITLE
fix(input): add va-input-wrapper flex:1

### DIFF
--- a/packages/ui/src/components/va-input/components/VaInputWrapper/VaInputWrapper.vue
+++ b/packages/ui/src/components/va-input/components/VaInputWrapper/VaInputWrapper.vue
@@ -215,6 +215,7 @@ export default defineComponent({
   vertical-align: var(--va-input-wrapper-vertical-align);
   min-width: var(--va-input-wrapper-min-width);
   max-width: 100%;
+  flex:1;
 
   &__field {
     position: relative;


### PR DESCRIPTION
`.va-input-wrapper` need  `flex:1`


<img width="1605" alt="image" src="https://user-images.githubusercontent.com/36926073/197976087-8685f607-aa23-47f0-a2ca-6977d7c81dc8.png">


<img width="1541" alt="image" src="https://user-images.githubusercontent.com/36926073/197976846-fd9bb53e-93b8-4a1a-ad52-5c8a8e647c6b.png">

and the select component  is correct  and it has `flex:1`
<img width="1561" alt="image" src="https://user-images.githubusercontent.com/36926073/197977104-1d10377d-3d4b-4282-957a-88a09584c41c.png">


```vue
 <div class="grid grid-cols-4 gap-2">

  <va-dropdown
    :auto-placement="false"
    :close-on-content-click="false"
    @open.once="onOpen()"
    @close="onClose()"
    placement="bottom"
    v-model="state.showDropDown"
    prevent-overflow
    :offset="[0, 50]"
  >
    <template #anchor>
      <va-input
        :modelValue="shownValue"
        :label="props.label"
        readonly
        class="cursor-pointer"
      >
        <template #appendInner>
          <va-icon name="collections_bookmark" @click.stop="openBookMark()" />
        </template>
      </va-input>
    </template>
</va-dropdown>
</div>
```

