### PR TITLE
feat: removed deprecated in 1.6.0 props

### DIFF
--- a/packages/ui/src/components/va-badge/VaBadge.vue
+++ b/packages/ui/src/components/va-badge/VaBadge.vue
@@ -25,7 +25,6 @@ import pick from 'lodash/pick.js'
 import {
   useColors, useTextColor,
   useComponentPresetProp,
-  useDeprecated,
   useBem,
 } from '../../composables'
 import { useFloatingPosition, useFloatingPositionProps } from './hooks/useFloatingPositionStyles'
@@ -46,9 +45,6 @@ export default defineComponent({
   },
 
   setup (props, { slots }) {
-    // TODO: remove `left` and `bottom` props in 1.6.0
-    useDeprecated(['left', 'bottom'])
-
     const isEmpty = computed(() => !(props.text || props.visibleEmpty || props.dot || slots.text))
 
     const isFloating = computed(() => !!(slots.default || props.dot))

--- a/packages/ui/src/components/va-button-dropdown/VaButtonDropdown.vue
+++ b/packages/ui/src/components/va-button-dropdown/VaButtonDropdown.vue
@@ -83,7 +83,6 @@ import { extractComponentProps, filterComponentProps } from '../../utils/compone
 
 import {
   useBem,
-  useDeprecated,
   useComponentPresetProp,
   useStateful, useStatefulProps,
   useEmitProxy,
@@ -144,9 +143,6 @@ export default defineComponent({
   },
 
   setup (props, { emit, slots }) {
-    // TODO(1.6.0): Remove deprecated props
-    useDeprecated(['flat', 'outline'])
-
     const { valueComputed } = useStateful(props, emit)
 
     const computedIcon = computed(() => valueComputed.value ? props.openedIcon : props.icon)

--- a/packages/ui/src/components/va-button-group/VaButtonGroup.vue
+++ b/packages/ui/src/components/va-button-group/VaButtonGroup.vue
@@ -11,7 +11,7 @@ import { defineComponent, computed } from 'vue'
 import { extractComponentProps } from '../../utils/component-options'
 import omit from 'lodash/omit.js'
 
-import { useBem, useDeprecated, useComponentPresetProp } from '../../composables'
+import { useBem, useComponentPresetProp } from '../../composables'
 
 import { VaConfig } from '../va-config'
 import { VaButton } from '../va-button'
@@ -31,9 +31,6 @@ export default defineComponent({
   },
 
   setup: (props) => {
-    // TODO(1.6.0): Remove deprecated props
-    useDeprecated(['flat', 'outline'])
-
     const buttonConfig = computed(() => ({ VaButton: { ...props } }))
     const computedClass = useBem('va-button-group', () => ({
       square: !props.round,

--- a/packages/ui/src/components/va-button-toggle/VaButtonToggle.vue
+++ b/packages/ui/src/components/va-button-toggle/VaButtonToggle.vue
@@ -19,7 +19,7 @@
 import { defineComponent, PropType, computed } from 'vue'
 import { extractComponentProps } from '../../utils/component-options'
 
-import { useDeprecated, useComponentPresetProp, useColors } from '../../composables'
+import { useComponentPresetProp, useColors } from '../../composables'
 
 import { ButtonOption } from './types'
 
@@ -50,9 +50,6 @@ export default defineComponent({
   },
 
   setup (props, { emit }) {
-    // TODO(1.6.0): Remove deprecated props
-    useDeprecated(['flat', 'outline'])
-
     const { getColor, shiftHSLAColor } = useColors()
     const p = VaButtonGroupProps.color
     const colorComputed = computed(() => getColor(props.color))

--- a/packages/ui/src/components/va-button/VaButton.vue
+++ b/packages/ui/src/components/va-button/VaButton.vue
@@ -109,10 +109,7 @@ export default defineComponent({
     iconRight: { type: String, default: '' },
     iconColor: { type: String, default: '' },
   },
-  setup (props, { slots }) {
-    // TODO: Remove deprecated props in 1.6.0
-    useDeprecated(['flat', 'outline'])
-
+  setup (props) {
     // colors
     const { getColor } = useColors()
     const colorComputed = computed(() => getColor(props.color))

--- a/packages/ui/src/components/va-navbar/VaNavbar.vue
+++ b/packages/ui/src/components/va-navbar/VaNavbar.vue
@@ -9,7 +9,6 @@
     </div>
 
     <div class="va-navbar__center">
-      <slot name="center" />
       <slot />
     </div>
 
@@ -33,7 +32,6 @@ import {
   setupScroll,
   useFixedBar,
   useTextColor,
-  useDeprecated,
   useFixedBarProps,
   useComponentPresetProp,
 } from '../../composables'
@@ -49,9 +47,6 @@ export default defineComponent({
   },
 
   setup (props) {
-    // TODO(1.6.0): Remove deprecated slots
-    useDeprecated(['center'], ['slots'])
-
     const { scrollRoot, isScrolledDown } = setupScroll(props.fixed)
     const { fixedBarStyleComputed } = useFixedBar(props, isScrolledDown)
 

--- a/packages/ui/src/components/va-scroll-container/VaScrollContainer.vue
+++ b/packages/ui/src/components/va-scroll-container/VaScrollContainer.vue
@@ -9,7 +9,6 @@
 <script lang="ts">
 import { computed, defineComponent, PropType } from 'vue'
 
-import { __DEV__ } from '../../utils/env'
 import { useColors, useSize, useSizeProps } from '../../composables'
 
 export default defineComponent({
@@ -47,15 +46,7 @@ export default defineComponent({
         const color = getColor(props.color)
         return props.gradient ? `linear-gradient(0deg, var(--va-scroll-container-scrollbar-gradient-to) 0%, ${color} 100%)` : color
       }),
-      scrollbarSize: computed(() => {
-        if (typeof props.size === 'string' && ['thin', 'default', 'none'].includes(props.size)) {
-          // TODO: remove in 1.6.0
-          __DEV__ && console.warn('`VaScrollbar` `size` property acceptable values list was changed. Please, check the documentation (https://vuestic.dev/ui-elements/scroll-container).')
-          return '4px'
-        }
-
-        return sizeComputed.value
-      }),
+      scrollbarSize: computed(() => sizeComputed.value),
       scrollbarPosition: computed(() => props.rtl ? 'rtl' : 'ltr'),
     }
   },


### PR DESCRIPTION
## Description
- [x] Removed all props and slots with mark `remove in 1.6.0`.

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)