### PR TITLE
fix#3662/VaDropdown overflow bug

### DIFF
--- a/packages/docs/config/vuestic-config.ts
+++ b/packages/docs/config/vuestic-config.ts
@@ -19,7 +19,6 @@ export const VuesticConfig = defineVuesticConfig({
     },
     VaDropdown: {
       target: scrollWrapperSelector,
-      teleport: 'body',
     },
     VaBacktop: {
       target: scrollWrapperSelector,


### PR DESCRIPTION
closes #3662 

predefined `teleport: 'body'` makes each `<va-dropdown/>` to be atached to `<body></body>` regardless of whether teleport was defined or not, by removing this line, we will fix all the strange behavior with overflow.