### PR TITLE
feat#3392: make currentPresetName a writable computed

### DIFF
--- a/packages/ui/src/composables/useColors.ts
+++ b/packages/ui/src/composables/useColors.ts
@@ -144,8 +144,10 @@ export const useColors = () => {
     return getColorLightnessFromCache(color) > globalConfig.value.colors.threshold ? darkColor : lightColor
   }
 
-  const currentPresetName = computed(() => globalConfig.value.colors!.currentPresetName)
-
+  const currentPresetName = computed<string>({
+    get: () => globalConfig.value.colors!.currentPresetName,
+    set: (v:string) => { globalConfig.value.colors!.currentPresetName = v },
+  })
   const presets = computed(() => globalConfig.value.colors!.presets)
 
   const applyPreset = (presetName: string) => {

--- a/packages/ui/src/composables/useColors.ts
+++ b/packages/ui/src/composables/useColors.ts
@@ -146,7 +146,7 @@ export const useColors = () => {
 
   const currentPresetName = computed<string>({
     get: () => globalConfig.value.colors!.currentPresetName,
-    set: (v:string) => { globalConfig.value.colors!.currentPresetName = v },
+    set: (v: string) => { applyPreset(v) },
   })
   const presets = computed(() => globalConfig.value.colors!.presets)
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->
# Make currentPresetName a WritableComputed property
<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail -->
closes #3392
A setter was added to the computed property `currentPresetName` in `packages/ui/src/composables/useColors.ts`.
This setter assigns a new string value to the `currentPresetName` property of `globalConfig.value.colors`.

## Markup:
<!-- Paste your markup here. -->
<details>

```ts
 const currentPresetName = computed<string>({
    get: () => globalConfig.value.colors!.currentPresetName,
    set: (v:string) => { globalConfig.value.colors!.currentPresetName = v },
  })
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
