### PR TITLE
fix: change title and subtitle styles to look different on mobile resolution

### DIFF
--- a/packages/docs/modules/page-config/blocks/subtitle/index.vue
+++ b/packages/docs/modules/page-config/blocks/subtitle/index.vue
@@ -29,5 +29,11 @@ const { t } = useI18n()
 
   font-size: 2rem;
   line-height: 2.5rem;
+
+  @media screen and (max-width: 767px) {
+    font-size: 1.5rem !important;
+    line-height: 2rem;
+    margin-top: 2rem;
+  }
 }
 </style>

--- a/packages/docs/modules/page-config/blocks/title/index.vue
+++ b/packages/docs/modules/page-config/blocks/title/index.vue
@@ -28,7 +28,7 @@ const { t } = useI18n()
   --code-bg: transparent;
 
   @media screen and (max-width: 767px) {
-    font-size: 2rem !important;
+    font-size: 2.5rem !important;
   }
 }
 </style>


### PR DESCRIPTION
closes #3486

I changed the `title` and `sub-title` styles to look different on mobile resolution.

## Result:
### On desktop:
![image](https://github.com/epicmaxco/vuestic-ui/assets/58943459/98a8dab8-8712-4043-bcae-bef20fb0c7e4)



### On mobile:
![image](https://github.com/epicmaxco/vuestic-ui/assets/58943459/49bd1ca5-f3cb-4968-8cdb-e3377062ceef)

