### PR TITLE
fix(#3197): prevent bind both to and href props on router link in VaS…

### DIFF
--- a/packages/ui/src/components/va-sidebar/VaSidebarItem/VaSidebarItem.vue
+++ b/packages/ui/src/components/va-sidebar/VaSidebarItem/VaSidebarItem.vue
@@ -5,8 +5,6 @@
     tabindex="0"
     :class="{ 'va-sidebar-item--active': $props.active }"
     :style="computedStyle"
-    :href="hrefComputed"
-    :to="$props.to"
     :is="tagComputed"
     v-bind="linkAttributesComputed"
     v-on="keyboardFocusListeners"


### PR DESCRIPTION
closes #3197