### PR TITLE
fix: remove units for height and width attributes; fix svg

### DIFF
--- a/packages/docs/components/landing/Admin.vue
+++ b/packages/docs/components/landing/Admin.vue
@@ -40,8 +40,8 @@
             <img
               src="/landing/admin/admin.png"
               alt="Vuestic Admin"
-              height="555px"
-              width="875px"
+              height="555"
+              width="875"
             >
           </div>
           <div class="admin__content__item admin__content__item--second">
@@ -52,8 +52,8 @@
                   <img
                     src="/landing/admin/open-source.svg"
                     alt="Open source"
-                    height="32px"
-                    width="32px"
+                    height="32"
+                    width="32"
                   >
                 </div>
                 <h2 class="item__title">
@@ -66,8 +66,8 @@
                   <img
                     src="/landing/admin/themes.svg"
                     alt="Themes"
-                    height="32px"
-                    width="32px"
+                    height="32"
+                    width="32"
                   >
                 </div>
                 <h2 class="item__title">
@@ -80,8 +80,8 @@
                   <img
                     src="/landing/admin/responsive.svg"
                     alt="Responsive"
-                    height="32px"
-                    width="32px"
+                    height="32"
+                    width="32"
                   >
                 </div>
                 <h2 class="item__title">
@@ -94,8 +94,8 @@
                   <img
                     src="/landing/admin/i18n.svg"
                     alt="i18n"
-                    height="32px"
-                    width="32px"
+                    height="32"
+                    width="32"
                   >
                 </div>
                 <h2 class="item__title">

--- a/packages/docs/components/landing/Header.vue
+++ b/packages/docs/components/landing/Header.vue
@@ -61,13 +61,15 @@
           </nav>
           <!-- mobile -->
           <div
-            class="menu"
             v-if="isHidden"
+            class="menu"
             @click="isHidden = false"
           >
             <img
               src="/landing/hamburger.svg"
               alt="Open menu"
+              height="24"
+              width="24"
             >
           </div>
           <nav
@@ -81,6 +83,8 @@
               <img
                 src="/landing/cross.svg"
                 alt="Close menu"
+                height="24"
+                width="24"
               >
             </div>
             <va-list>

--- a/packages/docs/components/landing/OpenSource.vue
+++ b/packages/docs/components/landing/OpenSource.vue
@@ -10,8 +10,8 @@
             <img
               src="/landing/icon-open-source.svg"
               alt="Open source"
-              height="100px"
-              width="100px"
+              height="100"
+              width="100"
             >
           </div>
           <h2 class="opensource__title">
@@ -40,8 +40,8 @@
           <img
             src="/landing/image-open-source.png"
             alt="Open source"
-            height="446px"
-            width="632px"
+            height="446"
+            width="632"
           >
         </div>
       </div>
@@ -76,7 +76,7 @@ export default defineComponent({
   position: relative;
   padding-top: 10rem;
   padding-bottom: 10rem;
-  background-image: url("@/public/landing/pattern-2.svg");
+  background-image: url("/landing/pattern-2.svg");
   background-size: cover;
   background-repeat: no-repeat;
   background-position: top;

--- a/packages/docs/components/landing/Preview.vue
+++ b/packages/docs/components/landing/Preview.vue
@@ -40,7 +40,7 @@
           <!-- items -->
           <!--          <div class="item">-->
           <!--            <div class="item__frame">-->
-          <!--              <img src="/landing/features/nuxt-support.svg" alt="nuxt-support" height="48px" width="48px" />-->
+          <!--              <img src="/landing/features/nuxt-support.svg" alt="nuxt-support" height="48" width="48" />-->
           <!--            </div>-->
           <!--            <h2 class="item__title">{{$t('landing.preview.features.nuxt.title')}}</h2>-->
           <!--            <router-link class="item__link" :to="`/${$root.$i18n.locale}/getting-started/nuxt-integration`">-->
@@ -53,8 +53,8 @@
               <img
                 src="/landing/features/components.svg"
                 alt="Responsive components"
-                height="48px"
-                width="48px"
+                height="48"
+                width="48"
               >
             </div>
             <h2 class="item__title">
@@ -73,8 +73,8 @@
               <img
                 src="/landing/features/keyboard-navigation.svg"
                 alt="Accessibility"
-                height="48px"
-                width="48px"
+                height="48"
+                width="48"
               >
             </div>
             <h2 class="item__title">
@@ -93,8 +93,8 @@
               <img
                 src="/landing/features/modern-browsers.svg"
                 alt="Modern browsers"
-                height="48px"
-                width="48px"
+                height="48"
+                width="48"
               >
             </div>
             <h2 class="item__title">

--- a/packages/docs/components/landing/SeamlessIntegration.vue
+++ b/packages/docs/components/landing/SeamlessIntegration.vue
@@ -46,6 +46,8 @@
             <img
               src="/landing/plus.svg"
               alt="Plus icon"
+              height="96"
+              width="96"
             >
           </div>
           <!-- /First block -->
@@ -101,7 +103,7 @@ const options = ref(['Spain', 'Germany', 'France', 'Italy', 'China', 'Japan', 'P
   position: relative;
   padding-top: 8.5rem;
   padding-bottom: 12rem;
-  background-image: url("@/public/landing/pattern-3.svg");
+  background-image: url("/landing/pattern-3.svg");
   background-size: cover;
   background-color: var(--va-background-landing);
   color: var(--va-on-background-landing);

--- a/packages/docs/page-config/introduction/team/components/team.vue
+++ b/packages/docs/page-config/introduction/team/components/team.vue
@@ -13,8 +13,8 @@
           <img
             :src="item.image"
             :alt="item.name"
-            height="140px"
-            width="140px"
+            height="140"
+            width="140"
           >
         </va-avatar>
         <strong class="mt-3 mb-1">{{ item.name }}</strong>

--- a/packages/docs/pages/index.vue
+++ b/packages/docs/pages/index.vue
@@ -35,7 +35,7 @@ useHead({
   }
 
   &__preview-wrapper {
-    background-image: url("@/public/landing/pattern.svg");
+    background-image: url("/landing/pattern.svg");
     background-size: unset;
     background-repeat: no-repeat;
     background-position: top;


### PR DESCRIPTION
Close #3030 

## Description
- According to the MDN docs for the img tag, removed units from `height` and `width` attributes.
- Removed public path from svg path'.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
