### PR TITLE
Fix#3488/focus clear icon

### DIFF
--- a/packages/ui/src/components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/va-select/VaSelect.vue
@@ -499,11 +499,6 @@ export default defineComponent({
       }
     })
 
-    const onInputFocus = () => {
-      isInputFocused.value = true
-      onFocus()
-    }
-
     const onInputBlur = () => {
       if (showDropdownContentComputed.value) { return }
 
@@ -653,6 +648,9 @@ export default defineComponent({
       searchInput.value = ''
       emit('clear')
       resetValidation()
+      nextTick(() => {
+        isInputFocused.value = true
+      })
     })
 
     const focusAutocompleteInput = (e?: Event) => {
@@ -700,7 +698,7 @@ export default defineComponent({
       tp,
       t,
 
-      onInputFocus,
+      onInputFocus: onFocus,
       onInputBlur,
       focusOptionList,
       focusSearchBar,

--- a/packages/ui/src/components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/va-select/VaSelect.vue
@@ -476,7 +476,11 @@ export default defineComponent({
       showDropdownContent.value = false
       searchInput.value = ''
       validate()
+      nextTick(() => {
+        isInputFocused.focusIfNothingIfFocused()
+      })
     }
+
     const hideAndFocus = () => {
       handleDropdownClose()
       isInputFocused.value = true

--- a/packages/ui/src/composables/useFocusDeep.ts
+++ b/packages/ui/src/composables/useFocusDeep.ts
@@ -1,31 +1,22 @@
-import { shallowRef, computed, Ref, onMounted, DefineComponent } from 'vue'
+import { computed, Ref, DefineComponent } from 'vue'
 import { useHTMLElement } from './useHTMLElement'
-import { useCaptureEvent } from './useCaptureEvent'
 import { useCurrentElement } from './useCurrentElement'
-import { blurElement, focusElement } from '../utils/focus'
+import { useFocusedElement } from './useFocusedElement'
 
-const useActiveElement = () => {
-  const activeEl = shallowRef<HTMLElement>()
-
-  const updateActiveElement = () => {
-    activeEl.value = document.activeElement as HTMLElement
-  }
-
-  onMounted(updateActiveElement)
-
-  useCaptureEvent('focus', updateActiveElement)
-  useCaptureEvent('blur', updateActiveElement)
-
-  return activeEl
-}
-
+/**
+ * `true` if `el` or any of his children are in focus
+ *
+ *  if set to `true` set `el` focused, but if any of `el` children was focused before, set child focused instead
+ *
+ * @notice this will not trigger native `focus` event and you need to trigger it manually and handle infinite loop
+ */
 export const useFocusDeep = (el?: Ref<HTMLElement | DefineComponent | undefined>) => {
-  const focused = useActiveElement()
+  const focused = useFocusedElement()
   const current = useCurrentElement(el ? useHTMLElement(el) : undefined)
   // Cache previouslyFocusedElement, so we can simply come back to it
   let previouslyFocusedElement: HTMLElement | null = null
 
-  return computed<boolean | undefined>({
+  const isFocused = computed<boolean | undefined>({
     get () {
       if (!focused.value) { return false }
       if (focused.value === current.value) { return true }
@@ -41,10 +32,30 @@ export const useFocusDeep = (el?: Ref<HTMLElement | DefineComponent | undefined>
         target = current.value
       }
 
+      // NOTICE: Focus and blur events will not be dispatched here to prevent infinite loop
       if (value) {
         (target)?.focus()
       } else {
         (target)?.blur()
+      }
+    },
+  })
+
+  return Object.assign(isFocused, {
+    /** Focus `el` if focus is not set to any other element */
+    focusIfNothingIfFocused: () => {
+      // body if focused by default, but we assume it means nothing is focused
+      // by nothing we mean elements like input, button, etc.
+      if (focused.value === document.body) {
+        isFocused.value = true
+      }
+    },
+
+    focusPreviousElement: () => {
+      if (previouslyFocusedElement) {
+        previouslyFocusedElement.focus()
+      } else {
+        document.body.focus()
       }
     },
   })

--- a/packages/ui/src/composables/useFocusedElement.ts
+++ b/packages/ui/src/composables/useFocusedElement.ts
@@ -1,0 +1,17 @@
+import { onMounted, shallowRef } from 'vue'
+import { useCaptureEvent } from './useCaptureEvent'
+
+export const useFocusedElement = () => {
+  const activeEl = shallowRef<HTMLElement>()
+
+  const updateActiveElement = () => {
+    activeEl.value = document.activeElement as HTMLElement
+  }
+
+  onMounted(updateActiveElement)
+
+  useCaptureEvent('focus', updateActiveElement)
+  useCaptureEvent('blur', updateActiveElement)
+
+  return activeEl
+}


### PR DESCRIPTION
closes #3488 

Now when shift tab is pressed in select with focused clear icon it correctly moves to input, not clear icon.
And also now input field is focused after dropdown is closed.

![2023-06-12 at 7 04 15 - Magenta Wildebeest](https://github.com/epicmaxco/vuestic-ui/assets/23530004/d2887b58-1033-4de8-8561-3b7d0ea4c7af)
