### PR TITLE
docs: make inline text reasonable size

### DIFF
--- a/packages/docs/modules/page-config/blocks/api/components/api-table.vue
+++ b/packages/docs/modules/page-config/blocks/api/components/api-table.vue
@@ -101,7 +101,6 @@ defineProps({
       & .MarkdownView {
         code,
         p {
-          font-size: inherit;
           margin-bottom: 0;
         }
       }

--- a/packages/docs/modules/page-config/blocks/table/index.vue
+++ b/packages/docs/modules/page-config/blocks/table/index.vue
@@ -101,7 +101,6 @@ const columnsComputed = computed(() => {
       & .MarkdownView {
         code,
         p {
-          font-size: inherit;
           margin-bottom: 0;
         }
       }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5394573/220215206-ac8bc213-232e-490d-8f04-21e2a333e527.png)

After:
![image](https://user-images.githubusercontent.com/5394573/220215170-7e6b8ac6-dcd7-485e-a9f1-b94a60e1301a.png)
