### PR TITLE
feat(ui): expose aria labels as props

### DIFF
--- a/packages/ui/src/components/va-backtop/VaBacktop.vue
+++ b/packages/ui/src/components/va-backtop/VaBacktop.vue
@@ -3,7 +3,7 @@
     v-if="visible"
     class="va-backtop"
     role="button"
-    :aria-label="t('backToTop')"
+    :aria-label="tp($props.ariaLabel)"
     :style="computedStyle"
     @click="scrollToTop"
     @keydown.enter.stop="scrollToTop"
@@ -49,6 +49,7 @@ export default defineComponent({
       default: 'bottom',
       validator: (value: string) => ['bottom', 'top'].includes(value),
     },
+    ariaLabel: { type: String, default: '$t:backToTop' },
   },
   setup (props) {
     const targetScrollValue = ref(0)

--- a/packages/ui/src/components/va-breadcrumbs/VaBreadcrumbs.vue
+++ b/packages/ui/src/components/va-breadcrumbs/VaBreadcrumbs.vue
@@ -15,6 +15,7 @@ export default defineComponent({
     color: { type: String, default: 'secondary' },
     activeColor: { type: String, default: null },
     separatorColor: { type: String, default: null },
+    ariaLabel: { type: String, default: '$t:breadcrumbs' },
   },
   setup (props, { slots }) {
     const { alignComputed } = useAlign(props)
@@ -114,7 +115,7 @@ export default defineComponent({
       class: 'va-breadcrumbs',
       style: alignComputed.value,
       role: isAllChildLinks.value ? 'navigation' : undefined,
-      'aria-label': isAllChildLinks.value ? t('breadcrumbs') : undefined,
+      'aria-label': (isAllChildLinks.value ? t(props.ariaLabel) : undefined),
     }, getChildren())
   },
 })

--- a/packages/ui/src/components/va-button-dropdown/VaButtonDropdown.vue
+++ b/packages/ui/src/components/va-button-dropdown/VaButtonDropdown.vue
@@ -8,6 +8,7 @@
     >
       <template #anchor>
         <va-button
+          :aria-label="tp($props.ariaLabel)"
           v-bind="{ ...computedButtonIcons, ...buttonPropsComputed }"
           v-on="listeners"
           @keydown.esc.prevent="hideDropdown"
@@ -48,7 +49,7 @@
       >
         <template #anchor>
           <va-button
-            :aria-label="t('toggleDropdown')"
+            :aria-label="$props.ariaLabel || t('toggleDropdown')"
             :disabled="$props.disabled || $props.disableDropdown"
             :icon="computedIcon"
             :icon-color="$props.iconColor"
@@ -140,6 +141,8 @@ export default defineComponent({
 
     loading: { type: Boolean, default: false },
     label: { type: String },
+
+    ariaLabel: { type: String, default: '$t:toggleDropdown' },
   },
 
   setup (props, { emit, slots }) {

--- a/packages/ui/src/components/va-carousel/VaCarousel.vue
+++ b/packages/ui/src/components/va-carousel/VaCarousel.vue
@@ -7,7 +7,7 @@
     }"
     :style="{ height: ratio ? 'auto' : height }"
     role="region"
-    :aria-label="t('carousel')"
+    :aria-label="tp($props.ariaLabel)"
   >
     <template v-if="$props.arrows">
       <div
@@ -21,7 +21,7 @@
             <va-button
               :color="hover ? computedHoverColor : computedColor"
               :icon="vertical ? 'va-arrow-up' : 'va-arrow-left'"
-              :aria-label="t('goPreviousSlide')"
+              :aria-label="tp($props.ariaPreviousLabel)"
             />
           </va-hover>
         </slot>
@@ -37,7 +37,7 @@
             <va-button
               :color="hover ? computedHoverColor : computedColor"
               :icon="vertical ? 'va-arrow-down' : 'va-arrow-right'"
-              :aria-label="t('goNextSlide')"
+              :aria-label="tp($props.ariaNextLabel)"
             />
           </va-hover>
         </slot>
@@ -54,7 +54,7 @@
         <slot name="indicator" v-bind="{ item, index, goTo, isActive: isCurrentSlide(index) }">
           <va-hover #default="{ hover }" stateful>
             <va-button
-              :aria-label="t(`goSlide`, { index: index + 1 })"
+              :aria-label="tp($props.ariaGoToSlideLabel, { index: index + 1 })"
               round
               :color="isCurrentSlide(index) ? computedActiveColor : (hover ? computedHoverColor : computedColor)"
             >
@@ -79,7 +79,7 @@
           :style="slideStyleComputed"
           :aria-hidden="!isCurrentSlide(index)"
           :aria-current="isCurrentSlide(index)"
-          :aria-label="t('slideOf', { index: index + 1, length: slides.length })"
+          :aria-label="tp($props.ariaSlideOfLabel, { index: index + 1, length: slides.length })"
         >
           <slot v-bind="{ item, index, goTo, isActive: isCurrentSlide(index) }">
             <va-image
@@ -154,6 +154,12 @@ export default defineComponent({
     },
     color: { type: String, default: 'primary' },
     ratio: { type: Number },
+
+    ariaLabel: { type: String, default: '$t:carousel' },
+    ariaPreviousLabel: { type: String, default: '$t:goPreviousSlide' },
+    ariaNextLabel: { type: String, default: '$t:goNextSlide' },
+    ariaGoToSlideLabel: { type: String, default: '$t:goSlide' },
+    ariaSlideOfLabel: { type: String, default: '$t:slideOf' },
   },
 
   emits: useStatefulEmits,

--- a/packages/ui/src/components/va-chip/VaChip.vue
+++ b/packages/ui/src/components/va-chip/VaChip.vue
@@ -34,7 +34,7 @@
         role="button"
         name="va-close"
         class="va-chip__close-icon"
-        :aria-label="t('close')"
+        :aria-label="tp($props.ariaCloseLabel)"
         :tabindex="tabIndexComputed"
         :size="iconSize"
         @click.stop="close"
@@ -91,6 +91,8 @@ export default defineComponent({
       default: 'medium',
       validator: (value: string) => ['small', 'medium', 'large'].includes(value),
     },
+
+    ariaCloseLabel: { type: String, default: '$t:close' },
   },
 
   setup (props, { emit }) {

--- a/packages/ui/src/components/va-color-input/VaColorInput.vue
+++ b/packages/ui/src/components/va-color-input/VaColorInput.vue
@@ -11,7 +11,7 @@
         <va-color-indicator
           class="va-color-input__dot"
           role="button"
-          :aria-label="t('openColorPicker')"
+          :aria-label="tp($props.ariaOpenColorPickerLabel)"
           :aria-disabled="$props.disabled"
           :tabindex="tabIndexComputed"
           :color="valueComputed"
@@ -57,6 +57,7 @@ export default defineComponent({
       default: 'dot',
       validator: (value: string) => ['dot', 'square'].includes(value),
     },
+    ariaOpenColorPickerLabel: { type: String, default: '$t:openColorPicker' },
   },
   setup: (props, { emit }) => {
     const colorPicker = shallowRef<HTMLInputElement>()

--- a/packages/ui/src/components/va-color-palette/VaColorPalette.vue
+++ b/packages/ui/src/components/va-color-palette/VaColorPalette.vue
@@ -2,13 +2,13 @@
   <ul
     class="va-color-palette"
     role="listbox"
-    :aria-label="t('colorSelection')"
+    :aria-label="tp($props.ariaLabel)"
   >
     <va-color-indicator
       v-for="(color, index) in palette"
       :key="index"
       role="option"
-      :aria-label="t('color', { color })"
+      :aria-label="tp($props.ariaIndicatorLabel, { color })"
       :aria-selected="isSelected(color)"
       tabindex="0"
       :modelValue="isSelected(color)"
@@ -40,6 +40,8 @@ export default defineComponent({
       default: 'dot',
       validator: (value: string) => ['dot', 'square'].includes(value),
     },
+    ariaLabel: { type: String, default: '$t:colorSelection' },
+    ariaIndicatorLabel: { type: String, default: '$t:color' },
   },
   setup (props, { emit }) {
     const { valueComputed } = useStateful(props, emit)

--- a/packages/ui/src/components/va-counter/VaCounter.vue
+++ b/packages/ui/src/components/va-counter/VaCounter.vue
@@ -16,7 +16,7 @@
         <slot name="decreaseAction" v-bind="{ ...slotScope, decreaseCount }">
           <va-button
             class="va-counter__button-decrease"
-            :aria-label="t('decreaseCounter')"
+            :aria-label="tp($props.ariaDecreaseLabel)"
             v-bind="decreaseButtonProps"
             @click="decreaseCount"
           />
@@ -40,7 +40,7 @@
         <slot name="increaseAction" v-bind="{ ...slotScope, increaseCount }">
           <va-button
             class="va-counter__button-increase"
-            :aria-label="t('increaseCounter')"
+            :aria-label="tp($props.ariaIncreaseLabel)"
             v-bind="increaseButtonProps"
             @click="increaseCount"
           />
@@ -135,7 +135,7 @@ export default defineComponent({
     min: { type: Number, default: undefined },
     max: { type: Number, default: undefined },
     step: { type: Number, default: 1 },
-    label: { type: String, default: '' },
+    label: { type: String, default: '$t:counterValue' },
     // hint
     messages: { type: [Array, String] as PropType<string[] | string>, default: () => [] },
     // style
@@ -151,6 +151,9 @@ export default defineComponent({
     rounded: { type: Boolean, default: false },
     margins: { type: [String, Number], default: '4px' },
     textColor: { type: String, default: undefined },
+
+    ariaDecreaseLabel: { type: String, default: '$t:decreaseCounter' },
+    ariaIncreaseLabel: { type: String, default: '$t:increaseCounter' },
   },
 
   emits: [
@@ -288,11 +291,11 @@ export default defineComponent({
       disabled: isIncreaseActionDisabled.value,
     }))
 
-    const { t } = useTranslation()
+    const { tp } = useTranslation()
 
     const inputAttributesComputed = computed(() => ({
       tabindex: tabIndexComputed.value,
-      'aria-label': props.label || t('counterValue'),
+      'aria-label': tp(props.label),
       'aria-valuemin': min.value,
       'aria-valuemax': max.value,
       ...omit(attrs, ['class', 'style']),
@@ -319,7 +322,7 @@ export default defineComponent({
     useCounterPropsValidation(props)
 
     return {
-      ...useTranslation(),
+      tp,
       input,
       valueComputed,
       isFocused,

--- a/packages/ui/src/components/va-data-table/VaDataTable.vue
+++ b/packages/ui/src/components/va-data-table/VaDataTable.vue
@@ -111,7 +111,7 @@
                       class="va-data-table__table-cell-checkbox"
                       :model-value="isRowSelected(row)"
                       :color="selectedColor"
-                      :aria-label="t(`selectRowByIndex`, { index: row.initialIndex })"
+                      :aria-label="tp($props.ariaSelectRowLabel, { index: row.initialIndex })"
                       @click.shift.exact.stop="shiftSelectRows(row)"
                       @click.ctrl.exact.stop="ctrlSelectRow(row)"
                       @click.exact.stop="ctrlSelectRow(row)"
@@ -257,6 +257,7 @@ export default defineComponent({
     ...useRowsProps,
     ...useSelectableProps,
     ...useThrottleProps,
+    ...pick(VaDataTableThRowProps, ['ariaSelectAllRowsLabel', 'ariaSortColumnByLabel']),
     hoverable: { type: Boolean, default: false },
     clickable: { type: Boolean, default: false },
     loading: { type: Boolean, default: false },
@@ -271,6 +272,8 @@ export default defineComponent({
     grid: { type: Boolean, default: false },
     gridColumns: { type: Number, default: 0 },
     wrapperSize: { type: [Number, String] as PropType<number | string | 'auto'>, default: 'auto' },
+
+    ariaSelectRowLabel: { type: String, default: '$t:selectRowByIndex' },
   },
 
   emits: [

--- a/packages/ui/src/components/va-data-table/components/VaDataTableThRow.vue
+++ b/packages/ui/src/components/va-data-table/components/VaDataTableThRow.vue
@@ -9,7 +9,7 @@
         v-if="multiplySelectAvailable"
         class="va-data-table__table-cell-checkbox"
         :model-value="$props.severalRowsSelected ? 'idl' : $props.allRowsSelected"
-        :aria-label="t('selectAllRows')"
+        :aria-label="tp($props.ariaSelectAllRowsLabel)"
         :true-value="true"
         :false-value="false"
         :color="$props.selectedColor"
@@ -98,6 +98,9 @@ export default defineComponent({
     sortBySync: { type: String, required: true },
     sortingOrderIconName: { type: String as PropType<TSortIcon>, required: true },
     sortingOrderSync: { type: String as PropType<DataTableSortingOrder | null>, default: null },
+
+    ariaSelectAllRowsLabel: { type: String, default: '$t:selectAllRows' },
+    ariaSortColumnByLabel: { type: String, default: '$t:sortColumnBy' },
   },
 
   emits: [
@@ -106,7 +109,7 @@ export default defineComponent({
   ],
 
   setup (props, { emit }) {
-    const { t } = useTranslation()
+    const { t, tp } = useTranslation()
 
     const {
       getFooterCSSVariables,
@@ -120,7 +123,7 @@ export default defineComponent({
         ? props.sortingOrderSync === 'asc' ? 'ascending' : 'descending'
         : 'none') as 'none' | 'ascending' | 'descending'
 
-      const ariaLabel = column.sortable ? t('sortColumnBy', { name: column.label }) : undefined
+      const ariaLabel = column.sortable ? tp(props.ariaSortColumnByLabel, { name: column.label }) : undefined
 
       return {
         'aria-sort': ariaSort,
@@ -145,7 +148,7 @@ export default defineComponent({
     const multiplySelectAvailable = computed(() => props.selectMode === 'multiple')
 
     return {
-      t,
+      tp,
       getClass,
       sortByColumn,
       getColumnStyles,

--- a/packages/ui/src/components/va-date-input/VaDateInput.vue
+++ b/packages/ui/src/components/va-date-input/VaDateInput.vue
@@ -38,7 +38,7 @@
             <slot name="prependInner" v-bind="slotScope" />
             <va-icon
               v-if="$props.leftIcon"
-              :aria-label="t('toggleDropdown')"
+              :aria-label="tp($props.ariaToggleDropdownLabel)"
               v-bind="iconProps"
               @click.stop="showDropdown"
               @keydown.enter.stop="showDropdown"
@@ -49,7 +49,7 @@
           <template #icon>
             <va-icon
               v-if="canBeCleared"
-              :aria-label="t('resetDate')"
+              :aria-label="tp($props.ariaResetLabel)"
               v-bind="{ ...iconProps, ...clearIconProps }"
               @click.stop="reset"
               @keydown.enter.stop="reset"
@@ -57,7 +57,7 @@
             />
             <va-icon
               v-else-if="!$props.leftIcon && $props.icon"
-              :aria-label="t('toggleDropdown')"
+              :aria-label="tp($props.ariaToggleDropdownLabel)"
               v-bind="iconProps"
               @click.stop="showDropdown"
               @keydown.enter.stop="showDropdown"
@@ -175,6 +175,10 @@ export default defineComponent({
     color: { type: String, default: 'primary' },
     leftIcon: { type: Boolean, default: false },
     icon: { type: String, default: 'va-calendar' },
+
+    ariaToggleDropdownLabel: { type: String, default: '$t:toggleDropdown' },
+    ariaResetLabel: { type: String, default: '$t:resetDate' },
+    ariaSelectedDateLabel: { type: String, default: '$t:selectedDate' },
   },
 
   emits: [
@@ -376,14 +380,14 @@ export default defineComponent({
       },
     }))
 
-    const { t } = useTranslation()
+    const { tp } = useTranslation()
 
     const inputAttributesComputed = computed(() => ({
       readonly: props.readonly || !props.manualInput,
       disabled: props.disabled,
       tabindex: props.disabled ? -1 : 0,
       value: valueText.value,
-      ariaLabel: props.label || t('selectedDate'),
+      ariaLabel: props.label || tp('selectedDate'),
       ariaRequired: props.requiredMark,
       ariaDisabled: props.disabled,
       ariaReadOnly: props.readonly,
@@ -401,7 +405,7 @@ export default defineComponent({
     }))
 
     return {
-      t,
+      tp,
       datePicker,
       valueText,
       valueWithoutText,

--- a/packages/ui/src/components/va-date-picker/components/VaDatePickerHeader/VaDatePickerHeader.vue
+++ b/packages/ui/src/components/va-date-picker/components/VaDatePickerHeader/VaDatePickerHeader.vue
@@ -12,7 +12,7 @@
         size="small"
         :color="color"
         :textColor="textColor"
-        :aria-label="t('nextPeriod')"
+        :aria-label="tp($props.ariaPreviousPeriodLabel)"
         round
         @click="prev"
       />
@@ -26,7 +26,7 @@
           size="small"
           :color="color"
           :textColor="textColor"
-          :aria-label="t('switchView')"
+          :aria-label="tp($props.ariaSwitchViewLabel)"
           @click="switchView"
         >
           <slot name="year" v-bind="{ year: syncView.year }">{{ syncView.year }}</slot>
@@ -46,7 +46,7 @@
         size="small"
         :color="color"
         :textColor="textColor"
-        :aria-label="t('previousPeriod')"
+        :aria-label="tp($props.ariaNextPeriodLabel)"
         @click="next"
         round
       />
@@ -74,6 +74,10 @@ export default defineComponent({
     color: { type: String },
     textColor: { type: String },
     disabled: { type: Boolean, default: false },
+
+    ariaNextPeriodLabel: { type: String, default: '$t:nextPeriod' },
+    ariaPreviousPeriodLabel: { type: String, default: '$t:previousPeriod' },
+    ariaSwitchViewLabel: { type: String, default: '$t:switchView' },
   },
 
   setup (props, { emit }) {

--- a/packages/ui/src/components/va-dropdown/VaDropdown.vue
+++ b/packages/ui/src/components/va-dropdown/VaDropdown.vue
@@ -74,6 +74,8 @@ export default defineComponent({
     },
     /** Not reactive */
     keyboardNavigation: { type: Boolean, default: false },
+
+    ariaLabel: { type: String, default: '$t:toggleDropdown' },
   },
 
   emits: [...useStatefulEmits, 'anchor-click', 'anchor-right-click', 'content-click', 'click-outside', 'close', 'open'],
@@ -224,11 +226,10 @@ export default defineComponent({
       props,
     )
 
-    const { t } = useTranslation()
     const isMounted = useIsMounted()
 
     return {
-      t,
+      ...useTranslation(),
       isMounted,
       valueComputed,
       computedAnchorRef,
@@ -262,7 +263,7 @@ export default defineComponent({
       role: 'button',
       class: ['va-dropdown', ...this.computedClass.asArray.value],
       style: { position: 'relative' },
-      'aria-label': this.t('toggleDropdown'),
+      'aria-label': this.tp(this.$props.ariaLabel),
       'aria-disabled': this.$props.disabled,
       'aria-expanded': !!this.valueComputed.value,
       ...this.$attrs,

--- a/packages/ui/src/components/va-file-upload/VaFileUpload.vue
+++ b/packages/ui/src/components/va-file-upload/VaFileUpload.vue
@@ -41,6 +41,7 @@
     >
     <va-file-upload-list
       v-if="files.length && !$props.hideFileList"
+      v-bind="fileUploadListProps"
       :type="type"
       :files="files"
       :color="colorComputed"
@@ -65,6 +66,9 @@ import { VaFileUploadKey, VaFile } from './types'
 
 import { VaButton, VaModal } from '../index'
 import { VaFileUploadList } from './VaFileUploadList'
+import { extractComponentProps, filterComponentProps } from '../../utils/component-options'
+
+const VaFileUploadListProps = extractComponentProps(VaFileUploadList)
 
 export default defineComponent({
   name: 'VaFileUpload',
@@ -77,6 +81,7 @@ export default defineComponent({
 
   props: {
     ...useComponentPresetProp,
+    ...VaFileUploadListProps,
     fileTypes: { type: String, default: '' },
     dropzone: { type: Boolean, default: false },
     hideFileList: { type: Boolean, default: false },
@@ -212,6 +217,7 @@ export default defineComponent({
     })
 
     return {
+      fileUploadListProps: filterComponentProps(VaFileUploadListProps),
       modal,
       dropzoneHighlight,
       fileInputRef,

--- a/packages/ui/src/components/va-file-upload/VaFileUploadGalleryItem/VaFileUploadGalleryItem.vue
+++ b/packages/ui/src/components/va-file-upload/VaFileUploadGalleryItem/VaFileUploadGalleryItem.vue
@@ -37,7 +37,7 @@
           color="danger"
           icon="va-delete"
           class="va-file-upload-gallery-item__delete"
-          :aria-label="t('removeFile')"
+          :aria-label="tp($props.ariaRemoveFileLabel)"
           @click="removeImage"
           @focus="onFocus"
           @blur="onBlur"
@@ -76,6 +76,8 @@ export default defineComponent({
   props: {
     file: { type: Object as PropType<ConvertedFile>, default: null },
     color: { type: String, default: 'success' },
+
+    ariaRemoveFileLabel: { type: String, default: '$t:removeFile' },
   },
 
   setup (props, { emit }) {

--- a/packages/ui/src/components/va-file-upload/VaFileUploadList/VaFileUploadList.vue
+++ b/packages/ui/src/components/va-file-upload/VaFileUploadList/VaFileUploadList.vue
@@ -8,8 +8,8 @@
       <va-file-upload-list-item
         v-for="(file, index) in filesList"
         :key="file.name"
+        v-bind="itemProps"
         :file="file"
-        :color="color"
         role="listitem"
         @remove="$emit('remove', index)"
       />
@@ -17,15 +17,16 @@
     <template v-if="type === 'gallery'">
       <va-file-upload-gallery-item
         v-for="(file, index) in filesList"
+        v-bind="galleryItemProps"
         :key="file.name"
         :file="file"
-        :color="color"
         role="listitem"
         @remove="$emit('remove', index)"
       />
     </template>
     <template v-if="type === 'single' && filesList.length">
       <va-file-upload-single-item
+        v-bind="singleItemProps"
         :file="filesList[filesList.length - 1]"
         @remove="$emit('removeSingle')"
       />
@@ -43,6 +44,12 @@ import { VaFileUploadSingleItem } from '../VaFileUploadSingleItem'
 
 import type { VaFile, ConvertedFile } from '../types'
 
+import { extractComponentProps, filterComponentProps } from '../../../utils/component-options'
+
+const VaFileUploadGalleryItemProps = extractComponentProps(VaFileUploadGalleryItem)
+const VaFileUploadListItemProps = extractComponentProps(VaFileUploadListItem)
+const VaFileUploadSingleItemProps = extractComponentProps(VaFileUploadSingleItem)
+
 export default defineComponent({
   name: 'VaFileUploadList',
   components: {
@@ -55,7 +62,9 @@ export default defineComponent({
   props: {
     type: { type: String, default: '' },
     files: { type: Array as PropType<VaFile[]>, default: null },
-    color: { type: String, default: 'success' },
+    ...VaFileUploadGalleryItemProps,
+    ...VaFileUploadListItemProps,
+    ...VaFileUploadSingleItemProps,
   },
   setup (props) {
     const filesList = computed(() => props.files.map(convertFile))
@@ -89,6 +98,9 @@ export default defineComponent({
     }
 
     return {
+      galleryItemProps: filterComponentProps(VaFileUploadGalleryItemProps),
+      itemProps: filterComponentProps(VaFileUploadListItemProps),
+      singleItemProps: filterComponentProps(VaFileUploadSingleItemProps),
       filesList,
     }
   },

--- a/packages/ui/src/components/va-file-upload/VaFileUploadListItem/VaFileUploadListItem.vue
+++ b/packages/ui/src/components/va-file-upload/VaFileUploadListItem/VaFileUploadListItem.vue
@@ -23,7 +23,7 @@
           color="danger"
           icon="clear"
           class="va-file-upload-list-item__delete"
-          :aria-label="t('removeFile')"
+          :aria-label="tp($props.ariaRemoveFileLabel)"
           @click.stop="removeFile"
           @keydown.enter.stop="removeFile"
           @keydown.space.stop="removeFile"
@@ -62,6 +62,8 @@ export default defineComponent({
   props: {
     file: { type: Object as PropType<ConvertedFile | null>, default: null },
     color: { type: String, default: 'success' },
+
+    ariaRemoveFileLabel: { type: String, default: '$t:removeFile' },
   },
 
   setup (props, { emit }) {

--- a/packages/ui/src/components/va-file-upload/VaFileUploadSingleItem/VaFileUploadSingleItem.vue
+++ b/packages/ui/src/components/va-file-upload/VaFileUploadSingleItem/VaFileUploadSingleItem.vue
@@ -12,7 +12,7 @@
       <va-button
         v-if="!disabled"
         class="va-file-upload-single-item__button"
-        :aria-label="t('removeFile')"
+        :aria-label="tp($props.ariaRemoveFileLabel)"
         size="small"
         color="danger"
         flat
@@ -46,6 +46,7 @@ export default defineComponent({
 
   props: {
     file: { type: Object as PropType<ConvertedFile | null>, default: null },
+    ariaRemoveFileLabel: { type: String, default: '$t:removeFile' },
   },
 
   setup: () => ({

--- a/packages/ui/src/components/va-input/VaInput.vue
+++ b/packages/ui/src/components/va-input/VaInput.vue
@@ -35,7 +35,7 @@
       <va-icon
         v-if="canBeCleared"
         role="button"
-        :aria-label="t('reset')"
+        :aria-label="tp($props.ariaResetLabel)"
         :tabindex="tabIndexComputed"
         v-bind="clearIconProps"
         @click.stop="reset"
@@ -142,6 +142,7 @@ export default defineComponent({
     outline: { type: Boolean, default: false },
     bordered: { type: Boolean, default: false },
     requiredMark: { type: Boolean, default: false },
+    ariaResetLabel: { type: String, default: '$t:reset' },
   },
 
   emits: [

--- a/packages/ui/src/components/va-modal/VaModal.vue
+++ b/packages/ui/src/components/va-modal/VaModal.vue
@@ -44,7 +44,7 @@
                 name="va-close"
                 class="va-modal__close"
                 role="button"
-                :aria-label="t('close')"
+                :aria-label="tp($props.ariaCloseLabel)"
                 tabindex="0"
                 @click="cancel"
                 @keydown.space="cancel"
@@ -200,6 +200,7 @@ export default defineComponent({
     backgroundColor: { type: String, default: 'background-secondary' },
     noPadding: { type: Boolean, default: false },
     beforeClose: { type: Function as PropType<(hide: () => void) => any> },
+    ariaCloseLabel: { type: String, default: '$t:close' },
   },
   setup (props, { emit }) {
     const rootElement = shallowRef<HTMLElement>()

--- a/packages/ui/src/components/va-pagination/VaPagination.vue
+++ b/packages/ui/src/components/va-pagination/VaPagination.vue
@@ -2,7 +2,7 @@
   <nav
     v-if="showPagination"
     class="va-pagination"
-    :aria-label="t('pagination')"
+    :aria-label="tp($props.ariaLabel)"
     :class="classComputed"
     @keydown.left.stop="goPrevPage"
     @keydown.right.stop="goNextPage"
@@ -15,7 +15,7 @@
     >
       <va-button
         v-if="showBoundaryLinks"
-        :aria-label="t('goToTheFirstPage')"
+        :aria-label="tp($props.ariaGoToTheFirstPageLabel)"
         :disabled="$props.disabled || currentValue === 1"
         :icon="$props.boundaryIconLeft"
         v-bind="buttonPropsComputed"
@@ -28,7 +28,7 @@
     >
       <va-button
         v-if="showDirectionLinks"
-        :aria-label="t('goToPreviousPage')"
+        :aria-label="tp($props.ariaGoToPreviousPageLabel)"
         :disabled="$props.disabled || currentValue === 1"
         :icon="$props.directionIconLeft"
         v-bind="buttonPropsComputed"
@@ -41,7 +41,7 @@
         v-for="(n, i) in paginationRange" :key="i"
         :ref="setItemRefByIndex(i)"
         :class="{ 'va-button--ellipsis': n === '...', 'va-button--current': n === currentValue}"
-        :aria-label="t(`goToSpecificPage`, { page: n })"
+        :aria-label="tp($props.ariaGoToSpecificPageLabel, { page: n })"
         :aria-current="n === currentValue"
         :disabled="$props.disabled || n === '...'"
         v-bind="getPageButtonProps(n)"
@@ -55,7 +55,7 @@
       v-model="inputValue"
       ref="htmlInput"
       class="va-pagination__input va-button"
-      :aria-label="t('goToSpecificPageInput')"
+      :aria-label="tp($props.ariaGoToSpecificPageInputLabel)"
       :style="inputStyleComputed"
       :class="inputClassComputed"
       v-bind="inputAttributesComputed"
@@ -70,7 +70,7 @@
     >
       <va-button
         v-if="showDirectionLinks"
-        :aria-label="t('goNextPage')"
+        :aria-label="tp($props.ariaGoNextPageLabel)"
         :disabled="$props.disabled || currentValue === lastPage"
         :icon="$props.directionIconRight"
         v-bind="buttonPropsComputed"
@@ -83,7 +83,7 @@
     >
       <va-button
         v-if="showBoundaryLinks"
-        :aria-label="t('goLastPage')"
+        :aria-label="tp($props.ariaGoLastPageLabel)"
         :disabled="$props.disabled || currentValue === lastPage"
         :icon="$props.boundaryIconRight"
         v-bind="buttonPropsComputed"
@@ -154,6 +154,14 @@ export default defineComponent({
     rounded: { type: Boolean, default: false },
     activePageColor: { type: String, default: '' },
     buttonsPreset: { type: String, default: 'primary' },
+
+    ariaLabel: { type: String, default: '$t:pagination' },
+    ariaGoToTheFirstPageLabel: { type: String, default: '$t:goToTheFirstPage' },
+    ariaGoToPreviousPageLabel: { type: String, default: '$t:goToPreviousPage' },
+    ariaGoToSpecificPageLabel: { type: String, default: '$t:goToSpecificPage' },
+    ariaGoToSpecificPageInputLabel: { type: String, default: '$t:goToSpecificPageInput' },
+    ariaGoNextPageLabel: { type: String, default: '$t:goNextPage' },
+    ariaGoLastPageLabel: { type: String, default: '$t:goLastPage' },
   },
 
   setup (props, { emit }) {

--- a/packages/ui/src/components/va-progress-bar/VaProgressBar.vue
+++ b/packages/ui/src/components/va-progress-bar/VaProgressBar.vue
@@ -65,6 +65,7 @@ export default defineComponent({
     contentInside: { type: Boolean, default: false },
     showPercent: { type: Boolean, default: false },
     max: { type: Number, default: 100 },
+    ariaLabel: { type: String, default: '$t:progressState' },
   },
 
   setup (props) {
@@ -81,7 +82,7 @@ export default defineComponent({
       return props.size
     }
 
-    const { t } = useTranslation()
+    const { tp } = useTranslation()
 
     const progressBarValue = computed(() => 100 / props.max * props.modelValue)
 
@@ -117,7 +118,7 @@ export default defineComponent({
 
       ariaAttributesComputed: computed(() => ({
         role: 'progressbar',
-        'aria-label': t('progressState'),
+        'aria-label': tp(props.ariaLabel),
         'aria-valuenow': !props.indeterminate ? props.modelValue : undefined,
       })),
     }

--- a/packages/ui/src/components/va-progress-circle/VaProgressCircle.vue
+++ b/packages/ui/src/components/va-progress-circle/VaProgressCircle.vue
@@ -47,6 +47,7 @@ export default defineComponent({
     indeterminate: { type: Boolean, default: false },
     thickness: { type: Number, default: 0.06 },
     color: { type: String, default: 'primary' },
+    ariaLabel: { type: String, default: '$t:progressState' },
   },
 
   setup (props) {
@@ -60,7 +61,7 @@ export default defineComponent({
     const dashoffset = computed(() => dasharray.value * (1 - clamp(props.modelValue, 0, 100) / 100))
     const colorComputed = computed(() => getColor(props.color, undefined, true))
 
-    const { t } = useTranslation()
+    const { tp } = useTranslation()
 
     return {
       infoStyle: computed(() => ({ color: colorComputed.value })),
@@ -73,7 +74,7 @@ export default defineComponent({
       })),
       ariaAttributesComputed: computed(() => ({
         role: 'progressbar',
-        'aria-label': t('progressState'),
+        'aria-label': tp(props.ariaLabel),
         'aria-valuenow': !props.indeterminate ? props.modelValue : undefined,
       })),
 

--- a/packages/ui/src/components/va-rating/VaRating.vue
+++ b/packages/ui/src/components/va-rating/VaRating.vue
@@ -2,7 +2,7 @@
   <div
     class="va-rating"
     :class="rootClass"
-    :aria-label="t('currentRating', { max: $props.max, value: $props.modelValue })"
+    :aria-label="tp($props.ariaLabel, { max: $props.max, value: $props.modelValue })"
   >
     <div
       class="va-rating__item-wrapper"
@@ -16,7 +16,7 @@
         :key="itemNumber"
         class="va-rating__item"
         v-bind="VaRatingItemProps"
-        :aria-label="t('voteRating', { max: $props.max, value: $props.modelValue })"
+        :aria-label="tp($props.ariaItemLabel, { max: $props.max, value: $props.modelValue })"
         :model-value="getItemValue(itemNumber - 1)"
         :tabindex="tabIndexComputed"
         :disabled="$props.disabled"
@@ -76,6 +76,9 @@ export default defineComponent({
     halves: { type: Boolean, default: false },
     max: { type: Number, default: 5 },
     texts: { type: Array as PropType<string[]>, default: () => [] },
+
+    ariaLabel: { type: String, default: '$t:currentRating' },
+    ariaItemLabel: { type: String, default: '$t:voteRating' },
   },
   emits: ['update:modelValue'],
   components: { VaRatingItem, VaRatingItemNumberButton },

--- a/packages/ui/src/components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/va-select/VaSelect.vue
@@ -28,7 +28,7 @@
           <va-icon
             v-if="showClearIcon"
             role="button"
-            :aria-label="t('reset')"
+            :aria-label="tp($props.ariaResetLabel)"
             tabindex="0"
             v-bind="clearIconProps"
             @click.stop="reset"
@@ -77,7 +77,7 @@
         ref="searchBar"
         class="va-select-dropdown__content-search-input"
         v-model="searchInput"
-        :aria-label="t('optionsFilter')"
+        :aria-label="tp($props.ariaSearchLabel)"
         :tabindex="tabIndexComputed"
         :placeholder="tp($props.searchPlaceholderText)"
         bordered
@@ -229,6 +229,10 @@ export default defineComponent({
     placeholder: { type: String, default: '' },
     searchPlaceholderText: { type: String, default: '$t:search' },
     requiredMark: { type: Boolean, default: false },
+
+    ariaLabel: { type: String, default: undefined },
+    ariaSearchLabel: { type: String, default: '$t:optionsFilter' },
+    ariaResetLabel: { type: String, default: '$t:reset' },
   },
 
   setup (props, { emit, slots }) {
@@ -575,7 +579,7 @@ export default defineComponent({
       keepAnchorWidth: true,
       keyboardNavigation: true,
       innerAnchorSelector: '.va-input-wrapper__field',
-      'aria-label': props.modelValue ? `${t('selectedOption')}: ${props.modelValue}` : t('noSelectedOption'),
+      'aria-label': props.ariaLabel || (props.modelValue ? `${t('selectedOption')}: ${props.modelValue}` : t('noSelectedOption')),
     }))
 
     const optionsListPropsComputed = computed(() => ({

--- a/packages/ui/src/components/va-skeleton/VaSkeleton.vue
+++ b/packages/ui/src/components/va-skeleton/VaSkeleton.vue
@@ -3,7 +3,7 @@
     class="va-skeleton"
     role="status"
     aria-live="polite"
-    aria-label="Loading"
+    :aria-label="tp($props.ariaLabel)"
     aria-atomic="true"
     :class="classes"
     :is="tag"
@@ -15,7 +15,7 @@
 
 <script lang="ts">
 import { defineComponent, onMounted, ref, computed, PropType, onBeforeUnmount } from 'vue'
-import { useBem, useColors } from '../../composables'
+import { useBem, useColors, useTranslation } from '../../composables'
 
 export default defineComponent({
   name: 'VaSkeleton',
@@ -35,6 +35,7 @@ export default defineComponent({
     lastLineWidth: { type: [String], default: '75%' },
 
     variant: { type: String as PropType<'text' | 'circle' | 'rounded' | 'squared'>, default: 'squared' },
+    ariaLabel: { type: String, default: '$t:loading' },
   },
 
   setup (props, { attrs }) {
@@ -87,6 +88,7 @@ export default defineComponent({
     })
 
     return {
+      ...useTranslation(),
       classes: computed(() => [
         ...Object.keys(bem),
         (attrs as { class: string }).class,

--- a/packages/ui/src/components/va-slider/VaSlider.vue
+++ b/packages/ui/src/components/va-slider/VaSlider.vue
@@ -163,7 +163,7 @@ import { defineComponent, watch, PropType, ref, computed, onMounted, onBeforeUnm
 import pick from 'lodash/pick.js'
 
 import { generateUniqueId } from '../../utils/uuid'
-import { useComponentPresetProp, useColors, useArrayRefs, useBem } from '../../composables'
+import { useComponentPresetProp, useColors, useArrayRefs, useBem, useTranslation } from '../../composables'
 import { validateSlider } from './validateSlider'
 
 import { VaIcon } from '../va-icon'
@@ -193,6 +193,7 @@ export default defineComponent({
     iconAppend: { type: String, default: '' },
     vertical: { type: Boolean, default: false },
     showTrack: { type: Boolean, default: true },
+    ariaLabel: { type: String, default: '$t:sliderValue' },
   },
   setup (props, { emit, slots }) {
     const { getColor, getHoverColor } = useColors()
@@ -689,11 +690,13 @@ export default defineComponent({
 
     const ariaLabelIdComputed = computed(() => `aria-label-id-${generateUniqueId()}`)
 
+    const { tp } = useTranslation()
+
     const ariaAttributesComputed = computed(() => ({
       role: 'slider',
       'aria-valuemin': props.min,
       'aria-valuemax': props.max,
-      'aria-label': !slots.label && !props.label ? `current slider value is ${String(props.modelValue)}` : undefined,
+      'aria-label': !slots.label && !props.label ? tp(props.ariaLabel, { value: String(props.modelValue) }) : undefined,
       'aria-labelledby': slots.label || props.label ? ariaLabelIdComputed.value : undefined,
       'aria-orientation': props.vertical ? 'vertical' as const : 'horizontal' as const,
       'aria-disabled': props.disabled,

--- a/packages/ui/src/components/va-split/VaSplit.vue
+++ b/packages/ui/src/components/va-split/VaSplit.vue
@@ -3,7 +3,7 @@
     ref="splitPanelsContainer"
     class="va-split"
     :class="classComputed"
-    :aria-label="t('splitPanels')"
+    :aria-label="tp($props.ariaLabel)"
   >
     <div
       class="va-split__panel"
@@ -84,6 +84,8 @@ export default defineComponent({
       default: undefined,
     },
     snappingRange: { type: [Number, String] as PropType<number | string>, default: 4 },
+
+    ariaLabel: { type: String, default: '$t:splitPanels' },
   },
 
   emits: useStatefulEmits,

--- a/packages/ui/src/components/va-stepper/VaStepper.vue
+++ b/packages/ui/src/components/va-stepper/VaStepper.vue
@@ -88,7 +88,7 @@
   </div>
 </template>
 <script lang="ts">
-import { computed, defineComponent, nextTick, PropType, ref, Ref, shallowRef, watch } from 'vue'
+import { computed, defineComponent, PropType, ref, Ref, shallowRef, watch } from 'vue'
 import { useColors, useStateful, useStatefulProps, useTranslation } from '../../composables'
 import type { Step, StepControls } from './types'
 import VaStepperControls from './VaStepperControls.vue'
@@ -111,6 +111,7 @@ export default defineComponent({
     controlsHidden: { type: Boolean, default: false },
     nextDisabled: { type: Boolean, default: false },
     finishButtonHidden: { type: Boolean, default: false },
+    ariaLabel: { type: String, default: '$t:progress' },
   },
   emits: ['update:modelValue', 'finish'],
   setup (props, { emit }) {
@@ -123,8 +124,6 @@ export default defineComponent({
     const stepperColor = getColor(props.color)
 
     const isNextStepDisabled = (index: number) => props.nextDisabled && index > modelValue.value
-
-    const { t } = useTranslation()
 
     const setStep = (index: number) => {
       if (props.steps[index].disabled) { return }
@@ -209,6 +208,8 @@ export default defineComponent({
       isCompleted: props.modelValue > index,
     })
 
+    const { tp } = useTranslation()
+
     return {
       stepperNavigation,
       resetFocus,
@@ -227,7 +228,7 @@ export default defineComponent({
       },
       ariaAttributesComputed: computed(() => ({
         role: 'group',
-        'aria-label': t('progress'),
+        'aria-label': tp(props.ariaLabel),
         'aria-orientation': props.vertical ? 'vertical' as const : 'horizontal' as const,
       })),
     }

--- a/packages/ui/src/components/va-switch/VaSwitch.vue
+++ b/packages/ui/src/components/va-switch/VaSwitch.vue
@@ -116,7 +116,7 @@ export default defineComponent({
     falseLabel: { type: String, default: null },
     trueInnerLabel: { type: String, default: null },
     falseInnerLabel: { type: String, default: null },
-    ariaLabel: { type: String, default: 'Switch' },
+    ariaLabel: { type: String, default: '$t:switch' },
     color: { type: String, default: 'primary' },
     offColor: { type: String, default: 'background-element' },
     size: {

--- a/packages/ui/src/components/va-tabs/VaTabs.vue
+++ b/packages/ui/src/components/va-tabs/VaTabs.vue
@@ -12,7 +12,7 @@
       <va-button
         v-if="showPagination && !$props.hidePagination"
         class="va-tabs__pagination"
-        :aria-label="t('movePaginationLeft')"
+        :aria-label="tp($props.ariaMoveLeftLabel)"
         size="medium"
         :disabled="disablePaginationLeft"
         :color="color"
@@ -48,7 +48,7 @@
       <va-button
         v-if="showPagination && !$props.hidePagination"
         class="va-tabs__pagination"
-        :aria-label="t('movePaginationRight')"
+        :aria-label="tp($props.ariaMoveRightLabel)"
         size="medium"
         :color="color"
         :disabled="disablePaginationRight"
@@ -113,6 +113,8 @@ export default defineComponent({
     color: { type: String, default: 'primary' },
     prevIcon: { type: String, default: 'va-arrow-left' },
     nextIcon: { type: String, default: 'va-arrow-right' },
+    ariaMoveRightLabel: { type: String, default: '$t:movePaginationLeft' },
+    ariaMoveLeftLabel: { type: String, default: '$t:movePaginationRight' },
   },
 
   setup: (props, { emit }) => {

--- a/packages/ui/src/components/va-time-input/VaTimeInput.vue
+++ b/packages/ui/src/components/va-time-input/VaTimeInput.vue
@@ -41,7 +41,7 @@
           />
           <va-icon
             v-if="$props.leftIcon"
-            :aria-label="t('toggleDropdown')"
+            :aria-label="tp($props.ariaToggleDropdownLabel)"
             v-bind="iconProps"
             @click.stop="showDropdown"
             @keydown.enter.stop="showDropdown"
@@ -53,14 +53,14 @@
           <va-icon
             v-if="canBeClearedComputed"
             v-bind="{ ...iconProps, ...clearIconProps }"
-            :aria-label="t('resetTime')"
+            :aria-label="tp($props.ariaResetLabel)"
             @click.stop="reset"
             @keydown.enter.stop="reset"
             @keydown.space.stop="reset"
           />
           <va-icon
             v-else-if="!$props.leftIcon && $props.icon"
-            :aria-label="t('toggleDropdown')"
+            :aria-label="tp($props.ariaToggleDropdownLabel)"
             @click.stop="showDropdown"
             @keydown.enter.stop="showDropdown"
             @keydown.space.stop="showDropdown"
@@ -141,6 +141,10 @@ export default defineComponent({
     manualInput: { type: Boolean, default: false },
     leftIcon: { type: Boolean, default: false },
     icon: { type: String, default: 'schedule' },
+
+    ariaLabel: { type: String, default: '$t:selectedTime' },
+    ariaResetLabel: { type: String, default: '$t:resetTime' },
+    ariaToggleDropdownLabel: { type: String, default: '$t:toggleDropdown' },
   },
 
   inheritAttrs: false,
@@ -149,7 +153,7 @@ export default defineComponent({
     const input = shallowRef<HTMLInputElement>()
     const timePicker = shallowRef<typeof VaTimePicker>()
 
-    const [isOpenSync] = useSyncProp('isOpen', props, emit, false)
+    const [isOpenSync] = useSyncProp('isOpen', props, emit, false as boolean)
     const [modelValueSync] = useSyncProp('modelValue', props, emit)
 
     const { parse, isValid } = useTimeParser(props)
@@ -311,14 +315,14 @@ export default defineComponent({
       tabindex: iconTabindexComputed.value,
     }))
 
-    const { t } = useTranslation()
+    const { tp } = useTranslation()
 
     const inputAttributesComputed = computed(() => ({
       readonly: props.readonly || !props.manualInput,
       disabled: props.disabled,
       tabindex: props.disabled ? -1 : 0,
       value: valueText.value,
-      'aria-label': props.label || t('selectedTime'),
+      'aria-label': props.label || tp(props.ariaLabel),
       'aria-required': props.requiredMark,
       'aria-disabled': props.disabled,
       'aria-readonly': props.readonly,
@@ -336,7 +340,7 @@ export default defineComponent({
     }))
 
     return {
-      t,
+      tp,
       input,
       timePicker,
 

--- a/packages/ui/src/components/va-toast/VaToast.vue
+++ b/packages/ui/src/components/va-toast/VaToast.vue
@@ -27,7 +27,7 @@
           v-if="$props.closeable"
           class="va-toast__close-icon"
           role="button"
-          :aria-label="t('closeToast')"
+          :aria-label="tp($props.ariaCloseLabel)"
           tabindex="0"
           size="small"
           :name="$props.icon"
@@ -81,6 +81,7 @@ export default defineComponent({
       validator: (value: string) => ['top-right', 'top-left', 'bottom-right', 'bottom-left'].includes(value),
     },
     render: { type: Function },
+    ariaCloseLabel: { type: String, default: '$t:close' },
   },
   setup (props, { emit }) {
     const rootElement = shallowRef<HTMLElement>()

--- a/packages/ui/src/composables/useTranslation.ts
+++ b/packages/ui/src/composables/useTranslation.ts
@@ -21,14 +21,14 @@ export const useTranslation = () => {
 
   return {
     /** Translate prop. Translate only if key has `$t:` prefix */
-    tp: <Key extends string | undefined>(key: Key): Key => {
-      if (!key) { return undefined as Key }
+    tp: <Key extends string | undefined>(key: Key, values?: Record<string, Stringable>): string => {
+      if (!key) { return '' }
 
       if (key.startsWith('$t:')) {
-        return (config.value[key.slice(3) as keyof I18nConfig] || key) as Key
+        key = (config.value[key.slice(3) as keyof I18nConfig] || key) as NonNullable<Key>
       }
 
-      return key
+      return (applyI18nTemplate(key, values) || key)
     },
     t (key: string, values?: Record<string, Stringable>) {
       const translated = config.value[key as keyof I18nConfig]

--- a/packages/ui/src/services/i18n/config/default.ts
+++ b/packages/ui/src/services/i18n/config/default.ts
@@ -89,4 +89,13 @@ export const getI18nConfigDefaults = () => ({
 
   step: 'step',
   progress: 'progress',
+
+  /** Skeleton aria label */
+  loading: 'Loading',
+
+  /** Slider aria label */
+  sliderValue: 'Current slider value is {value}',
+
+  /** Switch aria label */
+  switch: 'Switch',
 })


### PR DESCRIPTION
Simply expose aria-labels as props, so it can be changed by user. Still use translation (also, it makes it noticeable in docs, that there are translations for aria things). The pattern is `aria[thingName]Label`. 

closes #3104

Wonder if there is some other aria things to translate.