### PR TITLE
feat: smart-helpers added to nuxt module types

### DIFF
--- a/packages/nuxt/src/types.ts
+++ b/packages/nuxt/src/types.ts
@@ -18,7 +18,7 @@ export interface VuesticOptions {
    *
    * @see https://vuestic.dev/en/getting-started/tree-shaking#css-code-split
    */
-  css: Array<'typography' | 'grid' | 'reset'> | boolean,
+  css: Array<'typography' | 'grid' | 'reset' | 'smart-helpers'> | boolean,
 
   /**
    * Use vuestic default fonts.


### PR DESCRIPTION
`smart-helpers` type for Nuxt 3 module.