### PR TITLE
Add accessibility docs for `VaProgressCircle`, and fix typo of docs in `VaProgressBar`

### DIFF
--- a/packages/docs/page-config/ui-elements/progress-bar/index.ts
+++ b/packages/docs/page-config/ui-elements/progress-bar/index.ts
@@ -37,7 +37,7 @@ export default definePageConfig({
     }),
 
     block.subtitle("Accessibility"),
-    block.paragraph("The [role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles)[[target=_blank]] of the component is [progressbar](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/progressbar_role)[[target=_blank]], the [aria-label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)[[target=_blank]] of the component is `progress-state`, if the value of the component is not indeterminate, [aria-valuenow](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuenow)[[target=_blank]] is set to the `modelValue` prop."),
+    block.paragraph("The [role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles)[[target=_blank]] of the component is [progressbar](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/progressbar_role)[[target=_blank]], the [aria-label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)[[target=_blank]] of the component is `progress state`, if the value of the component is not indeterminate, [aria-valuenow](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuenow)[[target=_blank]] is set to the `modelValue` prop."),
 
     block.subtitle("API"),
     block.api("VaProgressBar", {

--- a/packages/docs/page-config/ui-elements/progress-circle/index.ts
+++ b/packages/docs/page-config/ui-elements/progress-circle/index.ts
@@ -31,6 +31,9 @@ export default definePageConfig({
       description: "Use the `thickness` prop to adjust the stroke size."
     }),
 
+    block.subtitle("Accessibility"),
+    block.paragraph("The [role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles)[[target=_blank]] of the component is [progressbar](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/progressbar_role)[[target=_blank]], the [aria-label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)[[target=_blank]] of the component is `progress state`, if the value of the component is not indeterminate, [aria-valuenow](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuenow)[[target=_blank]] is set to the `modelValue` prop."),
+
     block.subtitle("API"),
     block.api("VaProgressCircle", {
       props: {


### PR DESCRIPTION
Add accessibility docs for `VaProgressCircle`, which fixes #3256.
Fix typo in docs of `VaProgressBar`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
