### PR TITLE
fix: add CleaveOptions type to mask prop to match real use

### DIFF
--- a/packages/ui/src/components/va-input/VaInput.demo.vue
+++ b/packages/ui/src/components/va-input/VaInput.demo.vue
@@ -558,6 +558,18 @@
         mask="date"
       />
       Value: {{ maskReturnFormattedValue }}
+      <va-input
+        v-model="maskObjectReturnFormattedValue"
+        :style="{paddingTop: '4px'}"
+        label="Phone mask, return formatted"
+        :return-raw="false"
+        type="input"
+        :mask="{
+          phone: true,
+          phoneRegionCode: 'US'
+        }"
+      />
+      Value: {{ maskObjectReturnFormattedValue }}
     </VbCard>
     <VbCard title="Number input">
       <va-input
@@ -660,6 +672,7 @@ import { VaButton } from './../va-button'
 import { VaIcon } from './../va-icon'
 import VaInputValidation from './VaInput-validation.vue'
 import { VaCheckbox } from '../va-checkbox'
+import 'cleave.js/dist/addons/cleave-phone.us'
 
 export default {
   components: {
@@ -687,6 +700,7 @@ export default {
       maskNumeralsValue: '',
       maskCustomBlocksValue: '',
       maskReturnFormattedValue: '',
+      maskObjectReturnFormattedValue: '',
       num: 10,
 
       isClearable: true,

--- a/packages/ui/src/components/va-input/hooks/useCleave.ts
+++ b/packages/ui/src/components/va-input/hooks/useCleave.ts
@@ -22,7 +22,7 @@ const DEFAULT_MASK_TOKENS: Record<string, Record<string, unknown>> = {
 }
 
 export const useCleaveProps = {
-  mask: { type: [String, Object] as PropType<string | Record<string, number[] | CleaveOptions>>, default: '' },
+  mask: { type: [String, Object] as PropType<string | Record<string, number[]> | CleaveOptions>, default: '' },
   returnRaw: { type: Boolean, default: true },
   modelValue: { type: [String, Number], default: '' },
 }

--- a/packages/ui/src/components/va-input/hooks/useCleave.ts
+++ b/packages/ui/src/components/va-input/hooks/useCleave.ts
@@ -22,7 +22,7 @@ const DEFAULT_MASK_TOKENS: Record<string, Record<string, unknown>> = {
 }
 
 export const useCleaveProps = {
-  mask: { type: [String, Object] as PropType<string | Record<string, number[]>>, default: '' },
+  mask: { type: [String, Object] as PropType<string | Record<string, number[] | CleaveOptions>>, default: '' },
   returnRaw: { type: Boolean, default: true },
   modelValue: { type: [String, Number], default: '' },
 }


### PR DESCRIPTION
## Description
The mask property from the useCleave() hook had the missing CleaveOptions type which is a valid input type for it

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
