### PR TITLE
feat: add privacy policy

### DIFF
--- a/packages/docs/components/landing/Footer.vue
+++ b/packages/docs/components/landing/Footer.vue
@@ -66,6 +66,10 @@
           >
             hello@epicmax.co
           </a>
+          <br>
+          <a href="https://www.iubenda.com/privacy-policy/50799764" title="Privacy Policy ">Privacy Policy</a>
+          •
+          <a href="https://www.iubenda.com/privacy-policy/50799764/cookie-policy" title="Privacy Policy ">Cookie Policy</a>
         </div>
       </div>
       <!--<LandingNewsBanner />-->


### PR DESCRIPTION
closes #3601

I chose a very simple approach to privacy policy - just add links to headers.
There are ways to improve it (add consent banner etc), but other ui solutions don't do it. It will also be harmful for user experience.

Links lead to iubenda - a site where said policies for each tool used (analytics, cdn etc) are being regularly updated, so we won't need to follow these up on our own.

<img width="440" alt="image" src="https://github.com/epicmaxco/vuestic-ui/assets/5394573/7da484f7-75ed-461f-b9c3-d645ed1ec9b2">
<img width="1068" alt="image" src="https://github.com/epicmaxco/vuestic-ui/assets/5394573/1ebb795b-bd6d-440a-bf3e-338a7050f37b">
