### PR TITLE
fix(docs): Add flex-wrap for Split example on button dropdown

### DIFF
--- a/packages/docs/page-config/ui-elements/button-dropdown/examples/Split.vue
+++ b/packages/docs/page-config/ui-elements/button-dropdown/examples/Split.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="display: flex; align-items: center;">
+  <div class="flex items-center flex-wrap">
     <va-button-dropdown
       class="mr-2 mb-2"
       split


### PR DESCRIPTION
close #3314 

## Description
- Allow wrapping of split button dropdown examples from the docs on mobile view.
- Use tailwind classes instead of inline-styles.

</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
