### PR TITLE
Docs/fix incorrect imports

### DIFF
--- a/packages/docs/modules/vuestic.ts
+++ b/packages/docs/modules/vuestic.ts
@@ -24,7 +24,9 @@ export default defineNuxtModule<VuesticOptions>({
   setup (options, nuxt) {
     nuxt.options.alias['@vuestic/ag-grid-theme'] = resolve(__dirname, '../../ag-grid-theme/src/styles/index.scss');
     nuxt.options.alias['vuestic-ui/styles/typography.css'] = resolve(__dirname, '../../ui/src/styles/typography/typography.scss');
+    nuxt.options.alias['vuestic-ui/styles/grid'] = resolve(__dirname, '../../ui/src/styles/grid/grid.scss');
     nuxt.options.alias['vuestic-ui/styles/essential.css'] = resolve(__dirname, '../../ui/src/styles/essential.scss');
+    nuxt.options.alias['vuestic-ui/styles/smart-helpers'] = resolve(__dirname, '../../ui/src/styles/smart-helpers/smart-helpers.scss');
     nuxt.options.alias['vuestic-ui/src'] = resolve(__dirname, '../../ui/src/');
     nuxt.options.alias['vuestic-ui/styles'] = resolve(__dirname, '../../ui/src/styles/');
     nuxt.options.alias['vuestic-ui/css'] =  resolve(__dirname, '../../ui/src/styles/index.scss');

--- a/packages/docs/page-config/services/breakpoints/examples/Default.vue
+++ b/packages/docs/page-config/services/breakpoints/examples/Default.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script setup lang="ts">
-import { useBreakpoint } from "vuestic-ui/src/composables";
+import { useBreakpoint } from "vuestic-ui";
 
 const breakpoint = useBreakpoint();
 </script>

--- a/packages/docs/page-config/services/colors-classes/examples/Default.vue
+++ b/packages/docs/page-config/services/colors-classes/examples/Default.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script>
-import { useGlobalConfig } from 'vuestic-ui/src/services/global-config/global-config'
+import { useGlobalConfig } from 'vuestic-ui'
 
 export default {
   setup () {

--- a/packages/docs/page-config/services/colors-config/examples/change-colors.vue
+++ b/packages/docs/page-config/services/colors-config/examples/change-colors.vue
@@ -14,7 +14,7 @@
 
 <script>
 import { computed } from "vue";
-import { useColors } from "vuestic-ui/src/main";
+import { useColors } from "vuestic-ui";
 
 export default {
   props: {

--- a/packages/docs/page-config/services/colors-config/examples/css-variable.vue
+++ b/packages/docs/page-config/services/colors-config/examples/css-variable.vue
@@ -23,7 +23,7 @@
 
 <script>
 import { computed } from "vue";
-import { useColors } from "vuestic-ui/src/main";
+import { useColors } from "vuestic-ui";
 
 export default {
   props: {

--- a/packages/docs/page-config/services/components-config/examples/button.vue
+++ b/packages/docs/page-config/services/components-config/examples/button.vue
@@ -19,7 +19,7 @@
 <script setup>
 import { computed, ref, watch } from "vue";
 
-import { useGlobalConfig } from "vuestic-ui/src/main";
+import { useGlobalConfig } from "vuestic-ui";
 
 const getDefaultButtonProps = () => ({
   round: false,

--- a/packages/docs/page-config/services/icons-config/code/setup-example.ts
+++ b/packages/docs/page-config/services/icons-config/code/setup-example.ts
@@ -1,4 +1,4 @@
-import { createVuestic, createIconsConfig } from "vuestic-ui/src/main";
+import { createVuestic, createIconsConfig } from "vuestic-ui";
 
 const aliases = [
   /*...*/

--- a/packages/docs/page-config/services/icons-config/components/use-copy-to-clipboard.ts
+++ b/packages/docs/page-config/services/icons-config/components/use-copy-to-clipboard.ts
@@ -1,4 +1,4 @@
-import { useToast } from "vuestic-ui/src/main";
+import { useToast } from "vuestic-ui";
 import { getWindow } from "vuestic-ui/src/utils/ssr";
 
 export const useCopyToClipboard = () => {

--- a/packages/docs/page-config/styles/colors/components/components/colors-grid.vue
+++ b/packages/docs/page-config/styles/colors/components/components/colors-grid.vue
@@ -16,7 +16,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { useColors } from "vuestic-ui/src/main";
+import { useColors } from "vuestic-ui";
 import ColorsGridCard from "./colors-grid-card.vue";
 import { presets } from 'vuestic-ui/src/services/color/presets'
 

--- a/packages/docs/page-config/styles/colors/components/theme.vue
+++ b/packages/docs/page-config/styles/colors/components/theme.vue
@@ -28,7 +28,7 @@
 
 <script>
 import { ref, watchEffect, toRef } from "vue";
-import { useColors } from "vuestic-ui/src/main";
+import { useColors } from "vuestic-ui";
 
 export default {
   setup() {

--- a/packages/docs/page-config/styles/grid/examples/AlignContent.vue
+++ b/packages/docs/page-config/styles/grid/examples/AlignContent.vue
@@ -101,7 +101,7 @@
 </template>
 
 <script>
-import VaCard from "vuestic-ui/src/components/va-card/VaCard";
+import { VaCard } from "vuestic-ui";
 
 export default {
   components: { VaCard },
@@ -109,8 +109,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "vuestic-ui/src/styles/resources";
-@import "vuestic-ui/src/styles/grid/grid.scss";
+@import "vuestic-ui/styles/grid";
 
 .row {
   min-height: 10rem;

--- a/packages/docs/page-config/styles/grid/examples/AlignDefault.vue
+++ b/packages/docs/page-config/styles/grid/examples/AlignDefault.vue
@@ -42,7 +42,7 @@
 </template>
 
 <script>
-import VaCard from "vuestic-ui/src/components/va-card/VaCard";
+import { VaCard } from "vuestic-ui";
 
 export default {
   components: { VaCard },
@@ -50,8 +50,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "vuestic-ui/src/styles/resources";
-@import "vuestic-ui/src/styles/grid/grid.scss";
+@import "vuestic-ui/styles/grid";
 
 .row {
   min-height: 6rem;

--- a/packages/docs/page-config/styles/grid/examples/AlignJustify.vue
+++ b/packages/docs/page-config/styles/grid/examples/AlignJustify.vue
@@ -120,7 +120,7 @@
 </template>
 
 <script>
-import VaCard from "vuestic-ui/src/components/va-card/VaCard";
+import { VaCard } from "vuestic-ui";
 
 export default {
   components: { VaCard },
@@ -128,8 +128,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "vuestic-ui/src/styles/resources";
-@import "vuestic-ui/src/styles/grid/grid.scss";
+@import "vuestic-ui/styles/grid";
 
 .row + .row {
   border-top: 1px solid var(--va-background-border);

--- a/packages/docs/page-config/styles/grid/examples/AlignSelf.vue
+++ b/packages/docs/page-config/styles/grid/examples/AlignSelf.vue
@@ -36,7 +36,7 @@
 </template>
 
 <script>
-import VaCard from "vuestic-ui/src/components/va-card/VaCard";
+import { VaCard } from "vuestic-ui";
 
 export default {
   components: { VaCard },
@@ -44,8 +44,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "vuestic-ui/src/styles/resources";
-@import "vuestic-ui/src/styles/grid/grid.scss";
+@import "vuestic-ui/styles/grid";
 
 .row {
   min-height: 6rem;

--- a/packages/docs/page-config/styles/grid/examples/Breakpoints.vue
+++ b/packages/docs/page-config/styles/grid/examples/Breakpoints.vue
@@ -42,8 +42,7 @@
 </template>
 
 <style lang="scss" scoped>
-@import "vuestic-ui/src/styles/resources";
-@import "vuestic-ui/src/styles/grid/grid.scss";
+@import "vuestic-ui/styles/grid";
 
 .item {
   border: 1px solid var(--va-background-border);

--- a/packages/docs/page-config/styles/grid/examples/Default.vue
+++ b/packages/docs/page-config/styles/grid/examples/Default.vue
@@ -17,15 +17,14 @@
 </template>
 
 <script>
-import VaCard from "vuestic-ui/src/components/va-card/VaCard";
+import { VaCard } from "vuestic-ui";
 export default {
   components: { VaCard },
 };
 </script>
 
 <style lang="scss" scoped>
-@import "vuestic-ui/src/styles/resources";
-@import "vuestic-ui/src/styles/grid/grid.scss";
+@import "vuestic-ui/styles/grid";
 
 .item {
   border: 1px solid var(--va-background-border);

--- a/packages/docs/page-config/styles/grid/examples/Gutters.vue
+++ b/packages/docs/page-config/styles/grid/examples/Gutters.vue
@@ -36,15 +36,14 @@
 </template>
 
 <script>
-import VaCard from "vuestic-ui/src/components/va-card/VaCard";
+import { VaCard } from "vuestic-ui";
 export default {
   components: { VaCard },
 };
 </script>
 
 <style lang="scss" scoped>
-@import "vuestic-ui/src/styles/resources";
-@import "vuestic-ui/src/styles/grid/grid.scss";
+@import "vuestic-ui/styles/grid";
 
 .layout {
   background-color: var(--va-secondary);

--- a/packages/docs/page-config/styles/grid/examples/Offsets.vue
+++ b/packages/docs/page-config/styles/grid/examples/Offsets.vue
@@ -42,15 +42,14 @@
 </template>
 
 <script>
-import VaCard from "vuestic-ui/src/components/va-card/VaCard";
+import { VaCard } from "vuestic-ui";
 export default {
   components: { VaCard },
 };
 </script>
 
 <style lang="scss" scoped>
-@import "vuestic-ui/src/styles/resources";
-@import "vuestic-ui/src/styles/grid/grid.scss";
+@import "vuestic-ui/styles/grid";
 
 .item {
   border: 1px solid var(--va-background-border);

--- a/packages/docs/page-config/ui-elements/file-upload/examples/Undo.vue
+++ b/packages/docs/page-config/ui-elements/file-upload/examples/Undo.vue
@@ -32,7 +32,7 @@
 </template>
 
 <script>
-import { VaFileUpload, VaInput, VaSwitch } from "vuestic-ui/src/components";
+import { VaFileUpload, VaInput, VaSwitch } from "vuestic-ui";
 
 export default {
   components: { VaFileUpload, VaInput, VaSwitch },

--- a/packages/docs/page-config/ui-elements/hover/examples/Slot.vue
+++ b/packages/docs/page-config/ui-elements/hover/examples/Slot.vue
@@ -10,7 +10,7 @@
 
 <script setup>
 import { computed } from "vue";
-import { useColors } from "vuestic-ui/src/main";
+import { useColors } from "vuestic-ui";
 
 const { getColors } = useColors();
 const colors = computed(getColors);

--- a/packages/docs/page-config/ui-elements/modal/examples/Create.vue
+++ b/packages/docs/page-config/ui-elements/modal/examples/Create.vue
@@ -24,7 +24,7 @@
 
 <script>
 import { defineComponent } from "vue";
-import { useModal } from "vuestic-ui/src/main";
+import { useModal } from "vuestic-ui";
 import message from "./popup-message";
 
 export default defineComponent({

--- a/packages/docs/page-config/ui-elements/navbar/examples/Colors.vue
+++ b/packages/docs/page-config/ui-elements/navbar/examples/Colors.vue
@@ -80,7 +80,7 @@
 
 <script setup>
 import { computed } from "vue";
-import { useColors } from "vuestic-ui/src/main";
+import { useColors } from "vuestic-ui";
 
 const { currentPresetName } = useColors();
 

--- a/packages/docs/page-config/ui-elements/pagination/examples/Colors.vue
+++ b/packages/docs/page-config/ui-elements/pagination/examples/Colors.vue
@@ -14,7 +14,7 @@
 
 <script setup>
 import { ref } from "vue";
-import { useGlobalConfig } from "vuestic-ui/src/services/global-config";
+import { useGlobalConfig } from "vuestic-ui";
 
 const value = ref(3);
 const { mergeGlobalConfig } = useGlobalConfig();

--- a/packages/docs/page-config/ui-elements/stepper/examples/Custom.vue
+++ b/packages/docs/page-config/ui-elements/stepper/examples/Custom.vue
@@ -63,7 +63,7 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
-import VaIcon from 'vuestic-ui/src/components/va-icon/VaIcon.vue'
+import { VaIcon } from 'vuestic-ui'
 
 const step = ref(0)
 


### PR DESCRIPTION
closes https://github.com/epicmaxco/vuestic-ui/issues/3100

Removed imports like `vuestic-ui/src/styles/grid.scss` which are not available for end-user.