### PR TITLE
[#2920] `va-navbar` center slot on mobiles fix

### DIFF
--- a/packages/ui/src/components/va-navbar/VaNavbar.vue
+++ b/packages/ui/src/components/va-navbar/VaNavbar.vue
@@ -180,7 +180,6 @@ export default defineComponent({
       width: 100%;
     }
 
-    &__center,
     &__background-shape {
       display: none;
     }


### PR DESCRIPTION
Closes: #2920

## Description
- [x] Center slot doesn't dissappear on mobile screens.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)