### PR TITLE
fix: build vuestic from sandbox if it doesn't exist

### DIFF
--- a/packages/sandbox/scripts/bundle-analysis.ts
+++ b/packages/sandbox/scripts/bundle-analysis.ts
@@ -24,6 +24,10 @@ import * as process from 'process'
   }
 
   if (forceRebuild || !existsSync(bundleSizesCachePath)) {
+    if (!existsSync('../ui/dist')) {
+      await $('yarn workspace vuestic-ui build', {})
+    }
+
     await Promise.all([
       $('vite build --config ./configs/vite/vite.empty.ts', { successMessage: 'Empty config was built.' }),
       $('vite build --config ./configs/vite/vite.button.ts', { successMessage: 'Config with button was built.' }),

--- a/packages/sandbox/scripts/bundle-analysis.ts
+++ b/packages/sandbox/scripts/bundle-analysis.ts
@@ -19,12 +19,15 @@ import * as process from 'process'
   }
 
   const bundleSizesCachePath = `./${analyticsStorePath}/bundle-sizes.js`
-  if ((forceRebuild) && existsSync(bundleSizesCachePath)) {
-    rmSync(bundleSizesCachePath)
-  }
+  const vuesticDistPath = '../ui/dist'
 
-  if (forceRebuild || !existsSync(bundleSizesCachePath)) {
-    if (!existsSync('../ui/dist')) {
+  if (forceRebuild) {
+    if (existsSync(bundleSizesCachePath)) {
+      rmSync(bundleSizesCachePath)
+    }
+
+    if (!existsSync(vuesticDistPath)) {
+      console.warn(`[bundle analysis] Vuestic dist wasn't found in ${vuesticDistPath}. Proceeding new build...`)
       await $('yarn workspace vuestic-ui build', {})
     }
 
@@ -35,6 +38,10 @@ import * as process from 'process'
       $('vite build --config ./configs/vite/vite.button-select.ts', { successMessage: 'Config with button and select was built.' }),
     ])
   }
+
+  const baseOutputPath = outputDir || analyticsStorePath
+  const mdFilePath = `${baseOutputPath}/tree-shaking.md`
+  const devMdFilePath = `${baseOutputPath}/dev-tree-shaking.md`
 
   if (existsSync(bundleSizesCachePath)) {
     const VUETIFY_VERSION = '3.0.3'
@@ -49,10 +56,8 @@ import * as process from 'process'
     const bundleSizes = await (async () => await require('../analysis/bundle-sizes.js'))()
     const { empty, button, buttonSelect, full } = bundleSizes
 
-    const baseOutputPath = outputDir || analyticsStorePath
     const getOutputBundleSize = (v: number) => Math.trunc((v - empty) / 1000)
 
-    const mdFilePath = `${baseOutputPath}/tree-shaking.md`
     writeFileSync(mdFilePath, `
 | Bundle                     | Vuestic UI                                |
 | -------------------------- | :---------------------------------------: |
@@ -60,10 +65,9 @@ import * as process from 'process'
 | Core + VaButton            | ~ ${getOutputBundleSize(button)} Kb       |
 | Core + VaButton + VaSelect | ~ ${getOutputBundleSize(buttonSelect)} Kb |
     `)
-    console.warn(`Result was successfully written to ${mdFilePath}.`)
+    console.warn(`[bundle analysis] Result was successfully written to ${mdFilePath}.`)
 
     if (isFullAnalysis) {
-      const devMdFilePath = `${baseOutputPath}/dev-tree-shaking.md`
       writeFileSync(devMdFilePath, `
 | Bundle                 | Vuestic UI                                | Vuetify UI (${VUETIFY_VERSION}) | Naive UI (${NAIVE_VERSION}) |
 | ---------------------- | :---------------------------------------: | :-----------------------------: | :-------------------------: |
@@ -72,11 +76,10 @@ import * as process from 'process'
 | Core + Button + Select | ~ ${getOutputBundleSize(buttonSelect)} Kb | ~ ${VUETIFY_BUTTON_SELECT_SIZE} Kb | ~ ${NAIVE_BUTTON_SELECT_SIZE} Kb |
     `)
 
-      console.warn(`Result was successfully written to ${devMdFilePath}.`)
+      console.warn(`[bundle analysis] Result was successfully written to ${devMdFilePath}.`)
     }
-
-    return
+  } else {
+    writeFileSync(mdFilePath, 'No cache was found. Please, run `yarn build:analysis && vue-cli-service serve` if you want to have bundle size data in dev.')
+    console.warn(`[bundle analysis] Blank file was written to ${mdFilePath}.`)
   }
-
-  console.warn(`${bundleSizesCachePath} file wasn't found. Bundle size analysis was terminated.`)
 })()


### PR DESCRIPTION
## Description
If `ui/dist` doesn't exist, `yarn build:analysis` command at the `sandbox` workspace fails. Let's handle this situation.

## Types of changes
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)