### PR TITLE
Add color prop to VaDivider component and bind it to CSS border color

### DIFF
--- a/packages/ui/src/components/va-divider/VaDivider.vue
+++ b/packages/ui/src/components/va-divider/VaDivider.vue
@@ -4,6 +4,7 @@
     class="va-divider"
     :class="classComputed"
     :aria-orientation="vertical ? 'vertical' : 'horizontal'"
+    :style="`color: ${color}; --va-divider-border-top-color: ${color}`"
   >
     <div
       v-if="hasSlot && !vertical"
@@ -32,6 +33,7 @@ export default defineComponent({
       default: 'center',
       validator: (value: string) => ['left', 'right', 'center'].includes(value),
     },
+    color: { type: String, default: '' }
   },
   setup: (props, { slots }) => ({
     hasSlot: computed(() => !!slots.default),
@@ -81,7 +83,7 @@ export default defineComponent({
     flex: 1;
     border-top-width: var(--va-divider-line-width);
     border-top-style: var(--va-divider-border-top-style);
-    border-top-color: var(--va-divider-border-top-color);
+    border-top-color: var(--va-divider-border-top-color)
   }
 
   &--dashed {

--- a/packages/ui/src/components/va-divider/VaDivider.vue
+++ b/packages/ui/src/components/va-divider/VaDivider.vue
@@ -17,6 +17,7 @@
 <script lang="ts">
 import { defineComponent, computed, PropType } from 'vue'
 import { useComponentPresetProp } from '../../composables/useComponentPreset'
+import { useColors } from '../../composables/useColors'
 
 const prefixClass = 'va-divider'
 
@@ -34,15 +35,22 @@ export default defineComponent({
     },
     color: { type: String, default: 'backgroundBorder' },
   },
-  setup: (props, { slots }) => ({
-    hasSlot: computed(() => !!slots.default),
-    classComputed: computed(() => ({
-      [`${prefixClass}--vertical`]: props.vertical,
-      [`${prefixClass}--inset`]: props.inset,
-      [`${prefixClass}--${props.orientation}`]: props.orientation && !props.vertical,
-      [`${prefixClass}--dashed`]: props.dashed,
-    })),
-  }),
+  setup (props, { slots }) {
+    const { getColor } = useColors()
+
+    const colorComputed = computed(() => getColor(props.color))
+
+    return {
+      colorComputed,
+      hasSlot: computed(() => !!slots.default),
+      classComputed: computed(() => ({
+        [`${prefixClass}--vertical`]: props.vertical,
+        [`${prefixClass}--inset`]: props.inset,
+        [`${prefixClass}--${props.orientation}`]: props.orientation && !props.vertical,
+        [`${prefixClass}--dashed`]: props.dashed,
+      })),
+    }
+  },
 })
 </script>
 
@@ -59,7 +67,7 @@ export default defineComponent({
     border-top: 0;
     border-right-width: var(--va-divider-line-width);
     border-right-style: var(--va-divider-border-style);
-    border-right-color: v-bind(color);
+    border-right-color: v-bind(colorComputed);
     display: var(--va-divider-vertical-display);
     vertical-align: top;
 
@@ -82,7 +90,7 @@ export default defineComponent({
     flex: 1;
     border-top-width: var(--va-divider-line-width);
     border-top-style: var(--va-divider-border-style);
-    border-top-color: v-bind(color);
+    border-top-color: v-bind(colorComputed);
   }
 
   &--dashed {

--- a/packages/ui/src/components/va-divider/VaDivider.vue
+++ b/packages/ui/src/components/va-divider/VaDivider.vue
@@ -4,7 +4,7 @@
     class="va-divider"
     :class="classComputed"
     :aria-orientation="vertical ? 'vertical' : 'horizontal'"
-    :style="`color: ${color}; --va-divider-border-top-color: ${color}`"
+
   >
     <div
       v-if="hasSlot && !vertical"
@@ -33,7 +33,6 @@ export default defineComponent({
       default: 'center',
       validator: (value: string) => ['left', 'right', 'center'].includes(value),
     },
-    color: { type: String, default: '' }
   },
   setup: (props, { slots }) => ({
     hasSlot: computed(() => !!slots.default),

--- a/packages/ui/src/components/va-divider/VaDivider.vue
+++ b/packages/ui/src/components/va-divider/VaDivider.vue
@@ -4,7 +4,6 @@
     class="va-divider"
     :class="classComputed"
     :aria-orientation="vertical ? 'vertical' : 'horizontal'"
-    :style="`color: ${color}; --va-divider-border-top-color: ${color}`"
   >
     <div
       v-if="hasSlot && !vertical"
@@ -33,7 +32,7 @@ export default defineComponent({
       default: 'center',
       validator: (value: string) => ['left', 'right', 'center'].includes(value),
     },
-    color: { type: String, default: '' }
+    color: { type: String, default: 'backgroundBorder' },
   },
   setup: (props, { slots }) => ({
     hasSlot: computed(() => !!slots.default),
@@ -57,10 +56,10 @@ export default defineComponent({
 
   &--vertical {
     margin: 0 var(--va-divider-margin);
-    border-top: var(--va-divider-vertical-border-top);
-    border-right-width: var(--va-divider-vertical-border-right-width);
-    border-right-style: var(--va-divider-vertical-border-right-style);
-    border-right-color: var(--va-divider-vertical-border-right-color);
+    border-top: 0;
+    border-right-width: var(--va-divider-line-width);
+    border-right-style: var(--va-divider-border-style);
+    border-right-color: v-bind(color);
     display: var(--va-divider-vertical-display);
     vertical-align: top;
 
@@ -82,8 +81,8 @@ export default defineComponent({
     content: "";
     flex: 1;
     border-top-width: var(--va-divider-line-width);
-    border-top-style: var(--va-divider-border-top-style);
-    border-top-color: var(--va-divider-border-top-color)
+    border-top-style: var(--va-divider-border-style);
+    border-top-color: v-bind(color);
   }
 
   &--dashed {

--- a/packages/ui/src/components/va-divider/VaDivider.vue
+++ b/packages/ui/src/components/va-divider/VaDivider.vue
@@ -4,7 +4,7 @@
     class="va-divider"
     :class="classComputed"
     :aria-orientation="vertical ? 'vertical' : 'horizontal'"
-
+    :style="`color: ${color}; --va-divider-border-top-color: ${color}`"
   >
     <div
       v-if="hasSlot && !vertical"
@@ -33,6 +33,7 @@ export default defineComponent({
       default: 'center',
       validator: (value: string) => ['left', 'right', 'center'].includes(value),
     },
+    color: { type: String, default: '' }
   },
   setup: (props, { slots }) => ({
     hasSlot: computed(() => !!slots.default),

--- a/packages/ui/src/components/va-divider/_variables.scss
+++ b/packages/ui/src/components/va-divider/_variables.scss
@@ -1,13 +1,11 @@
 :root,
 :host {
   --va-divider-display: flex;
-  --va-divider-color: var(--va-background-border);
 
   /* Margin around divider, not the same as CSS margin. Should be one value. */
   --va-divider-margin: 0.5rem;
   --va-divider-line-width: 1px;
-  --va-divider-border-top-style: solid;
-  --va-divider-border-top-color: var(--va-divider-color);
+  --va-divider-border-style: solid;
   --va-divider-text-font-size: 0.875rem;
   --va-divider-text-line-height: 0;
   --va-divider-text-height: 0;
@@ -18,10 +16,6 @@
   --va-divider-text-horizontal-offset: 1.25rem;
 
   /* Vertical */
-  --va-divider-vertical-border-top: 0;
-  --va-divider-vertical-border-right-width: 1px;
-  --va-divider-vertical-border-right-style: solid;
-  --va-divider-vertical-border-right-color: var(--va-divider-color);
   --va-divider-vertical-display: inline-flex;
 
   /* Inset */

--- a/packages/ui/src/components/va-divider/_variables.scss
+++ b/packages/ui/src/components/va-divider/_variables.scss
@@ -2,6 +2,7 @@
 :host {
   --va-divider-display: flex;
   --va-divider-color: var(--va-background-border);
+  --va-divider-border-color: var(--va-divider-color);
 
   /* Margin around divider, not the same as CSS margin. Should be one value. */
   --va-divider-margin: 0.5rem;

--- a/packages/ui/src/components/va-divider/_variables.scss
+++ b/packages/ui/src/components/va-divider/_variables.scss
@@ -2,7 +2,6 @@
 :host {
   --va-divider-display: flex;
   --va-divider-color: var(--va-background-border);
-  --va-divider-border-color: var(--va-divider-color);
 
   /* Margin around divider, not the same as CSS margin. Should be one value. */
   --va-divider-margin: 0.5rem;


### PR DESCRIPTION
Close #3153

…ers to specify the color of the divider. The color prop is then bound to the CSS border-color property using Vue's v-bind in CSS feature. This enables users to dynamically change the divider color using the color prop.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail -->

## Markup:
<!-- Paste your markup here. -->
<details>

```vue
// Your code
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
