### PR TITLE
fix: stepper accessibility navigation

### DIFF
--- a/packages/ui/src/components/va-stepper/VaStepper.vue
+++ b/packages/ui/src/components/va-stepper/VaStepper.vue
@@ -9,9 +9,9 @@
       ref="stepperNavigation"
       :class="{ 'va-stepper__navigation--vertical': $props.vertical }"
 
-      @click="onValueChange(false)"
-      @keyup.enter="onValueChange(true)"
-      @keyup.space="onValueChange(true)"
+      @click="onValueChange"
+      @keyup.enter="onValueChange"
+      @keyup.space="onValueChange"
       @keyup.left="onArrowKeyPress('prev')"
       @keyup.right="onArrowKeyPress('next')"
       @focusout="resetFocus"
@@ -235,9 +235,9 @@ export default defineComponent({
       onArrowKeyPress: (direction: 'prev' | 'next') => {
         setFocus(direction)
       },
-      onValueChange: (focus: boolean) => {
+      onValueChange: () => {
         focusedStep.value.stepIndex = props.modelValue
-        focusedStep.value.trigger = focus
+        focusedStep.value.trigger = true
       },
       ariaAttributesComputed: computed(() => ({
         role: 'group',

--- a/packages/ui/src/components/va-stepper/VaStepper.vue
+++ b/packages/ui/src/components/va-stepper/VaStepper.vue
@@ -10,12 +10,12 @@
       :class="{ 'va-stepper__navigation--vertical': $props.vertical }"
 
       @click="onNavigationValueChange()"
-      @keyup.enter="onNavigationValueChange()"
-      @keyup.space="onNavigationValueChange()"
-      @keyup.left="onArrowKeyPress('prev')"
-      @keyup.up="onArrowKeyPress('prev')"
-      @keyup.right="onArrowKeyPress('next')"
-      @keyup.down="onArrowKeyPress('next')"
+      @keydown.enter="onNavigationValueChange()"
+      @keydown.space="onNavigationValueChange()"
+      @keydown.left="onArrowKeyPress('prev')"
+      @keydown.up.prevent="onArrowKeyPress('prev')"
+      @keydown.right="onArrowKeyPress('next')"
+      @keydown.down.prevent="onArrowKeyPress('next')"
       @focusout="resetFocus"
     >
       <template
@@ -151,6 +151,14 @@ export default defineComponent({
         }
         focusedStep.value.stepIndex = newValue
         focusedStep.value.force = true
+      } else {
+        for (let availableIdx = 0; availableIdx < props.steps.length; availableIdx++) {
+          if (!props.steps[availableIdx].disabled) {
+            focusedStep.value.stepIndex = availableIdx
+            focusedStep.value.force = true
+            break
+          }
+        }
       }
     }
     const setFocusPrevStep = (idx: number) => {
@@ -162,6 +170,14 @@ export default defineComponent({
         }
         focusedStep.value.stepIndex = newValue
         focusedStep.value.force = true
+      } else {
+        for (let availableIdx = props.steps.length - 1; availableIdx >= 0; availableIdx--) {
+          if (!props.steps[availableIdx].disabled && !(isNextStepDisabled(availableIdx))) {
+            focusedStep.value.stepIndex = availableIdx
+            focusedStep.value.force = true
+            break
+          }
+        }
       }
     }
 

--- a/packages/ui/src/components/va-stepper/VaStepper.vue
+++ b/packages/ui/src/components/va-stepper/VaStepper.vue
@@ -9,13 +9,11 @@
       ref="stepperNavigation"
       :class="{ 'va-stepper__navigation--vertical': $props.vertical }"
 
-      @click="onNavigationValueChange()"
-      @keydown.enter="onNavigationValueChange()"
-      @keydown.space="onNavigationValueChange()"
-      @keydown.left="onArrowKeyPress('prev')"
-      @keydown.up.prevent="onArrowKeyPress('prev')"
-      @keydown.right="onArrowKeyPress('next')"
-      @keydown.down.prevent="onArrowKeyPress('next')"
+      @click="onValueChange(false)"
+      @keyup.enter="onValueChange(true)"
+      @keyup.space="onValueChange(true)"
+      @keyup.left="onArrowKeyPress('prev')"
+      @keyup.right="onArrowKeyPress('next')"
       @focusout="resetFocus"
     >
       <template
@@ -117,7 +115,7 @@ export default defineComponent({
     const stepperNavigation = shallowRef<HTMLElement>()
     const { valueComputed: modelValue }: { valueComputed: Ref<number> } = useStateful(props, emit, 'modelValue', { defaultValue: 0 })
 
-    const focusedStep = ref({ force: false, stepIndex: props.navigationDisabled ? -1 : props.modelValue })
+    const focusedStep = ref({ trigger: false, stepIndex: props.navigationDisabled ? -1 : props.modelValue })
 
     const { getColor } = useColors()
     const stepperColor = getColor(props.color)
@@ -150,12 +148,12 @@ export default defineComponent({
           return
         }
         focusedStep.value.stepIndex = newValue
-        focusedStep.value.force = true
+        focusedStep.value.trigger = true
       } else {
         for (let availableIdx = 0; availableIdx < props.steps.length; availableIdx++) {
           if (!props.steps[availableIdx].disabled) {
             focusedStep.value.stepIndex = availableIdx
-            focusedStep.value.force = true
+            focusedStep.value.trigger = true
             break
           }
         }
@@ -169,29 +167,29 @@ export default defineComponent({
           return
         }
         focusedStep.value.stepIndex = newValue
-        focusedStep.value.force = true
+        focusedStep.value.trigger = true
       } else {
         for (let availableIdx = props.steps.length - 1; availableIdx >= 0; availableIdx--) {
           if (!props.steps[availableIdx].disabled && !(isNextStepDisabled(availableIdx))) {
             focusedStep.value.stepIndex = availableIdx
-            focusedStep.value.force = true
+            focusedStep.value.trigger = true
             break
           }
         }
       }
     }
 
-    const resetFocus = (e: any) => {
+    const resetFocus = () => {
       requestAnimationFrame(() => {
         if (!stepperNavigation.value?.contains(document.activeElement)) {
           focusedStep.value.stepIndex = props.modelValue
-          focusedStep.value.force = false
+          focusedStep.value.trigger = false
         }
       })
     }
     watch(() => props.modelValue, () => {
       focusedStep.value.stepIndex = props.modelValue
-      focusedStep.value.force = false
+      focusedStep.value.trigger = false
     })
 
     const nextStep = (stepsToSkip = 0) => {
@@ -237,9 +235,9 @@ export default defineComponent({
       onArrowKeyPress: (direction: 'prev' | 'next') => {
         setFocus(direction)
       },
-      onNavigationValueChange: () => {
+      onValueChange: (focus: boolean) => {
         focusedStep.value.stepIndex = props.modelValue
-        focusedStep.value.force = true
+        focusedStep.value.trigger = focus
       },
       ariaAttributesComputed: computed(() => ({
         role: 'group',

--- a/packages/ui/src/components/va-stepper/VaStepperStepButton.vue
+++ b/packages/ui/src/components/va-stepper/VaStepperStepButton.vue
@@ -60,7 +60,7 @@ export default defineComponent({
     }))
 
     watch(() => props.focus, () => {
-      if (props.focus.force) {
+      if (props.focus.trigger) {
         nextTick(() => stepElement.value?.focus())
       }
     }, { deep: true })
@@ -96,7 +96,7 @@ export default defineComponent({
     flex-shrink: 0;
     padding: var(--va-stepper-step-button-padding);
 
-    @include keyboard-focus-outline;
+    @include keyboard-focus-outline($radius: var(--va-stepper-step-border-radius));
 
     &::after {
       content: "";


### PR DESCRIPTION
## Description
- prevent default behavior for top and bottom arrows
- add focus loop according to [w3](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/) 


> When focus is on a tab element in a horizontal tab list:
Left Arrow: moves focus to the previous tab. If focus is on the first tab, moves focus to the last tab. Optionally, activates the newly focused tab.
Right Arrow: Moves focus to the next tab. If focus is on the last tab element, moves focus to the first tab. Optionally, activates the newly focused tab.

P.S. Stepper behaves as tabs component, so, I decided to use the same pattern

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
