### PR TITLE
[#2980] VaTreeView expandable node cursor style

### DIFF
--- a/packages/ui/src/components/va-tree-view/VaTreeView.demo.vue
+++ b/packages/ui/src/components/va-tree-view/VaTreeView.demo.vue
@@ -159,6 +159,15 @@
         </template>
       </va-tree-view>
     </VbCard>
+
+    <VbCard title="Expand by node">
+      <va-tree-view
+        :nodes="nodesChecked"
+        expand-all
+        selectable
+        expand-node-by="node"
+      />
+    </VbCard>
   </VbDemo>
 </template>
 

--- a/packages/ui/src/components/va-tree-view/components/VaTreeNode/VaTreeNode.vue
+++ b/packages/ui/src/components/va-tree-view/components/VaTreeNode/VaTreeNode.vue
@@ -127,7 +127,7 @@ export default defineComponent({
     }))
 
     const cursorClassComputed = useBem('va-tree-node-content', () => ({
-      expandable: (props.node.hasChildren === true && expandNodeBy === 'node'),
+      clickable: (props.node.hasChildren === true && expandNodeBy === 'node'),
     }))
 
     const tabIndexComputed = computed(() => props.node.disabled ? -1 : 0)
@@ -220,6 +220,10 @@ export default defineComponent({
     &--indent {
       margin-left: var(--va-tree-node-indent);
     }
+
+    &--clickable {
+      cursor: pointer;
+    }
   }
 
   &-children {
@@ -244,10 +248,6 @@ export default defineComponent({
       cursor: pointer;
       pointer-events: all;
     }
-  }
-
-  &--expandable {
-    cursor: pointer;
   }
 
   &:focus-visible > .va-tree-node-root {

--- a/packages/ui/src/components/va-tree-view/components/VaTreeNode/VaTreeNode.vue
+++ b/packages/ui/src/components/va-tree-view/components/VaTreeNode/VaTreeNode.vue
@@ -127,7 +127,7 @@ export default defineComponent({
     }))
 
     const cursorClassComputed = useBem('va-tree-node-content', () => ({
-      cursor: (props.node.hasChildren === true && expandNodeBy === 'node'),
+      expandable: (props.node.hasChildren === true && expandNodeBy === 'node'),
     }))
 
     const tabIndexComputed = computed(() => props.node.disabled ? -1 : 0)
@@ -246,8 +246,8 @@ export default defineComponent({
     }
   }
 
-  &--cursor {
-    cursor: var(--va-tree-node-cursor-type);
+  &--expandable {
+    cursor: pointer;
   }
 
   &:focus-visible > .va-tree-node-root {

--- a/packages/ui/src/components/va-tree-view/components/VaTreeNode/VaTreeNode.vue
+++ b/packages/ui/src/components/va-tree-view/components/VaTreeNode/VaTreeNode.vue
@@ -48,7 +48,7 @@
             <va-icon :name="iconComputed" size="small" />
           </slot>
         </div>
-        <div class="va-tree-node-content__body">
+        <div class="va-tree-node-content__body" :class="cursorClassComputed">
           <slot name="content" v-bind="$props.node">{{ labelComputed }}</slot>
         </div>
       </div>
@@ -126,6 +126,10 @@ export default defineComponent({
       indent: props.node.hasChildren === false,
     }))
 
+    const cursorClassComputed = useBem('va-tree-node-content', () => ({
+      cursor: (props.node.hasChildren === true && expandNodeBy === 'node'),
+    }))
+
     const tabIndexComputed = computed(() => props.node.disabled ? -1 : 0)
 
     const onNodeClick = (type: typeof expandNodeBy) => {
@@ -158,6 +162,7 @@ export default defineComponent({
       isExpandedComputed,
       expandedClassComputed,
       treeNodeClassComputed,
+      cursorClassComputed,
     }
   },
 })
@@ -239,6 +244,10 @@ export default defineComponent({
       cursor: pointer;
       pointer-events: all;
     }
+  }
+
+  &--cursor {
+    cursor: var(--va-tree-node-cursor-type);
   }
 
   &:focus-visible > .va-tree-node-root {

--- a/packages/ui/src/components/va-tree-view/components/VaTreeNode/_variables.scss
+++ b/packages/ui/src/components/va-tree-view/components/VaTreeNode/_variables.scss
@@ -8,4 +8,5 @@
   --va-tree-node-content-body-item-flex: 1;
   --va-tree-node-interactive-bg-opacity: 0.1;
   --va-tree-node-children-background: linear-gradient(#adb3b9 33%, rgba(255, 255, 255, 0) 0%) 15px/1px 3px repeat-y transparent;
+  --va-tree-node-cursor-type: pointer;
 }

--- a/packages/ui/src/components/va-tree-view/components/VaTreeNode/_variables.scss
+++ b/packages/ui/src/components/va-tree-view/components/VaTreeNode/_variables.scss
@@ -8,5 +8,4 @@
   --va-tree-node-content-body-item-flex: 1;
   --va-tree-node-interactive-bg-opacity: 0.1;
   --va-tree-node-children-background: linear-gradient(#adb3b9 33%, rgba(255, 255, 255, 0) 0%) 15px/1px 3px repeat-y transparent;
-  --va-tree-node-cursor-type: pointer;
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail -->
(closes #2980 )
When expandNodeBy is "node" you can click on the node itself to expand it.
This is not visible for the end user because the mouse is still the same.
This PR changes the cursor style to `pointer` when expandNodeBy==="node" and it has children (=when it's expandable).
Used a scss variable called --va-tree-node-cursor-type (so the developer could change it)

## Markup:
<!-- Paste your markup here. -->
<details>

`components/va-tree-view/components/VaTreeNode/VaTreeNode.vue`  
```vue
<div class="va-tree-node-content__body" :class="cursorClassComputed">
  <slot name="content" v-bind="$props.node">{{ labelComputed }}</slot>
</div>
```
```ts
const cursorClassComputed = useBem('va-tree-node-content', () => ({
  cursor: (props.node.hasChildren === true && expandNodeBy === 'node'),
}))
```
`.../VaTreeNode/_variables.scss`  
```scss
.va-tree-node {
  ...
  &--cursor {
    cursor: var(--va-tree-node-cursor-type);
  }
  ...
}
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
