### PR TITLE
[#3375] Unexpected theme change on Colors page

### DIFF
--- a/packages/docs/composables/useTheme.ts
+++ b/packages/docs/composables/useTheme.ts
@@ -13,9 +13,10 @@ export const useTheme = () => {
     }
 
     if (cookie.value) {
-      applyPreset(colorMode.value)
+      applyPreset(cookie.value)
       return
     }
+
     if (!colorMode.unknown) {
       applyPreset(colorMode.value)
     }

--- a/packages/docs/page-config/styles/colors/components/theme.vue
+++ b/packages/docs/page-config/styles/colors/components/theme.vue
@@ -19,7 +19,7 @@
       Primary color
       <va-color-palette
         v-model="primaryColor"
-        class="ml-2"
+        class="!ml-2"
         :palette="primaryColorVariants"
       />
     </p>
@@ -32,13 +32,9 @@ import { useColors } from "vuestic-ui";
 
 export default {
   setup() {
-    const { presets, applyPreset, colors } = useColors();
+    const { presets, applyPreset, colors, currentPresetName } = useColors();
 
-    const savedTheme = (typeof localStorage !== 'undefined' && localStorage.getItem("vuestic-docs-theme")?.toLowerCase())
-
-    const theme = ref(
-      savedTheme || "light"
-    );
+    const theme = ref(currentPresetName.value || "light");
 
     watchEffect(() => {
       applyPreset(theme.value);
@@ -56,10 +52,12 @@ export default {
 
     return {
       theme,
-      themeOptions: Object.keys(presets.value).map((themeName) => ({
-        value: themeName,
-        label: themeName,
-      })),
+      themeOptions: Object.keys(presets.value)
+        .filter((themeName) => themeName !== 'landing')
+        .map((themeName) => ({
+          value: themeName,
+          label: themeName,
+        })),
 
       primaryColor,
       primaryColorVariants,


### PR DESCRIPTION
## Description
close #3375 

- [x] apply the `currentPresetName` color preset on the Colors page
- [x] minor fix `useTheme`

<details>

![chrome-capture-2023-3-26 (1)](https://user-images.githubusercontent.com/55198465/234626396-3e32f0ec-aef0-42e0-b4aa-e93f87825460.gif)

</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
