### PR TITLE
сlose modal/confirm programmatically

### DIFF
--- a/packages/ui/src/components/va-modal/VaModal.demo.vue
+++ b/packages/ui/src/components/va-modal/VaModal.demo.vue
@@ -369,6 +369,16 @@
         Show modal and close after 3 sec
       </button>
     </VbCard>
+    <VbCard title="programmaticallyClose">
+      <button @click="programmaticallyClose('confirm', true)">
+        Show confirm and close after 3 sec using button "ok"
+      </button>
+    </VbCard>
+    <VbCard title="programmaticallyClose">
+      <button @click="programmaticallyClose('confirm', false)">
+        Show confirm and close after 3 sec using button "cancel"
+      </button>
+    </VbCard>
   </VbDemo>
 </template>
 
@@ -454,11 +464,17 @@ export default {
       }
     },
 
-    programmaticallyClose () {
+    async programmaticallyClose (typeModal, typeOk) {
       const modal = this.$vaModal
-      modal.init('Wait a 3 seconds')
+      if (typeModal === 'confirm') {
+        modal.confirm('Wait a 3 seconds for close').then((ok) => {
+          ok ? alert('ok') : alert('cancel')
+        })
+      } else {
+        modal.init('Wait a 3 seconds for close')
+      }
       setTimeout(() => {
-        modal.close()
+        modal.close(typeOk)
       }, 3000)
     },
   },

--- a/packages/ui/src/components/va-modal/VaModal.demo.vue
+++ b/packages/ui/src/components/va-modal/VaModal.demo.vue
@@ -364,6 +364,11 @@
 
       <va-modal v-model="showBeforeHideModal" :message="message" :beforeClose="beforeClose" />
     </VbCard>
+    <VbCard title="programmaticallyClose">
+      <button @click="programmaticallyClose">
+        Show modal and close after 3 sec
+      </button>
+    </VbCard>
   </VbDemo>
 </template>
 
@@ -447,6 +452,14 @@ export default {
       if (window.confirm('Are you sure?')) {
         hide()
       }
+    },
+
+    programmaticallyClose () {
+      const modal = this.$vaModal
+      modal.init('Wait a 3 seconds')
+      setTimeout(() => {
+        modal.close()
+      }, 3000)
     },
   },
 }

--- a/packages/ui/src/components/va-modal/hooks/useModal.ts
+++ b/packages/ui/src/components/va-modal/hooks/useModal.ts
@@ -25,7 +25,7 @@ export const useModal = () => {
   const confirm = (options: string | ModalOptions) => {
     if (typeof options === 'string') {
       return new Promise<boolean>((resolve, reject) => {
-        createModalInstance({
+        modalInstance = createModalInstance({
           message: options as string,
           onOk () {
             resolve(true)
@@ -38,7 +38,7 @@ export const useModal = () => {
     }
 
     return new Promise<boolean>((resolve, reject) => {
-      createModalInstance({
+      modalInstance = createModalInstance({
         ...options,
         onOk () {
           options?.onOk?.()
@@ -52,8 +52,16 @@ export const useModal = () => {
     })
   }
 
-  const close = () => {
+  /**
+   * @param type can be true or false
+   */
+  const close = (ok: boolean) => {
     modalInstance.props!.onClose()
+    if (ok === true) {
+      modalInstance.props!.onOk()
+    } else if (ok === false) {
+      modalInstance.props!.onCancel()
+    }
   }
 
   return { init, confirm, close }

--- a/packages/ui/src/components/va-modal/hooks/useModal.ts
+++ b/packages/ui/src/components/va-modal/hooks/useModal.ts
@@ -13,8 +13,9 @@ export const useModal = () => {
   /**
    * @param options can be message string or options object
    */
+  let modalInstance: any
   const init = (options: string | ModalOptions) => {
-    return createModalInstance(options, appContext)
+    modalInstance = createModalInstance(options, appContext)
   }
 
   /**
@@ -51,5 +52,9 @@ export const useModal = () => {
     })
   }
 
-  return { init, confirm }
+  const close = () => {
+    modalInstance.props!.onClose()
+  }
+
+  return { init, confirm, close }
 }

--- a/packages/ui/src/components/va-modal/plugin/index.ts
+++ b/packages/ui/src/components/va-modal/plugin/index.ts
@@ -11,7 +11,7 @@ const createVaModalPlugin = (app: App) => ({
   confirm (options: string | ModalOptions) {
     if (typeof options === 'string') {
       return new Promise<boolean>((resolve) => {
-        createModalInstance({
+        modalInstance = createModalInstance({
           message: options as string,
           onOk () {
             resolve(true)
@@ -24,7 +24,7 @@ const createVaModalPlugin = (app: App) => ({
     }
 
     return new Promise<boolean>((resolve) => {
-      createModalInstance({
+      modalInstance = createModalInstance({
         ...options,
         onOk () {
           options?.onOk?.()
@@ -37,8 +37,13 @@ const createVaModalPlugin = (app: App) => ({
       }, app?._context)
     })
   },
-  close () {
+  close (ok: boolean) {
     modalInstance.props!.onClose()
+    if (ok === true) {
+      modalInstance.props!.onOk()
+    } else if (ok === false) {
+      modalInstance.props!.onCancel()
+    }
   },
 })
 

--- a/packages/ui/src/components/va-modal/plugin/index.ts
+++ b/packages/ui/src/components/va-modal/plugin/index.ts
@@ -3,9 +3,10 @@ import { defineVuesticPlugin, defineGlobalProperty } from '../../../services/vue
 import { createModalInstance } from '../modal'
 import { ModalOptions } from '../types'
 
+let modalInstance: any
 const createVaModalPlugin = (app: App) => ({
   init (options: string | ModalOptions) {
-    return createModalInstance(options, app?._context)
+    modalInstance = createModalInstance(options, app?._context)
   },
   confirm (options: string | ModalOptions) {
     if (typeof options === 'string') {
@@ -35,6 +36,9 @@ const createVaModalPlugin = (app: App) => ({
         },
       }, app?._context)
     })
+  },
+  close () {
+    modalInstance.props!.onClose()
   },
 })
 

--- a/packages/ui/src/components/va-modal/useConfirm.demo.vue
+++ b/packages/ui/src/components/va-modal/useConfirm.demo.vue
@@ -20,6 +20,16 @@
         Alert promise result
       </va-button>
     </VaCard>
+    <VaCard>
+      <va-button @click="programmaticallyClose(true)">
+        Programmatically close using button "ok"
+      </va-button>
+    </VaCard>
+    <VaCard>
+      <va-button @click="programmaticallyClose(false)">
+        Programmatically close using button "cancel"
+      </va-button>
+    </VaCard>
   </VbDemo>
 </template>
 
@@ -27,8 +37,25 @@
 import { VaButton } from '../va-button'
 import { useModal } from './'
 
-const { confirm } = useModal()
+const { confirm, close } = useModal()
 const alert = (...args) => window.alert(...args)
+
+const programmaticallyClose = async (type) => {
+  setTimeout(() => {
+    close(type)
+  }, 3000)
+  const result = await confirm({
+    message: 'Wait a 3 seconds for close',
+    title: 'Programmatically close',
+    okText: 'approved',
+    cancelText: 'canceled',
+  })
+  if (result) {
+    alert('approved')
+  } else {
+    alert('canceled')
+  }
+}
 </script>
 
 <style lang="scss">


### PR DESCRIPTION
close #3346
## Description
Added function close() for the Modals including the confirm
 
But i have one bug. This string break "background overlay" if reopen modal:
 packages\ui\src\components\va-modal\VaModal.vue => computedOverlayStyles => if (!props.overlay || !isLowestLevelModal.value) { return }

## Markup:
<details>

```vue
// Your code
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
