### PR TITLE
[#2685] Color dropdown badge padding fix

### DIFF
--- a/packages/docs/src/components/header/components/ColorDropdown.vue
+++ b/packages/docs/src/components/header/components/ColorDropdown.vue
@@ -88,7 +88,7 @@ export default defineComponent({
     position: relative;
     display: flex;
     align-items: center;
-    margin-right: 2rem;
+    padding-right: 2.25rem;
   }
 
   &__content {


### PR DESCRIPTION
Closes: #2685 

## Description
Slightly increased space between dropdown and badge.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
