### PR TITLE
fix: currentPresetName in createVuestic does nothing

### DIFF
--- a/packages/ui/src/services/color-config/plugin/create-color-config-plugin.ts
+++ b/packages/ui/src/services/color-config/plugin/create-color-config-plugin.ts
@@ -1,17 +1,16 @@
+import { PartialGlobalConfig } from './../../global-config/types'
 import { ColorVariables } from './../types'
 import { App, watch } from 'vue'
 import { isServer } from '../../../utils/ssr-utils'
-import { getGlobalProperty } from '../../../vuestic-plugin/utils'
 import { cssVariableName } from '../utils'
-import { getTextColor } from '../color-functions'
 import { useColors } from '../../../composables'
 
 export const setCSSVariable = (name: string, value: string, root: HTMLElement) => {
   root.style.setProperty(cssVariableName(name), value)
 }
 
-export const createColorConfigPlugin = (app: App) => {
-  const { colors, getTextColor, getColor } = useColors()
+export const createColorConfigPlugin = (app: App, config: PartialGlobalConfig | undefined) => {
+  const { colors, getTextColor, getColor, currentPresetName, applyPreset } = useColors()
 
   /** Renders CSS variables string. Use this in SSR mode */
   const renderCSSVariables = (colors: ColorVariables | undefined) => {
@@ -36,11 +35,13 @@ export const createColorConfigPlugin = (app: App) => {
     })
   }
 
-  updateColors(colors)
-
   watch(colors, (newValue) => {
     updateColors(newValue)
   }, { immediate: true, deep: true })
+
+  if (config?.colors?.currentPresetName) {
+    applyPreset(config.colors.currentPresetName)
+  }
 
   return {
     renderCSSVariables,

--- a/packages/ui/src/services/color-config/plugin/create-color-config-plugin.ts
+++ b/packages/ui/src/services/color-config/plugin/create-color-config-plugin.ts
@@ -9,7 +9,7 @@ export const setCSSVariable = (name: string, value: string, root: HTMLElement) =
   root.style.setProperty(cssVariableName(name), value)
 }
 
-export const createColorConfigPlugin = (app: App, config: PartialGlobalConfig | undefined) => {
+export const createColorConfigPlugin = (app: App, config?: PartialGlobalConfig) => {
   const { colors, getTextColor, getColor, currentPresetName, applyPreset } = useColors()
 
   /** Renders CSS variables string. Use this in SSR mode */

--- a/packages/ui/src/services/color-config/plugin/index.ts
+++ b/packages/ui/src/services/color-config/plugin/index.ts
@@ -3,7 +3,7 @@ import { createColorConfigPlugin } from './create-color-config-plugin'
 import { defineGlobalProperty, defineVuesticPlugin } from '../../../vuestic-plugin/utils'
 
 /** Creates color css variables and reactively updates on ColorConfig changes. */
-export const ColorConfigPlugin = defineVuesticPlugin((config: PartialGlobalConfig | undefined) => ({
+export const ColorConfigPlugin = defineVuesticPlugin((config?: PartialGlobalConfig) => ({
   install (app) {
     defineGlobalProperty(app, '$vaColorConfig', createColorConfigPlugin(app, config))
   },

--- a/packages/ui/src/services/color-config/plugin/index.ts
+++ b/packages/ui/src/services/color-config/plugin/index.ts
@@ -1,10 +1,11 @@
+import { PartialGlobalConfig } from './../../global-config/types'
 import { createColorConfigPlugin } from './create-color-config-plugin'
 import { defineGlobalProperty, defineVuesticPlugin } from '../../../vuestic-plugin/utils'
 
 /** Creates color css variables and reactively updates on ColorConfig changes. */
-export const ColorConfigPlugin = defineVuesticPlugin(() => ({
+export const ColorConfigPlugin = defineVuesticPlugin((config: PartialGlobalConfig | undefined) => ({
   install (app) {
-    defineGlobalProperty(app, '$vaColorConfig', createColorConfigPlugin(app))
+    defineGlobalProperty(app, '$vaColorConfig', createColorConfigPlugin(app, config))
   },
 }))
 

--- a/packages/ui/src/vuestic-plugin/create-vuestic/create-vuestic-essential.ts
+++ b/packages/ui/src/vuestic-plugin/create-vuestic/create-vuestic-essential.ts
@@ -36,8 +36,7 @@ export const createVuesticEssential = defineVuesticPlugin((options: {
     // These plugins have dependant plugins, so have to be registered first.
     usePlugin(app, plugins?.GlobalConfigPlugin || GlobalConfigPlugin, config)
     usePlugin(app, plugins?.CachePlugin || CachePlugin)
-
-    usePlugin(app, plugins?.ColorConfigPlugin || ColorConfigPlugin)
+    usePlugin(app, plugins?.ColorConfigPlugin || ColorConfigPlugin, config)
 
     if (plugins) {
       Object.entries(plugins).forEach(([name, plugin]) => {

--- a/packages/ui/src/vuestic-plugin/create-vuestic/create-vuestic.ts
+++ b/packages/ui/src/vuestic-plugin/create-vuestic/create-vuestic.ts
@@ -29,9 +29,9 @@ export const createVuestic = defineVuesticPlugin((options: { config?: PartialGlo
     // These plugins have dependant plugins, so have to be registered first.
     usePlugin(app, GlobalConfigPlugin(config))
     usePlugin(app, CachePlugin)
+    usePlugin(app, ColorConfigPlugin(config))
 
     usePlugin(app, BreakpointConfigPlugin)
-    usePlugin(app, ColorConfigPlugin)
     usePlugin(app, VaDropdownPlugin)
     usePlugin(app, VaToastPlugin)
     usePlugin(app, VaModalPlugin)


### PR DESCRIPTION
Now it works:
```ts
const theme = Boolean(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light'

createApp(App)
  .use(createVuestic({
    config: {
      colors: {
        currentPresetName: theme,
      }
    }
  }))
  .mount('#app')
```