### PR TITLE
fix(#3046): remove vuestic from excluded optimizeDeps

### DIFF
--- a/packages/docs/modules/vuestic.ts
+++ b/packages/docs/modules/vuestic.ts
@@ -36,7 +36,6 @@ export default defineNuxtModule<VuesticOptions>({
     originalNuxtModule(options, nuxt)
 
     nuxt.options.build.transpile.push('lodash')
-    nuxt.options.vite.optimizeDeps?.exclude?.push('vuestic-ui')
   }
 })
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23530004/220885903-26def791-b1d0-465c-a0f8-686f37455fc0.png)

Hell yeah, found it!

Maybe it is a solution for https://github.com/epicmaxco/vuestic-ui/issues/3046, but it is not directly fixes it. I'll double-check it in new nuxt project.