### PR TITLE
[#3053] grid/reset deprecated alert color changed

### DIFF
--- a/packages/docs/page-config/styles/grid/index.ts
+++ b/packages/docs/page-config/styles/grid/index.ts
@@ -2,7 +2,7 @@ export default definePageConfig({
   blocks: [
     block.title("grid.title"),
     block.paragraph("grid.summaryText"),
-    block.alert("grid.deprecated", "primary"),
+    block.alert("grid.deprecated", "danger"),
 
     block.example("Default"),
 

--- a/packages/docs/page-config/styles/reset/index.ts
+++ b/packages/docs/page-config/styles/reset/index.ts
@@ -2,7 +2,7 @@ export default definePageConfig({
   blocks: [
     block.title("reset.title"),
     block.paragraph("reset.description"),
-    block.alert("reset.deprecated", "primary"),
+    block.alert("reset.deprecated", "danger"),
 
     block.headline("reset.features.title"),
     block.paragraph("reset.features.info"),

--- a/packages/docs/page-config/styles/tailwind/index.ts
+++ b/packages/docs/page-config/styles/tailwind/index.ts
@@ -3,7 +3,7 @@ export default definePageConfig({
     block.title("tailwind.title"),
     block.paragraph("tailwind.summaryText"),
 
-    block.alert("tailwind.deprecated", "warning"),
+    block.alert("tailwind.deprecated", "danger"),
 
     block.headline("tailwind.preparation.title"),
     block.paragraph("tailwind.preparation.text"),


### PR DESCRIPTION
Closes: #3053 

## Description
- [x] deprecated color changed to danger.

<img width="1053" alt="image" src="https://user-images.githubusercontent.com/64714442/223390739-2040b799-5581-428a-b8fa-0a64ac999ae3.png">

## Types of changes
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)