### PR TITLE
 feat: change i18n translation view

### DIFF
--- a/packages/docs/modules/page-config/blocks/api/index.vue
+++ b/packages/docs/modules/page-config/blocks/api/index.vue
@@ -3,6 +3,7 @@ import { DefineComponent, PropType } from 'vue';
 import merge from 'lodash/merge'
 import camelCase from 'lodash/camelCase'
 import ApiTable from './components/ApiDocs.vue';
+import { MarkdownView } from '../shared/markdown'
 import {
   CssVariables,
   ManualApiOptions,
@@ -83,7 +84,7 @@ const propsOptions = computed(() => {
       name: name,
       description: getDescription('props', name),
       types: '`' + prop.types + '`',
-      default: cleanDefaultValue(prop.default),
+      default: cleanDefaultValue(prop.default) ?? '',
     }))
     .sort((a, b) => (a.name || '').localeCompare(b.name))
   }
@@ -137,6 +138,10 @@ const cssVariablesOptions = computed(() => props.cssVariables.map(([name, value,
   name, value, /* comment */ // TODO: Enable comment when everywhere is used correct comments
   // TODO: Or add tanslations after i18n splitted
 })))
+
+const isValueIsDefaultTranslation = (value: String) => {
+  return value.startsWith('`"$t:');
+}
 </script>
 
 <template>
@@ -155,6 +160,28 @@ const cssVariablesOptions = computed(() => props.cssVariables.map(([name, value,
           text="required"
           color="primary"
         />
+      </template>
+      <template
+        #default="{value}"
+      >
+        <div class="flex items-center gap-1">
+          <markdown-view :content="value" />        
+          <va-popover
+            placement="right"
+            trigger="click"
+          >
+            <va-icon
+              v-if="isValueIsDefaultTranslation(value)"
+              name="info"
+              color="secondary"
+            />
+            <template #body>
+              <nuxt-link to="/services/i18n#translations">
+                Read more
+              </nuxt-link>
+            </template>
+          </va-popover>
+        </div> 
       </template>
     </ApiTable>
 

--- a/packages/docs/page-config/services/i18n/index.ts
+++ b/packages/docs/page-config/services/i18n/index.ts
@@ -1,13 +1,16 @@
 import { getI18nConfigDefaults } from "vuestic-ui/src/services/i18n";
 
+const configTranslations = Object
+  .entries(getI18nConfigDefaults())
+  .sort((a, b) => a[0].localeCompare(b[0]))
+
 export default definePageConfig({
   blocks: [
     block.title("i18n"),
     block.paragraph("We made a separated config for i18n messages, so you can redefine messages we use in components."),
 
-    block.collapse("i18n default messages", [
-      block.code(JSON.stringify(getI18nConfigDefaults(), null, 2)),
-    ]),
+    block.subtitle("Translations"),
+    block.table([{ title: "Key", type: 'code'}, "Value"], configTranslations),
 
     block.subtitle("Change default messages"),
     block.paragraph("Default messages can be set in `GlobalConfig`. Config is fully typed, so you can use autocomplete to find messages you want to change."),


### PR DESCRIPTION
close #3445 

I changed the view of "i18n default messages" on the corresponding page.

### Before:
![image](https://github.com/epicmaxco/vuestic-ui/assets/58943459/5235b04e-0803-4811-bbd3-028957f0b65e)

### After:
![image](https://github.com/epicmaxco/vuestic-ui/assets/58943459/2b6dc43e-dfd6-4012-b156-70c3a2ced3fe)


Also added informational footnotes with reference to ["i18n" article](https://ui.vuestic.dev/services/i18n#i-18-n) for props that contain `"$t:"` in their default values.

### Example:
![image](https://github.com/epicmaxco/vuestic-ui/assets/58943459/eba50f5c-daa0-4286-87cd-70e29f9f2dd1)

![image](https://github.com/epicmaxco/vuestic-ui/assets/58943459/2945fad4-94a4-4600-9ae7-4852cd203c48)
