### PR TITLE
fix: made focused anchor is always visible

### DIFF
--- a/packages/docs/modules/page-config/blocks/shared/anchor/Anchor.vue
+++ b/packages/docs/modules/page-config/blocks/shared/anchor/Anchor.vue
@@ -48,7 +48,11 @@ export default defineComponent({
   opacity: 0;
   font-size: 95%;
   transition: opacity 0.1s ease-in-out;
-
+  
+  &:focus {
+    opacity: 1;
+  }
+  
   &--force-show {
     opacity: 1;
   }


### PR DESCRIPTION
close #3531 
Changed `page-config-anchor` style for `Anchor` component to always show on focus.
