### PR TITLE
fix: overflow scroll will cause a white area

### DIFF
--- a/packages/ui/src/components/va-modal/VaModal.vue
+++ b/packages/ui/src/components/va-modal/VaModal.vue
@@ -307,7 +307,7 @@ export default defineComponent({
     watch(valueComputed, newValueComputed => { // watch for open/close modal
       if (newValueComputed) {
         registerModal()
-        setBodyOverflow('scroll hidden')
+        setBodyOverflow('hidden')
         return
       }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail -->

The overflow scroll set by v-modal will cause a white bar to appear at the bottom of the page.

![PixelSnap 2023-03-19 at 21 19 08@2x](https://user-images.githubusercontent.com/9162521/226177746-50397cdf-da0b-4303-931b-b2377ef7e424.png)



## Markup:
<!-- Paste your markup here. -->
<details>

```vue
// Your code
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
