### PR TITLE
Accept string[] and boolean when configuring mask

### DIFF
--- a/packages/ui/src/components/va-input/hooks/useCleave.ts
+++ b/packages/ui/src/components/va-input/hooks/useCleave.ts
@@ -22,7 +22,7 @@ const DEFAULT_MASK_TOKENS: Record<string, Record<string, unknown>> = {
 }
 
 export const useCleaveProps = {
-  mask: { type: [String, Object] as PropType<string | Record<string, number[] | string[]>>, default: '' },
+  mask: { type: [String, Object] as PropType<string | Record<string, number[] | string[]> | boolean>, default: '' },
   returnRaw: { type: Boolean, default: true },
   modelValue: { type: [String, Number], default: '' },
 }

--- a/packages/ui/src/components/va-input/hooks/useCleave.ts
+++ b/packages/ui/src/components/va-input/hooks/useCleave.ts
@@ -22,7 +22,7 @@ const DEFAULT_MASK_TOKENS: Record<string, Record<string, unknown>> = {
 }
 
 export const useCleaveProps = {
-  mask: { type: [String, Object] as PropType<string | Record<string, number[]>>, default: '' },
+  mask: { type: [String, Object] as PropType<string | Record<string, number[] | string[]>>, default: '' },
   returnRaw: { type: Boolean, default: true },
   modelValue: { type: [String, Number], default: '' },
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail -->
This change will allow passing other data that cleave.js accepts, without typecript errors (ie: _delimiters_)

## Markup:
<!-- Paste your markup here. -->
<details>

```vue
  <va-input
    v-model="form.document"
    label="CPF"
    placeholder="000.000.000-00"
    mask="{
      blocks: [3, 3, 3, 2],
      delimiters: ['.', '.', '-'],
      numericOnly: true,
    }"
  />
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
