### PR TITLE
fix(#2839): do not register vuestic-ui.css in nuxt which contains all…

### DIFF
--- a/packages/nuxt/src/composables/use-css.ts
+++ b/packages/nuxt/src/composables/use-css.ts
@@ -28,7 +28,7 @@ export const useVuesticCSS = (options: VuesticOptions) => {
     })
   } else if (options.css === true) {
     /** Register all CSS */
-    nuxt.options.css.push('vuestic-ui/dist/vuestic-ui.css')
+    nuxt.options.css.push('vuestic-ui/dist/styles/index.css')
   }
 
   if (options.fonts) {


### PR DESCRIPTION
closes https://github.com/epicmaxco/vuestic-ui/issues/2839

It looks like we were register vuestic-ui.css which contains all css for IIFE and CJS builds. I'm not sure if we want to import vuestic/css which should return different css for es and cjs build. So instead I choose to register vuestic/styles/index.css manually.

Please, need some sort of QA.