### PR TITLE
fix(#3296): append css wrong paths on windows

### DIFF
--- a/packages/ui/build/plugins/append-component-css.ts
+++ b/packages/ui/build/plugins/append-component-css.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'fs'
-import { extname, dirname, basename, relative, resolve } from 'path'
+import { extname, dirname, basename, relative, resolve } from 'pathe'
 import { createDistTransformPlugin } from './fabrics/create-dist-transform-plugin'
 
 const parsePath = (path: string) => {


### PR DESCRIPTION
closes https://github.com/epicmaxco/vuestic-ui/issues/3296

Fix relative build path while building on windows machine.

From `import '..\..\../Modal.css' to `import '../../../Modal.css'`