### PR TITLE
fix: make text white for examples of `accordion` and `select` in dark mode

### DIFF
--- a/packages/docs/page-config/ui-elements/accordion/examples/Menu.vue
+++ b/packages/docs/page-config/ui-elements/accordion/examples/Menu.vue
@@ -68,7 +68,6 @@ export default {
   padding: 0.5rem;
   display: flex;
   flex-direction: column;
-  color: black !important;
   transition: all 0.2s ease-in;
 
   &:hover {


### PR DESCRIPTION
The text of `Menu` example of `accordion` is black in dark mode, this pr changed it to show white.
I currently don't know what part of `select` is wrong, waiting for response from issue maker to respond.

Fixes #3604.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
