### PR TITLE
fix: change text color for outlined alerts

### DIFF
--- a/packages/ui/src/components/va-alert/useAlertStyles.ts
+++ b/packages/ui/src/components/va-alert/useAlertStyles.ts
@@ -50,7 +50,7 @@ export const useAlertStyles = (props: AlertStyleProps) => {
   const contentStyle = computed(() => {
     return {
       alignItems: props.center ? 'center' : '',
-      color: props.border ? getColor(getTextColor(background.value), undefined, true) : textColorComputed.value,
+      color: (props.border || props.outline) ? getColor(getTextColor(background.value), undefined, true) : textColorComputed.value,
     }
   })
 


### PR DESCRIPTION
Related to #2578

## Description
- Changed default text color for the outlined alerts.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
