### PR TITLE
fix: add single root instance to bind colors by v-bind at styles

### DIFF
--- a/packages/docs/modules/page-config/blocks/shared/code/CodeView.vue
+++ b/packages/docs/modules/page-config/blocks/shared/code/CodeView.vue
@@ -1,23 +1,25 @@
 <template>
-  <va-tabs
-    v-if="!isString"
-    v-model="index"
-    class="DocsCode__tabs"
-  >
-    <template #tabs>
-      <va-tab
-        v-for="tab in tabs"
-        :key="tab"
-      >
-        {{ tab }}
-      </va-tab>
-    </template>
-  </va-tabs>
-  <code-highlight-wrapper
-    :code="escapeVuesticImport(contents[index])"
-    :lang="$props.language"
-    class="DocsCode"
-  />
+  <div>
+    <va-tabs
+      v-if="!isString"
+      v-model="index"
+      class="DocsCode__tabs"
+    >
+      <template #tabs>
+        <va-tab
+          v-for="tab in tabs"
+          :key="tab"
+        >
+          {{ tab }}
+        </va-tab>
+      </template>
+    </va-tabs>
+    <code-highlight-wrapper
+      :code="escapeVuesticImport(contents[index])"
+      :lang="$props.language"
+      class="DocsCode"
+    />
+  </div>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
## Description
- Fixed missing highlight.js styles.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
