### PR TITLE
fix: change VaIcon import to get right icon size config

### DIFF
--- a/packages/ui/src/components/va-input/VaInput.vue
+++ b/packages/ui/src/components/va-input/VaInput.vue
@@ -93,7 +93,7 @@ import type { AnyStringPropType } from '../../utils/types/prop-type'
 
 import VaInputWrapper from './components/VaInputWrapper/VaInputWrapper.vue'
 import VaTextarea from './components/VaTextarea/VaTextarea.vue'
-import VaIcon from '../va-icon/VaIcon.vue'
+import { VaIcon } from '../va-icon'
 import { focusElement, blurElement } from '../../utils/focus'
 import { unwrapEl } from '../../utils/unwrapEl'
 

--- a/packages/ui/src/components/va-time-input/VaTimeInput.vue
+++ b/packages/ui/src/components/va-time-input/VaTimeInput.vue
@@ -103,7 +103,7 @@ import { useTimeFormatter } from './hooks/time-text-formatter'
 
 import VaTimePicker from '../va-time-picker/VaTimePicker.vue'
 import { VaInputWrapper } from '../va-input'
-import VaIcon from '../va-icon/VaIcon.vue'
+import { VaIcon } from '../va-icon'
 import { VaDropdown, VaDropdownContent } from '../va-dropdown'
 
 const VaInputWrapperProps = extractComponentProps(VaInputWrapper, ['focused', 'maxLength', 'counterValue'])


### PR DESCRIPTION
closes #3551

**The problem was that:** `VaIcon` was imported as a whole component in `VaInput` and `VaTimeInput`, so `VaIcon` used the default size configuration for components, where the **"small"** size is `32px`.

I changed the import to correct form and now `VaIcon` use `ConfigTransport`.
Now the "small" size of the icon is `16px`, as it should be.
