### PR TITLE
Automatically close sidebar when clicking outside of sidebar

### DIFF
--- a/packages/ui/src/components/va-sidebar/VaSidebar.demo.vue
+++ b/packages/ui/src/components/va-sidebar/VaSidebar.demo.vue
@@ -155,6 +155,25 @@
         </va-sidebar>
       </div>
     </VbCard>
+    <VbCard title="close on click outside">
+      <va-checkbox v-model="doShowVmodelClickOutside" />
+      <br />
+      <div class="demo__sidebar-container-2x">
+        <va-sidebar
+          v-model="doShowVmodelClickOutside"
+          close-on-click-outside
+        >
+          <div>Item</div>
+          <div>Item</div>
+        </va-sidebar>
+      </div>
+      <div class="demo__sidebar-container-2x">
+        <va-sidebar v-model="doShowVmodelClickOutside" position="right">
+          <div>Item</div>
+          <div>Item</div>
+        </va-sidebar>
+      </div>
+    </VbCard>
   </VbDemo>
 </template>
 
@@ -181,6 +200,7 @@ export default {
       minimized: true,
       minimizedWithWidth: true,
       doShowVmodelDemoSidebar: true,
+      doShowVmodelClickOutside: true,
     }
   },
 }

--- a/packages/ui/src/components/va-sidebar/VaSidebar.vue
+++ b/packages/ui/src/components/va-sidebar/VaSidebar.vue
@@ -58,8 +58,6 @@ export default defineComponent({
   components: { VaConfig },
 
   setup (props, { emit }) {
-    const rootElement = shallowRef<HTMLElement>()
-
     const { getColor } = useColors()
     useSidebar(props)
 
@@ -98,6 +96,8 @@ export default defineComponent({
     const updateHoverState = (newHoverState: boolean) => {
       isHovered.value = props.hoverable && newHoverState
     }
+
+    const rootElement = shallowRef<HTMLElement>()
 
     useClickOutside([rootElement], () => {
       if (props.closeOnClickOutside && props.modelValue) {

--- a/packages/ui/src/components/va-sidebar/VaSidebar.vue
+++ b/packages/ui/src/components/va-sidebar/VaSidebar.vue
@@ -1,5 +1,6 @@
 <template>
   <aside
+    ref="rootElement"
     class="va-sidebar"
     :class="computedClass"
     :style="computedStyle"
@@ -15,11 +16,11 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, ref, PropType } from 'vue'
+import { defineComponent, computed, ref, PropType, shallowRef } from 'vue'
 
 import { VaConfig } from '../va-config'
 import { getGradientBackground } from '../../services/color'
-import { useColors, useTextColor, useBem } from '../../composables'
+import { useColors, useTextColor, useBem, useClickOutside } from '../../composables'
 import { useSidebar } from './hooks/useSidebar'
 import { useComponentPresetProp } from '../../composables/useComponentPreset'
 
@@ -49,11 +50,16 @@ export default defineComponent({
     minimizedWidth: { type: String, default: '4rem' },
     modelValue: { type: Boolean, default: true },
     animated: { type: Boolean, default: true },
+    closeOnClickOutside: { type: Boolean, default: false },
   },
+
+  emits: ['update:modelValue'],
 
   components: { VaConfig },
 
-  setup (props) {
+  setup (props, { emit }) {
+    const rootElement = shallowRef<HTMLElement>()
+
     const { getColor } = useColors()
     useSidebar(props)
 
@@ -93,11 +99,20 @@ export default defineComponent({
       isHovered.value = props.hoverable && newHoverState
     }
 
+    useClickOutside([rootElement], () => {
+      if (props.closeOnClickOutside && props.modelValue) {
+        setTimeout(() => {
+          emit('update:modelValue', false)
+        }, 0)
+      }
+    })
+
     return {
       computedWidth,
       computedClass,
       computedStyle,
       updateHoverState,
+      rootElement,
       vaSidebarItemProps: computed(() => ({
         textColor: props.textColor,
         activeColor: props.activeColor,


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail -->
There is new prop in Sidebar which is called `close-on-click-outside` (false by default). Demo was added.

close: [#3390](https://github.com/epicmaxco/vuestic-ui/issues/3390)

## Markup:
<!-- Paste your markup here. -->
<details>

```vue
// Your code
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
