### PR TITLE
feat: add optional strong typing to DataTableColumn

### DIFF
--- a/packages/ui/src/components/va-data-table/types.ts
+++ b/packages/ui/src/components/va-data-table/types.ts
@@ -9,9 +9,9 @@ export type DataTableSortingOptions = DataTableSortingOrder[]
 
 // provided column definitions (<va-data-table `:columns="myColumns"` />)
 // should look like an array of the following objects (and/or strings)
-export type DataTableColumn = {
+export type DataTableColumn<T = string> = {
   [key: string]: any
-  key: string // name of an item's property: 'userName', 'address.zipCode'
+  key: T // name of an item's property: 'userName', 'address.zipCode'
   name?: string // column unique name (used in slots)
   label?: string // what to display in the respective heading
   thTitle?: string // <th>'s `title` attribute's value


### PR DESCRIPTION
## Description
Added generic to DataTableColumn to allow for strongly-typed keys when using the interface.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
