### PR TITLE
Fix/button wrong focus, switching to CSS hover/pressed states

### DIFF
--- a/packages/ui/src/components/va-button-group/VaButtonGroup.demo.vue
+++ b/packages/ui/src/components/va-button-group/VaButtonGroup.demo.vue
@@ -20,6 +20,69 @@
       </va-button-group>
     </VbCard>
 
+    <VbCard title="Presets & styles">
+      <va-button-group class="mb-6">
+        <va-button>One</va-button>
+        <va-button>Two</va-button>
+        <va-button>Three</va-button>
+      </va-button-group>
+
+      <va-button-group
+        preset="primary"
+        class="mb-6"
+      >
+        <va-button>One</va-button>
+        <va-button>Two</va-button>
+        <va-button>Three</va-button>
+      </va-button-group>
+
+      <va-button-group
+        preset="secondary"
+        class="mb-6"
+      >
+        <va-button>One</va-button>
+        <va-button>Two</va-button>
+        <va-button>Three</va-button>
+      </va-button-group>
+
+      <va-button-group
+        preset="plain"
+        class="mb-6"
+      >
+        <va-button>One</va-button>
+        <va-button>Two</va-button>
+        <va-button>Three</va-button>
+      </va-button-group>
+
+      <va-button-group
+        preset="plainOpacity"
+        class="mb-6"
+      >
+        <va-button>One</va-button>
+        <va-button>Two</va-button>
+        <va-button>Three</va-button>
+      </va-button-group>
+
+      <va-button-group
+        preset="secondary"
+        border-color="primary"
+        class="mb-6"
+      >
+        <va-button>One</va-button>
+        <va-button>Two</va-button>
+        <va-button>Three</va-button>
+      </va-button-group>
+
+      <va-button-group
+        round
+        class="mb-6"
+      >
+        <va-button>One</va-button>
+        <va-button>Two</va-button>
+        <va-button>Three</va-button>
+      </va-button-group>
+    </VbCard>
+
     <VbCard>
       <table class="table table-bordered">
         <tr>

--- a/packages/ui/src/components/va-button-group/VaButtonGroup.vue
+++ b/packages/ui/src/components/va-button-group/VaButtonGroup.vue
@@ -81,14 +81,9 @@ export default defineComponent({
     margin: var(--va-button-group-button-margin);
     width: var(--va-button-group-button-width);
     box-shadow: none;
-    outline: none;
 
     &:focus-visible {
-      outline: none !important;
-
-      &::before {
-        @include focus-outline($offset: -2px, $radius: 'inherit');
-      }
+      @include focus-outline($offset: -2px, $radius: 'inherit');
     }
   }
 

--- a/packages/ui/src/components/va-button/VaButton.demo.vue
+++ b/packages/ui/src/components/va-button/VaButton.demo.vue
@@ -10,6 +10,7 @@
             <va-button preset="secondary">Secondary</va-button>
             <va-button preset="plain">Plain</va-button>
             <va-button preset="plainOpacity">Plain with opacity</va-button>
+            <va-button color="info" gradient>Gradient</va-button>
           </td>
         </tr>
 
@@ -30,6 +31,8 @@
             <va-button preset="plain" hoverBehavior="mask" hoverMaskColor="warning" :hoverOpacity="1">
               Hover me
             </va-button>
+            <va-button color="info" gradient hoverBehavior="opacity" :hoverOpacity="0.4">Hover me</va-button>
+            <va-button preset="plain" color="info" gradient hoverBehavior="opacity" :hoverOpacity="0.4">Hover me</va-button>
           </td>
         </tr>
 
@@ -50,6 +53,8 @@
             <va-button preset="plain" hoverBehavior="mask" hoverMaskColor="warning" :hoverOpacity="1">
               Press me
             </va-button>
+            <va-button color="info" gradient pressedBehavior="opacity" :pressedOpacity="0.4">Press me</va-button>
+            <va-button preset="plain" color="info" gradient pressedBehavior="opacity" :pressedOpacity="0.4">Press me</va-button>
           </td>
         </tr>
 

--- a/packages/ui/src/components/va-button/VaButton.vue
+++ b/packages/ui/src/components/va-button/VaButton.vue
@@ -169,8 +169,6 @@ export default defineComponent({
     } = useButtonBackground(colorComputed)
     const contentColorComputed = useButtonTextColor(textColorComputed, colorComputed, isPressed, isHovered)
 
-    console.log(contentColorComputed.value)
-
     const computedStyle = computed(() => ({
       borderColor: props.borderColor ? getColor(props.borderColor) : 'transparent',
       ...contentColorComputed.value,

--- a/packages/ui/src/components/va-button/VaButton.vue
+++ b/packages/ui/src/components/va-button/VaButton.vue
@@ -164,11 +164,12 @@ export default defineComponent({
 
     const {
       backgroundColor,
-      backgroundColorOpacity,
-      backgroundMaskOpacity,
-      backgroundMaskColor,
-    } = useButtonBackground(colorComputed, isPressed, isHovered)
+      hoverBackgroundColor,
+      pressedBackgroundColor,
+    } = useButtonBackground(colorComputed)
     const contentColorComputed = useButtonTextColor(textColorComputed, colorComputed, isPressed, isHovered)
+
+    console.log(contentColorComputed.value)
 
     const computedStyle = computed(() => ({
       borderColor: props.borderColor ? getColor(props.borderColor) : 'transparent',
@@ -189,9 +190,8 @@ export default defineComponent({
       iconAttributesComputed,
 
       backgroundColor,
-      backgroundMaskColor,
-      backgroundMaskOpacity,
-      backgroundColorOpacity,
+      hoverBackgroundColor,
+      pressedBackgroundColor,
 
       ...publicMethods,
     }
@@ -212,7 +212,7 @@ export default defineComponent({
   border-width: var(--va-button-border-width);
   border-color: var(--va-button-border-color);
   border-style: var(--va-button-border-style);
-  background-image: var(--va-button-background-image);
+  background: var(--va-button-background-image), v-bind(backgroundColor);
   box-shadow: var(--va-button-box-shadow);
   font-family: var(--va-font-family);
   font-weight: var(--va-button-font-weight);
@@ -222,23 +222,12 @@ export default defineComponent({
   box-sizing: border-box;
   cursor: var(--va-button-cursor);
 
-  &::after,
-  &::before {
-    content: '';
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    border-radius: inherit;
+  &:hover {
+    background: var(--va-button-background-image), v-bind(hoverBackgroundColor);
   }
 
-  &::before {
-    background: v-bind(backgroundColor);
-    opacity: v-bind(backgroundColorOpacity);
-  }
-
-  &::after {
-    background-color: v-bind(backgroundMaskColor);
-    opacity: v-bind(backgroundMaskOpacity);
+  &:active {
+    background: var(--va-button-background-image), v-bind(pressedBackgroundColor);
   }
 
   &__content {

--- a/packages/ui/src/components/va-button/hooks/useButtonBackground.ts
+++ b/packages/ui/src/components/va-button/hooks/useButtonBackground.ts
@@ -1,6 +1,6 @@
-import { computed, Ref, ComputedRef, getCurrentInstance } from 'vue'
+import { Ref, getCurrentInstance } from 'vue'
 
-import { colorToRgba, useColors } from '../../../composables'
+import { colorToRgba, getGradientBackgroundWithOpacity, useColors } from '../../../composables'
 
 import type { ButtonPropsTypes } from '../types'
 
@@ -19,7 +19,7 @@ export const useButtonBackground: UseButtonBackground = (
   if (!instance) { throw new Error('`useButtonBackground` hook must be used only inside of setup function!') }
   const props = instance.props as Required<ButtonPropsTypes>
 
-  const { getColor, getGradientBackground } = useColors()
+  const { getColor } = useColors()
 
   if (props.plain) {
     return {
@@ -29,24 +29,21 @@ export const useButtonBackground: UseButtonBackground = (
     }
   }
 
-  const background = props.gradient ? getGradientBackground(colorComputed.value) : colorComputed.value
-
   const getBackgroundWithOpacity = (background: string, opacity: number) => {
-    return props.gradient ? background : colorToRgba(background === 'transparent' ? '#FFFFFF' : background, opacity)
+    return props.gradient ? getGradientBackgroundWithOpacity(background, opacity) : colorToRgba(background === 'transparent' ? '#FFFFFF' : background, opacity)
   }
 
-  const backgroundColor = getBackgroundWithOpacity(background, props.backgroundOpacity)
+  const backgroundColor = getBackgroundWithOpacity(colorComputed.value, props.backgroundOpacity)
 
   const hoverBackgroundColor = () => {
     const opacity = props.hoverBehavior === 'opacity' ? props.hoverOpacity : props.backgroundOpacity
-    const color = props.hoverBehavior === 'mask' ? getColor(props.hoverMaskColor) : background
-    console.log(props.hoverBehavior, background, opacity, color)
+    const color = props.hoverBehavior === 'mask' ? getColor(props.hoverMaskColor) : colorComputed.value
     return getBackgroundWithOpacity(color, opacity)
   }
 
   const pressedBackgroundColor = () => {
     const opacity = props.pressedBehavior === 'opacity' ? props.pressedOpacity : props.backgroundOpacity
-    const color = props.pressedBehavior === 'mask' ? getColor(props.pressedMaskColor) : background
+    const color = props.pressedBehavior === 'mask' ? getColor(props.pressedMaskColor) : colorComputed.value
     return getBackgroundWithOpacity(color, opacity)
   }
 

--- a/packages/ui/src/components/va-button/hooks/useButtonTextColor.ts
+++ b/packages/ui/src/components/va-button/hooks/useButtonTextColor.ts
@@ -54,10 +54,9 @@ export const useButtonTextColor: UseButtonTextColor = (
 
   const props = instance.props as Required<ButtonPropsTypes>
 
-  const { getColor, colorToRgba, getStateMaskGradientBackground } = useColors()
+  const { getColor, colorToRgba } = useColors()
 
   const plainColorStyles = computed(() => ({
-    // background: 'transparent',
     color: textColorComputed.value,
     '-webkit-background-clip': 'text' as const,
     'background-clip': 'text' as const,
@@ -72,7 +71,6 @@ export const useButtonTextColor: UseButtonTextColor = (
       stateStyles = { color: colorToRgba(textColorComputed.value, stateOpacity) }
     } else {
       stateStyles = {
-        // background: getStateMaskGradientBackground(colorComputed.value, maskStateColor, stateOpacity),
         color: stateOpacity < 1 ? colorToRgba(textColorComputed.value, getOpacity(stateOpacity)) : maskStateColor,
       }
     }
@@ -97,10 +95,8 @@ export const useButtonTextColor: UseButtonTextColor = (
   return computed(() => {
     const defaultColorStyles = {
       color: textColorComputed.value,
-      // background: 'transparent',
     }
     props.plain && Object.assign(defaultColorStyles, plainColorStyles.value)
-    // props.plain && Object.assign(defaultColorStyles, plainColorStyles.value, { background: textColorComputed.value })
 
     if (!props.plain) { return defaultColorStyles }
     if (isPressed.value) { return pressedTextColorComputed.value }

--- a/packages/ui/src/components/va-button/hooks/useButtonTextColor.ts
+++ b/packages/ui/src/components/va-button/hooks/useButtonTextColor.ts
@@ -7,7 +7,7 @@ import { ButtonPropsTypes } from '../types'
 
 type ButtonTextColorStyles = {
   color: string
-  background?: string
+  // background?: string
   opacity?: number
   'background-clip'?: 'text',
   '-webkit-background-clip'?: 'text',
@@ -57,10 +57,10 @@ export const useButtonTextColor: UseButtonTextColor = (
   const { getColor, colorToRgba, getStateMaskGradientBackground } = useColors()
 
   const plainColorStyles = computed(() => ({
-    background: 'transparent',
+    // background: 'transparent',
     color: textColorComputed.value,
-    '-webkit-background-clip': 'text',
-    'background-clip': 'text',
+    '-webkit-background-clip': 'text' as const,
+    'background-clip': 'text' as const,
     opacity: getPlainTextOpacity.value,
   }))
 
@@ -72,7 +72,7 @@ export const useButtonTextColor: UseButtonTextColor = (
       stateStyles = { color: colorToRgba(textColorComputed.value, stateOpacity) }
     } else {
       stateStyles = {
-        background: getStateMaskGradientBackground(colorComputed.value, maskStateColor, stateOpacity),
+        // background: getStateMaskGradientBackground(colorComputed.value, maskStateColor, stateOpacity),
         color: stateOpacity < 1 ? colorToRgba(textColorComputed.value, getOpacity(stateOpacity)) : maskStateColor,
       }
     }
@@ -97,10 +97,10 @@ export const useButtonTextColor: UseButtonTextColor = (
   return computed(() => {
     const defaultColorStyles = {
       color: textColorComputed.value,
-      background: 'transparent',
+      // background: 'transparent',
     }
-
-    props.plain && Object.assign(defaultColorStyles, plainColorStyles.value, { background: textColorComputed.value })
+    props.plain && Object.assign(defaultColorStyles, plainColorStyles.value)
+    // props.plain && Object.assign(defaultColorStyles, plainColorStyles.value, { background: textColorComputed.value })
 
     if (!props.plain) { return defaultColorStyles }
     if (isPressed.value) { return pressedTextColorComputed.value }

--- a/packages/ui/src/composables/useHoverStyle.ts
+++ b/packages/ui/src/composables/useHoverStyle.ts
@@ -2,9 +2,9 @@ import { PropType } from 'vue'
 
 export const useHoverStyleProps = {
   hoverBehavior: {
-    type: String as PropType<'opacity' | 'mask'>,
-    default: 'mask',
-    validator: (value: string) => ['opacity', 'mask'].includes(value),
+    type: String as PropType<'opacity' | 'mask' | 'none'>,
+    default: 'none',
+    validator: (value: string) => ['opacity', 'mask', 'none'].includes(value),
   },
   hoverOpacity: { type: Number, default: 0.15 },
   hoverMaskColor: { type: String, default: 'textInverted' },

--- a/packages/ui/src/composables/usePressedStyle.ts
+++ b/packages/ui/src/composables/usePressedStyle.ts
@@ -2,9 +2,9 @@ import { PropType } from 'vue'
 
 export const usePressedStyleProps = {
   pressedBehavior: {
-    type: String as PropType<'opacity' | 'mask'>,
-    default: 'mask',
-    validator: (value: string) => ['opacity', 'mask'].includes(value),
+    type: String as PropType<'opacity' | 'mask' | 'none'>,
+    default: 'none',
+    validator: (value: string) => ['opacity', 'mask', 'none'].includes(value),
   },
   pressedOpacity: { type: Number, default: 0.13 },
   pressedMaskColor: { type: String, default: 'textPrimary' },

--- a/packages/ui/src/services/color/utils.ts
+++ b/packages/ui/src/services/color/utils.ts
@@ -106,6 +106,13 @@ export const getGradientBackground = (color: string) => {
   return `linear-gradient(to right, ${colorLeft}, ${colorRight})`
 }
 
+export const getGradientBackgroundWithOpacity = (color: string, opacity = 1) => {
+  const colorLeft = new ColorTranslator(shiftGradientColor(color)).setA(opacity).HSLA
+  const colorRight = new ColorTranslator(color).setA(opacity).HSLA
+
+  return `linear-gradient(to right, ${colorLeft}, ${colorRight})`
+}
+
 export const getStateMaskGradientBackground = (color: string, maskColor: string, maskOpacity: number) => {
   const mask = colorToRgba(maskColor, maskOpacity)
 


### PR DESCRIPTION
Closes #3089
## Description
- Changed the hover and pressed behavior from JS to CSS.
- Removed the use of additional :after and :before pseudo-elements.
- Created background helper functions that return 3 colors - general, hover, and pressed - and can switch from one to another.
- Managed background opacity through the alpha channel.
- Added a new Gradient background helper that can use alpha opacity.
- Modified the button group outline to work like all the others, without using pseudo-elements.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
