### PR TITLE
fix: replace navbar static height with paddings, fix: mobile layout

### DIFF
--- a/packages/docs/src/page-configs/ui-elements/navbar/examples/Height.vue
+++ b/packages/docs/src/page-configs/ui-elements/navbar/examples/Height.vue
@@ -1,5 +1,5 @@
 <template>
-  <va-navbar color="#282F69" style="height: 38px;">
+  <va-navbar color="#282F69" style="height: 100px;">
     <template #left>
       <va-navbar-item class="logo">LOGO</va-navbar-item>
     </template>

--- a/packages/ui/src/components/va-navbar/VaNavbar.vue
+++ b/packages/ui/src/components/va-navbar/VaNavbar.vue
@@ -89,7 +89,7 @@ export default defineComponent({
   align-items: center;
   transition: var(--va-navbar-transition);
   position: var(--va-navbar-position);
-  padding: var(--va-navbar-padding-y) var(--va-navbar-padding-y);
+  padding: var(--va-navbar-padding-y) var(--va-navbar-padding-x);
   background-color: var(--va-primary);
   font-family: var(--va-font-family);
   top: 0;

--- a/packages/ui/src/components/va-navbar/VaNavbar.vue
+++ b/packages/ui/src/components/va-navbar/VaNavbar.vue
@@ -174,7 +174,6 @@ export default defineComponent({
   @include media-breakpoint-down(sm) {
     display: flex;
     flex-direction: column;
-    justify-content: center;
     align-items: center;
     height: var(--va-navbar-mobile-height);
     padding: var(--va-navbar-sm-padding);

--- a/packages/ui/src/components/va-navbar/VaNavbar.vue
+++ b/packages/ui/src/components/va-navbar/VaNavbar.vue
@@ -84,8 +84,8 @@ export default defineComponent({
 @import "variables";
 
 .va-navbar {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template: "left center right" / 1fr auto 1fr;
   align-items: center;
   transition: var(--va-navbar-transition);
   position: var(--va-navbar-position);
@@ -100,7 +100,6 @@ export default defineComponent({
 
   &__left {
     display: flex;
-    flex-direction: row;
     grid-area: left;
 
     & > .va-navbar__item {
@@ -119,9 +118,8 @@ export default defineComponent({
 
   &__center {
     display: flex;
+    justify-content: center;
     grid-area: center;
-    margin-left: auto;
-    margin-right: auto;
 
     & > .va-navbar__item {
       margin: 0 var(--va-navbar-item-margin);

--- a/packages/ui/src/components/va-navbar/VaNavbar.vue
+++ b/packages/ui/src/components/va-navbar/VaNavbar.vue
@@ -48,7 +48,7 @@ export default defineComponent({
     shape: { type: Boolean, default: false },
   },
 
-  setup (props, { slots }) {
+  setup (props) {
     // TODO(1.6.0): Remove deprecated slots
     useDeprecated(['center'], ['slots'])
 
@@ -70,22 +70,10 @@ export default defineComponent({
       fill: textColorComputed.value,
     }))
 
-    const gridTemplateComputed = computed(() => {
-      const gridTemplateAreas = [
-        slots.left && 'left',
-        (slots.default || slots.center) && 'center',
-        slots.right && 'right',
-      ].filter(v => v)
-      const sizes = '1fr '.repeat(gridTemplateAreas.length).trimEnd()
-
-      return `"${gridTemplateAreas.join(' ')}" / ${sizes}`
-    })
-
     return {
       scrollRoot,
       computedStyle,
       shapeStyleComputed,
-      gridTemplateComputed,
     }
   },
 })
@@ -96,14 +84,12 @@ export default defineComponent({
 @import "variables";
 
 .va-navbar {
-  display: grid;
-  grid-template: v-bind(gridTemplateComputed);
+  display: flex;
+  justify-content: space-between;
   align-items: center;
   transition: var(--va-navbar-transition);
   position: var(--va-navbar-position);
-  height: var(--va-navbar-height);
-  padding-left: var(--va-navbar-padding-left);
-  padding-right: var(--va-navbar-padding-right);
+  padding: var(--va-navbar-padding-y) var(--va-navbar-padding-y);
   background-color: var(--va-primary);
   font-family: var(--va-font-family);
   top: 0;
@@ -116,7 +102,6 @@ export default defineComponent({
     display: flex;
     flex-direction: row;
     grid-area: left;
-    justify-self: start;
 
     & > .va-navbar__item {
       margin-right: var(--va-navbar-item-margin-side);
@@ -135,7 +120,8 @@ export default defineComponent({
   &__center {
     display: flex;
     grid-area: center;
-    justify-self: center;
+    margin-left: auto;
+    margin-right: auto;
 
     & > .va-navbar__item {
       margin: 0 var(--va-navbar-item-margin);
@@ -155,7 +141,6 @@ export default defineComponent({
     flex-direction: row;
     justify-content: flex-end;
     grid-area: right;
-    justify-self: end;
 
     & > .va-navbar__item {
       margin-right: var(--va-navbar-item-margin-side);

--- a/packages/ui/src/components/va-navbar/_variables.scss
+++ b/packages/ui/src/components/va-navbar/_variables.scss
@@ -1,8 +1,8 @@
 .va-navbar {
   --va-navbar-mobile-height: 6.5rem;
   --va-navbar-height: 4.0625rem;
-  --va-navbar-padding-left: 1rem;
-  --va-navbar-padding-right: 1rem;
+  --va-navbar-padding-x: 1rem;
+  --va-navbar-padding-y: 1.2rem;
   --va-navbar-transition: transform 0.5s ease;
   --va-navbar-position: relative;
   --va-nav-z-index: calc(var(--va-z-index-teleport-overlay) - 100);


### PR DESCRIPTION
I changed navbar height to be defined by padding rather than height so it can expand instead of overflowing and fixed a couple of layout bugs.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
