### PR TITLE
[#3116] tab shift autocomplete behaviour fix

### DIFF
--- a/packages/ui/src/components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/va-select/VaSelect.vue
@@ -504,6 +504,7 @@ export default defineComponent({
     }
 
     const tabIndexComputed = computed(() => props.disabled ? -1 : props.tabindex)
+    const inputWrapperTabIndexComputed = computed(() => props.disabled || props.autocomplete ? -1 : 0)
 
     const scrollToSelected = () => {
       const selected = valueComputed.value
@@ -593,7 +594,7 @@ export default defineComponent({
       error: computedError.value,
       errorMessages: computedErrorMessages.value,
       focused: isFocused.value,
-      tabindex: tabIndexComputed.value,
+      tabindex: inputWrapperTabIndexComputed.value,
     }))
 
     // select content


### PR DESCRIPTION
Closes: #3116 

## Description
- [x] fixed tab-back behaviour for `autocomplete` `va-select` state.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)