### PR TITLE
fix: node 16 module resolution error

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -148,7 +148,8 @@
     ".": {
       "import": {
         "node": "./dist/esm-node/main.mjs",
-        "default": "./dist/es/main.js"
+        "default": "./dist/es/main.js",
+        "types": "./dist/types/main.d.ts"
       },
       "require": "./dist/cjs/main.js"
     },


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail -->

Adds a "types" field to the `exports` block in package.json to allow TypeScript's Node16 resolution to work properly.

Without it, TypeScript throws this error:

```
Could not find a declaration file for module 'vuestic-ui'. '/workspace/node_modules/vuestic-ui/dist/es/main.js' implicitly has an 'any' type.
  There are types at '/workspace/node_modules/vuestic-ui/dist/types/main.d.ts', but this result could not be resolved when respecting package.json "exports". The 'vuestic-ui' library may need to update its package.json or typings
```

## Markup:
<!-- Paste your markup here. -->
<details>

```vue
// Your code
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
