### PR TITLE
Fix/ssr css variables

### DIFF
--- a/packages/ui/build/common-config.ts
+++ b/packages/ui/build/common-config.ts
@@ -1,3 +1,4 @@
+import { componentVBindFix } from './plugins/component-v-bind-fix';
 import { readFileSync, lstatSync, readdirSync } from 'fs'
 import vue from '@vitejs/plugin-vue'
 import { resolve as resolver } from 'path'
@@ -102,6 +103,7 @@ export default function createViteConfig (format: BuildFormat) {
   isEsm && config.plugins.push(chunkSplitPlugin({ strategy: 'unbundle' }))
   isEsm && !isNode && config.plugins.push(appendComponentCss())
   isEsm && config.plugins.push(removeSideEffectedChunks())
+  isEsm && config.plugins.push(componentVBindFix())
 
   config.build.rollupOptions = isNode ? { ...external, ...rollupMjsBuildOptions } : external
 

--- a/packages/ui/build/plugins/component-v-bind-fix.spec.ts
+++ b/packages/ui/build/plugins/component-v-bind-fix.spec.ts
@@ -6,7 +6,7 @@ describe('component-v-bind-fix', () => {
     // eslint-disable-next-line no-template-curly-in-string
     const expectedStyleString = '--va-0-color: ${String(color)};--va-1-background: ${String(background)}'
 
-    const expectedObjectStyleString = (styleContent: string) => `typeof ${styleContent} === 'object' ? { ...${styleContent}, '--va-0-color': String(color),'--va-1-background': String(background) } : ${styleContent} + \`;${expectedStyleString}\``
+    const expectedObjectStyleString = (styleContent: string) => `typeof ${styleContent} === 'object' ? (Array.isArray(${styleContent}) ? [...${styleContent}, \`${expectedStyleString}\`] : { ...${styleContent}, '--va-0-color': String(color),'--va-1-background': String(background) }) : ${styleContent} + \`;${expectedStyleString}\``
 
     const componentCode = (attrs = '', nestedAttrs = '') => `
 <template>
@@ -55,7 +55,7 @@ const background = 'yellow'
 `
 
     test('expectedObjectStyleString', () => {
-      expect(expectedObjectStyleString('style')).toBe(`typeof style === 'object' ? { ...style, '--va-0-color': String(color),'--va-1-background': String(background) } : style + \`;${expectedStyleString}\``)
+      expect(expectedObjectStyleString('style')).toBe(`typeof style === 'object' ? (Array.isArray(style) ? [...style, \`${expectedStyleString}\`] : { ...style, '--va-0-color': String(color),'--va-1-background': String(background) }) : style + \`;${expectedStyleString}\``)
     })
 
     test('replace v-bind() with var(--va-index-name)', () => {

--- a/packages/ui/build/plugins/component-v-bind-fix.spec.ts
+++ b/packages/ui/build/plugins/component-v-bind-fix.spec.ts
@@ -1,0 +1,167 @@
+import { describe, test, expect } from 'vitest'
+import { transformVueComponent } from './component-v-bind-fix'
+
+describe('component-v-bind-fix', () => {
+  describe('style guard', () => {
+    test('should use object if object', () => {
+      const styleValue: any = { color: 'red' }
+
+      expect(typeof styleValue === 'object'
+        ? { ...styleValue, ...{ background: 'blue' } }
+        : styleValue + ';background: blue')
+        .toEqual({ color: 'red', background: 'blue' })
+    })
+
+    test('should use string if string', () => {
+      const styleValue: any = 'color: red'
+
+      expect(typeof styleValue === 'object'
+        ? { ...styleValue, ...{ background: 'blue' } }
+        : styleValue + ';background: blue')
+        .toEqual('color: red;background: blue')
+    })
+
+    test('should use string if string with ;', () => {
+      const styleValue: any = 'color: red;'
+
+      expect(typeof styleValue === 'object'
+        ? { ...styleValue, ...{ background: 'blue' } }
+        : styleValue + ';background: blue')
+        // TODO: Not sure, but it looks like a correct CSS
+        .toEqual('color: red;;background: blue')
+    })
+  })
+
+  describe('transformVueComponent', () => {
+    const componentCode = (attrs = '', nestedAttrs = '') => `
+<template>
+  <button${attrs ? ' ' + attrs : ''}>
+    <span${nestedAttrs ? ' ' + nestedAttrs : ''}>
+      Hello
+    </span>
+    world!
+  </button>
+</template>
+
+<script setup>
+const color = computed(() => 'blue')
+const background = 'yellow'
+</script>
+
+<style>
+  button {
+    color: v-bind(color);
+    background: v-bind(background);
+  }
+</style>
+`
+
+    const expectedComponentCode = (attrs = '', nestedAttrs = '') => `
+<template>
+  <button${attrs ? ' ' + attrs : ''}>
+    <span${nestedAttrs ? ' ' + nestedAttrs : ''}>
+      Hello
+    </span>
+    world!
+  </button>
+</template>
+
+<script setup>
+const color = computed(() => 'blue')
+const background = 'yellow'
+</script>
+
+<style>
+  button {
+    color: var(--va-0-color);
+    background: var(--va-1-background);
+  }
+</style>
+`
+    const stringStyle = '--va-0-color: color;--va-1-background: background'
+
+    const objectGuardStyle = (exstingStyle: string) => {
+      // If exstingStyle is object, we should use spread operator, but if it is string, we should use semicolon
+      return `typeof ${exstingStyle} === 'object' ? { ...${exstingStyle}, ...{ '--va-0-color': color,'--va-1-background': background } } : ${exstingStyle} + ';${stringStyle}'`
+    }
+
+    test('replace v-bind() with var(--va-index-name)', () => {
+      const code = transformVueComponent(componentCode())
+
+      expect(code).toContain('var(--va-0-color)')
+      expect(code).toContain('var(--va-1-background)')
+
+      expect(code).not.toContain('v-bind(color)')
+      expect(code).not.toContain('v-bind(background)')
+    })
+
+    test("if root node doesn't have a style attr, we should add a style attr with css variables ", () => {
+      const code = transformVueComponent(componentCode())
+
+      expect(code).toBe(expectedComponentCode(
+        `style="${stringStyle}"`,
+      ))
+    })
+
+    test('if root node have a style attr we add to its value css variables', () => {
+      const code = transformVueComponent(componentCode(
+        'style="color: red"',
+      ))
+
+      expect(code).toBe(expectedComponentCode(
+        `style="color: red;${stringStyle}"`,
+      ))
+    })
+
+    test('if root node have a style object vbind, we replace it with object guard', () => {
+      const code = transformVueComponent(componentCode(
+        ':style="{ background: yellow }"',
+      ))
+
+      expect(code).toBe(expectedComponentCode(
+        `:style="${objectGuardStyle('{ background: yellow }')}"`,
+      ))
+    })
+
+    // TODO: Maybe better just use style string
+    test('if root node have both style attr and vbind we replace only vbind with object guard', () => {
+      const code = transformVueComponent(componentCode(
+        'style="color: blue" :style="{ background: yellow }"',
+      ))
+
+      expect(code).toBe(expectedComponentCode(
+        `style="color: blue" :style="${objectGuardStyle('{ background: yellow }')}"`,
+      ))
+    })
+
+    test('if root node have vbind and nested element has style attr, we replace only root node', () => {
+      const code = transformVueComponent(componentCode(
+        ':style="{ background: yellow }"',
+        'style="color: blue"',
+      ))
+
+      expect(code).toBe(expectedComponentCode(
+        `:style="${objectGuardStyle('{ background: yellow }')}"`,
+        'style="color: blue"',
+      ))
+    })
+
+    test('if root node have vbind and nested element has style vbind, we replace only root node', () => {
+      const code = transformVueComponent(componentCode(
+        ':style="{ background: yellow }"',
+        ':style="{ color: blue }"',
+      ))
+
+      expect(code).toBe(expectedComponentCode(
+        `:style="${objectGuardStyle('{ background: yellow }')}"`,
+        ':style="{ color: blue }"',
+      ))
+    })
+
+    test('if root node doesn\'t have any style we add it as string and nested elements stay the same', () => {
+      const code = transformVueComponent(componentCode('', ':style="{ color: blue }"'))
+
+      expect(code).toBe(expectedComponentCode(`style="${stringStyle}"`, ':style="{ color: blue }"'))
+    })
+  })
+})

--- a/packages/ui/build/plugins/component-v-bind-fix.ts
+++ b/packages/ui/build/plugins/component-v-bind-fix.ts
@@ -24,7 +24,14 @@ const renderObjectGuard = (styleContent: string, binds: string[]) => {
   const cssVariablesObject = binds.map((vBind, index) => {
     return `'--va-${index}-${kebabCase(vBind)}': String(${vBind})`
   }, '').join(',')
-  return `typeof ${styleContent} === 'object' ? { ...${styleContent}, ${cssVariablesObject} } : ${styleContent} + \`;${cssVariablesString}\``
+
+  // Merge existing style with css variables
+  const arrayStyle = `[...${styleContent}, \`${cssVariablesString}\`]`
+  const objectStyle = `{ ...${styleContent}, ${cssVariablesObject} }`
+  const stringStyle = `${styleContent} + \`;${cssVariablesString}\``
+
+  // Handle if style is an object, array or string
+  return `typeof ${styleContent} === 'object' ? (Array.isArray(${styleContent}) ? ${arrayStyle} : ${objectStyle}) : ${stringStyle}`
 }
 
 export const transformVueComponent = (code: string) => {

--- a/packages/ui/build/plugins/component-v-bind-fix.ts
+++ b/packages/ui/build/plugins/component-v-bind-fix.ts
@@ -1,0 +1,54 @@
+import { Plugin } from 'vite'
+
+export const transformVueComponent = (code: string) => {
+  const style = code.match(/<style[^>]*>([\s\S]*)<\/style>/)
+
+  const vBinds = style?.[1].match(/v-bind\((.*)\)/g)?.map((line) => line.match(/v-bind\((.*)\)/)?.[1]) ?? []
+
+  vBinds.forEach((vBind, index) => {
+    code = code.replace(new RegExp(`v-bind\\(${vBind}\\)`, 'gm'), `var(--va-${index}-${vBind})`)
+  })
+
+  const varsObject = `{ ${vBinds.map((vBind, index) => {
+    return `'--va-${index}-${vBind}': ${vBind}`
+  }, '').join(',')} }`
+
+  const varsString = vBinds.map((vBind, index) => {
+    return `--va-${index}-${vBind}: ${vBind}`
+  }, '').join(';')
+
+  const template = code.match(/<template[^>]*>([\s\S]*)<\/template>/)?.[1]
+
+  const rootNode = template?.match(/<[^>]*>/)?.[0]
+
+  if (!rootNode) { throw new Error('vuestic:v-bind-fix-plugin: Root node not found in template') }
+
+  const existingStyleVBind = rootNode?.match(/:style="([^"]*)"/)?.[1]
+  const existingStyle = rootNode?.match(/style="([^"]*)"/)?.[1]
+
+  if (existingStyleVBind) {
+    code = code.replace(/:style="([^"]*)"/, `:style="typeof $1 === 'object' ? { ...$1, ...${varsObject} } : $1 + ';${varsString}'"`)
+  } else if (existingStyle) {
+    code = code.replace(/style="([^"]*)"/, `style="$1;${varsString}"`)
+  } else {
+    const newRootNode = rootNode.replace('>', ` style="${varsString}">`)
+    code = code.replace(rootNode, newRootNode)
+  }
+
+  return code
+}
+
+export const componentVBindFix = (): Plugin => {
+  return {
+    name: 'vuestic:component-v-bind-fix',
+    enforce: 'pre',
+    transform (code, id) {
+      // console.log(id)
+      if (!id.includes('VaButton')) {
+        return
+      }
+
+      return transformVueComponent(code)
+    },
+  }
+}

--- a/packages/ui/build/plugins/component-v-bind-fix.ts
+++ b/packages/ui/build/plugins/component-v-bind-fix.ts
@@ -1,41 +1,48 @@
 import { Plugin } from 'vite'
 
+const parseVBinds = (style: string) => {
+  return style
+    .match(/v-bind\((.*)\)/g)
+    ?.map((line) => line.match(/v-bind\((.*)\)/)![1]) ?? []
+}
+
+const getRootNodeCode = (code: string) => {
+  const template = code.match(/<template[^>]*>([\s\S]*)<\/template>/)?.[1]
+  const rootNode = template?.match(/<[^>]*>/)?.[0]
+  return rootNode
+}
+
+const renderCssVariablesString = (vBinds: string[]) => {
+  return vBinds.map((vBind, index) => {
+    return `--va-${index}-${vBind}: ${vBind}`
+  }, '').join(';')
+}
+
 export const transformVueComponent = (code: string) => {
   const style = code.match(/<style[^>]*>([\s\S]*)<\/style>/)
+  if (!style) { return }
 
-  const vBinds = style?.[1].match(/v-bind\((.*)\)/g)?.map((line) => line.match(/v-bind\((.*)\)/)?.[1]) ?? []
+  const vBinds = parseVBinds(style[0])
+  if (!vBinds.length) { return }
 
+  const rootNode = getRootNodeCode(code)
+  if (!rootNode) { throw new Error('vuestic:v-bind-fix-plugin: Root node not found in template') }
+
+  // Replace each v-bind() with var(--va-index-name)
   vBinds.forEach((vBind, index) => {
     code = code.replace(new RegExp(`v-bind\\(${vBind}\\)`, 'gm'), `var(--va-${index}-${vBind})`)
   })
 
-  const varsObject = `{ ${vBinds.map((vBind, index) => {
-    return `'--va-${index}-${vBind}': ${vBind}`
-  }, '').join(',')} }`
+  const existingStyle = rootNode?.match(/[^:]style="([^"]*)"/)?.[1]
+  const cssVariablesString = renderCssVariablesString(vBinds)
 
-  const varsString = vBinds.map((vBind, index) => {
-    return `--va-${index}-${vBind}: ${vBind}`
-  }, '').join(';')
-
-  const template = code.match(/<template[^>]*>([\s\S]*)<\/template>/)?.[1]
-
-  const rootNode = template?.match(/<[^>]*>/)?.[0]
-
-  if (!rootNode) { throw new Error('vuestic:v-bind-fix-plugin: Root node not found in template') }
-
-  const existingStyleVBind = rootNode?.match(/:style="([^"]*)"/)?.[1]
-  const existingStyle = rootNode?.match(/style="([^"]*)"/)?.[1]
-
-  if (existingStyleVBind) {
-    code = code.replace(/:style="([^"]*)"/, `:style="typeof $1 === 'object' ? { ...$1, ...${varsObject} } : $1 + ';${varsString}'"`)
-  } else if (existingStyle) {
-    code = code.replace(/style="([^"]*)"/, `style="$1;${varsString}"`)
+  // If style attr already exists simply add css variables to it
+  if (existingStyle) {
+    return code.replace(/style="([^"]*)"/, `style="$1;${cssVariablesString}"`)
   } else {
-    const newRootNode = rootNode.replace('>', ` style="${varsString}">`)
-    code = code.replace(rootNode, newRootNode)
+    const newRootNode = rootNode.replace('>', ` style="${cssVariablesString}">`)
+    return code.replace(rootNode, newRootNode)
   }
-
-  return code
 }
 
 export const componentVBindFix = (): Plugin => {
@@ -43,8 +50,7 @@ export const componentVBindFix = (): Plugin => {
     name: 'vuestic:component-v-bind-fix',
     enforce: 'pre',
     transform (code, id) {
-      // console.log(id)
-      if (!id.includes('VaButton')) {
+      if (/\.vue$/.test(id)) {
         return
       }
 

--- a/packages/ui/build/plugins/component-v-bind-fix.ts
+++ b/packages/ui/build/plugins/component-v-bind-fix.ts
@@ -1,50 +1,92 @@
 import { Plugin } from 'vite'
 import kebabCase from 'lodash/kebabCase'
 
-const parseVBinds = (style: string) => {
+/**
+ * Parse css and extract all variable names used in `v-bind`
+ *
+ * @example
+ *
+ * ```css
+ * .va-button {
+ *  color: v-bind(colorComputed);
+ *  background-color: v-bind(getBg());
+ * }
+ * ```
+ *
+ * Returns`['colorComputed', 'getBg()']`
+ */
+const parseCssVBindCode = (style: string) => {
   return style
     .match(/v-bind\((.*)\)/g)
     ?.map((line) => line.match(/v-bind\(([^)]*)\)/)![1]) ?? []
 }
 
-const getRootNodeCode = (code: string) => {
+/**
+ * @example
+ *
+ * ```html
+ * <template>
+ *   <va-button>
+ *     Hello
+ *   </va-button>
+ * </template>
+ * ```
+ * Returns `<va-button>`
+ */
+const getRootNodeOpenTagCode = (code: string) => {
   const template = code.match(/<template[^>]*>([\s\S]*)<\/template>/)?.[1]
   const rootNode = template?.match(/<[^>]*>/)?.[0]
   return rootNode
 }
 
-const renderCssVariablesString = (vBinds: string[]) => {
+const renderCssVariablesAsStringCode = (vBinds: string[]) => {
   return vBinds.map((vBind, index) => {
     return `--va-${index}-${kebabCase(vBind)}: \${String(${vBind})}`
   }, '').join(';')
 }
 
-const renderObjectGuard = (styleContent: string, binds: string[]) => {
-  const cssVariablesString = renderCssVariablesString(binds)
-  const cssVariablesObject = binds.map((vBind, index) => {
+const renderCssVariablesAsObjectPropertiesCode = (vBinds: string[]) => {
+  return vBinds.map((vBind, index) => {
     return `'--va-${index}-${kebabCase(vBind)}': String(${vBind})`
   }, '').join(',')
-
-  // Merge existing style with css variables
-  const arrayStyle = `[...${styleContent}, \`${cssVariablesString}\`]`
-  const objectStyle = `{ ...${styleContent}, ${cssVariablesObject} }`
-  const stringStyle = `${styleContent} + \`;${cssVariablesString}\``
-
-  // Handle if style is an object, array or string
-  return `typeof ${styleContent} === 'object' ? (Array.isArray(${styleContent}) ? ${arrayStyle} : ${objectStyle}) : ${stringStyle}`
 }
 
-export const transformVueComponent = (code: string) => {
-  const style = code.match(/<style[^>]*>([\s\S]*)<\/style>/)
-  if (!style) { return }
+const renderObjectGuardCode = (existingContent: string, binds: string[]) => {
+  const renderedAsString = renderCssVariablesAsStringCode(binds)
+  const renderedAsObjectProperties = renderCssVariablesAsObjectPropertiesCode(binds)
 
-  const vBinds = parseVBinds(style[0])
-  if (!vBinds.length) { return }
+  // Merge existing style with rendered css variables
+  const arrayStyle = `[...${existingContent}, \`${renderedAsString}\`]`
+  const objectStyle = `{ ...${existingContent}, ${renderedAsObjectProperties} }`
+  const stringStyle = `${existingContent} + \`;${renderedAsString}\``
 
-  const rootNode = getRootNodeCode(code)
-  if (!rootNode) { throw new Error('vuestic:v-bind-fix-plugin: Root node not found in template') }
+  // Handle if style is an object, array or string
+  return `typeof ${existingContent} === 'object' ? (Array.isArray(${existingContent}) ? ${arrayStyle} : ${objectStyle}) : ${stringStyle}`
+}
 
-  // Replace each v-bind() with var(--va-index-name)
+const addStyleToRootNode = (rootNode: string, vBinds: string[]) => {
+  const [vBindCode, vBindContent] = rootNode?.match(/:style="([^"]*)"/) || []
+  const [attrCode, attrContent] = rootNode?.match(/[^:]style="([^"]*)"/) || []
+  const cssVariablesString = renderCssVariablesAsStringCode(vBinds)
+
+  // If style attr already exists add css variables to it
+  if (vBindContent) {
+    // If :style already exists add a object guard here, because we're not sure if it is string, object or array.
+    return rootNode.replace(/:style="([^"]*)"/, `:style="${renderObjectGuardCode(vBindContent, vBinds)}"`)
+  }
+
+  if (attrContent) {
+    // If style already exists as string attribute, append css variables string to it
+    return rootNode.replace(/style="([^"]*)"/, `:style="\`$1;${cssVariablesString}\`"`)
+  }
+
+  // Add :style to root node, because it doesn't exist yet
+  // Replace `/>` or `>` with :style="..."/> or :style="..."> respectively
+  return rootNode.replace(/(\/?>)$/, ` :style="\`${cssVariablesString}\`"$1`)
+}
+
+/** Replace each v-bind() with var(--va-index-name) */
+const replaceVueVBindWithCssVariables = (code: string, vBinds: string[]) => {
   vBinds.forEach((vBind, index) => {
     try {
       code = code.replace(new RegExp(`v-bind\\(${vBind}\\)`, 'gm'), `var(--va-${index}-${kebabCase(vBind)})`)
@@ -54,27 +96,22 @@ export const transformVueComponent = (code: string) => {
     }
   })
 
-  const [vBindCode, vBindContent] = rootNode?.match(/:style="([^"]*)"/) || []
-  const [attrCode, attrContent] = rootNode?.match(/[^:]style="([^"]*)"/) || []
-  const cssVariablesString = renderCssVariablesString(vBinds)
-  const hasVBind = Boolean(vBindCode)
+  return code
+}
 
-  // If style attr already exists simply add css variables to it
-  if (vBindContent || attrContent) {
-    if (hasVBind) {
-      return code.replace(/:style="([^"]*)"/, `:style="${renderObjectGuard(vBindContent, vBinds)}"`)
-    }
+export const transformVueComponent = (code: string) => {
+  const style = code.match(/<style[^>]*>([\s\S]*)<\/style>/)
+  if (!style) { return }
 
-    return code.replace(/style="([^"]*)"/, `:style="\`$1;${cssVariablesString}\`"`)
-  }
+  const vBinds = parseCssVBindCode(style[0])
+  if (!vBinds.length) { return }
 
-  if (/\/>$/.test(rootNode)) {
-    const newRootNode = rootNode.replace('/>', ` :style="\`${cssVariablesString}\`"/>`)
-    return code.replace(rootNode, newRootNode)
-  }
+  const rootNode = getRootNodeOpenTagCode(code)
+  if (!rootNode) { throw new Error('Root node not found in template') }
 
-  const newRootNode = rootNode.replace('>', ` :style="\`${cssVariablesString}\`">`)
-  return code.replace(rootNode, newRootNode)
+  code = replaceVueVBindWithCssVariables(code, vBinds)
+
+  return code.replace(rootNode, addStyleToRootNode(rootNode, vBinds))
 }
 
 export const componentVBindFix = (): Plugin => {

--- a/packages/ui/src/composables/useCSSVariables.ts
+++ b/packages/ui/src/composables/useCSSVariables.ts
@@ -2,5 +2,8 @@ import { computed } from 'vue'
 import kebab from 'lodash/kebabCase.js'
 
 export const useCSSVariables = (prefix: string, cb: () => Record<string, string>) => {
-  return computed(() => Object.entries(cb()).map(([key, value]) => ({ [`--${prefix}-${kebab(key)}`]: value })))
+  return computed(() => Object.entries(cb()).reduce((acc, [key, value]) => {
+    acc[`--${prefix}-${kebab(key)}`] = value
+    return acc
+  }, {} as Record<string, string>))
 }


### PR DESCRIPTION
closes https://github.com/epicmaxco/vuestic-ui/issues/3046

Added a build plugin which converts `v-bind(variable)` in <style> to `:style=""`.

Basically, creates a css variable like `--va-[index]-[kebab-name]` and pass it to style using v-bind and replaces vue v-bind in css with generated css variable. This way we ignore vue `useCSSVars` which is not available in cjs build. We also ensure that passed value to css variable is going to be String, which makes it work in Nuxt.