### PR TITLE
fix(types): replace vue global components target module with @vue/run…

### DIFF
--- a/packages/ui/src/components/va-dropdown/plugin/index.ts
+++ b/packages/ui/src/components/va-dropdown/plugin/index.ts
@@ -21,7 +21,7 @@ export const VaDropdownPlugin = defineVuesticPlugin(() => ({
   },
 }))
 
-declare module 'vue' {
+declare module '@vue/runtime-core' {
   export interface ComponentCustomProperties {
     $vaDropdown: typeof vaDropdownPlugin
 

--- a/packages/ui/src/components/va-modal/plugin/index.ts
+++ b/packages/ui/src/components/va-modal/plugin/index.ts
@@ -44,7 +44,7 @@ export const VaModalPlugin = defineVuesticPlugin(() => ({
   },
 }))
 
-declare module 'vue' {
+declare module '@vue/runtime-core' {
   export interface ComponentCustomProperties {
     $vaModal: ReturnType<typeof createVaModalPlugin>
   }

--- a/packages/ui/src/components/va-toast/plugin/index.ts
+++ b/packages/ui/src/components/va-toast/plugin/index.ts
@@ -24,7 +24,7 @@ export const VaToastPlugin = defineVuesticPlugin(() => ({
   },
 }))
 
-declare module 'vue' {
+declare module '@vue/runtime-core' {
   export interface ComponentCustomProperties {
     $vaToast: ReturnType<typeof createVaToastPlugin>
   }

--- a/packages/ui/src/services/breakpoint/plugin/index.ts
+++ b/packages/ui/src/services/breakpoint/plugin/index.ts
@@ -11,7 +11,7 @@ export const BreakpointConfigPlugin = defineVuesticPlugin(() => ({
   },
 }))
 
-declare module 'vue' {
+declare module '@vue/runtime-core' {
   export interface ComponentCustomProperties {
     $vaBreakpoint: ReturnType<typeof createBreakpointConfigPlugin>
   }

--- a/packages/ui/src/services/color/plugin/index.ts
+++ b/packages/ui/src/services/color/plugin/index.ts
@@ -9,7 +9,7 @@ export const ColorConfigPlugin = defineVuesticPlugin((config?: PartialGlobalConf
   },
 }))
 
-declare module 'vue' {
+declare module '@vue/runtime-core' {
   export interface ComponentCustomProperties {
     $vaColorConfig: ReturnType<typeof createColorConfigPlugin>
   }

--- a/packages/ui/src/services/colors-classes/plugin/index.ts
+++ b/packages/ui/src/services/colors-classes/plugin/index.ts
@@ -71,7 +71,7 @@ export const ColorsClassesPlugin = defineVuesticPlugin(() => ({
   },
 }))
 
-declare module 'vue' {
+declare module '@vue/runtime-core' {
   export interface ComponentCustomProperties {
     $vaColorsClasses: ReturnType<typeof createColorHelpersPlugin>
   }

--- a/packages/ui/src/services/global-config/plugin/index.ts
+++ b/packages/ui/src/services/global-config/plugin/index.ts
@@ -21,7 +21,7 @@ export const GlobalConfigPlugin = defineVuesticPlugin((config: PartialGlobalConf
   },
 }))
 
-declare module 'vue' {
+declare module '@vue/runtime-core' {
   export interface ComponentCustomProperties {
     $vaConfig: ReturnType<typeof createGlobalConfig>
   }

--- a/packages/ui/src/services/vue-plugin/create-vuestic/create-vuestic.ts
+++ b/packages/ui/src/services/vue-plugin/create-vuestic/create-vuestic.ts
@@ -7,7 +7,7 @@ import { setCurrentApp } from '../../current-app'
 import { ColorsClassesPlugin } from '../../colors-classes'
 
 // Declare all components globally
-declare module 'vue' {
+declare module '@vue/runtime-core' {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
   export interface GlobalComponents extends VuesticComponents {}
 }

--- a/packages/ui/src/services/vue-plugin/types/components.ts
+++ b/packages/ui/src/services/vue-plugin/types/components.ts
@@ -16,7 +16,7 @@ export type VuesticComponentName = keyof VuesticComponentsMap
  * @example
  * This will register all vuestic components globally:
  * ```
- * declare module 'vue' {
+ * declare module '@vue/runtime-core' {
  *   export interface GlobalComponents extends VuesticComponents {}
  * }
  * ```
@@ -24,7 +24,7 @@ export type VuesticComponentName = keyof VuesticComponentsMap
  * @example
  * If you using tree-shaking and want to register only specific components:
  * ```
- * declare module 'vue' {
+ * declare module '@vue/runtime-core' {
  *   export interface GlobalComponents extends VuesticComponents<'VaButton' | 'VaInput'> {}
  * }
  * ```

--- a/packages/ui/src/services/vue-plugin/utils/global-properties.ts
+++ b/packages/ui/src/services/vue-plugin/utils/global-properties.ts
@@ -7,7 +7,7 @@ export const extractGlobalProperties = (app: App | AppContext) => app.config.glo
  * Type safe set vue global property
  * Declare type before use this method.
  * ```
-declare module 'vue' {
+declare module '@vue/runtime-core' {
   export interface ComponentCustomProperties {
     $vaThing: ThingType
   }


### PR DESCRIPTION
closes #3552 

According to this guy https://stackoverflow.com/a/70502179 Volar is not able to recognize components declared in `vue` module, so instead we do this in `@vue/runtime-core` now. This also solves issue with re-declaring nuxt global components for me locally.

Waiting on response https://github.com/epicmaxco/vuestic-ui/issues/3552#issuecomment-1614741985 before merging...