### PR TITLE
fix: added props based support for nested overlay

### DIFF
--- a/packages/ui/src/components/va-modal/VaModal.demo.vue
+++ b/packages/ui/src/components/va-modal/VaModal.demo.vue
@@ -329,12 +329,12 @@
         Show first modal
       </button>
 
-      <va-modal :isShowNestedOverlay="true" v-model="showModalNested3" :message="message" hide-default-actions>
+      <va-modal :showNestedOverlay="true" v-model="showModalNested3" :message="message" hide-default-actions>
         <button class="mt-8" @click="showModalNested4 = !showModalNested4" color="secondary">
           Show second modal
         </button>
 
-        <va-modal :isShowNestedOverlay="true" v-model="showModalNested4" :message="mediumMessage">
+        <va-modal :showNestedOverlay="true" v-model="showModalNested4" :message="mediumMessage">
           Second Modal
         </va-modal>
       </va-modal>

--- a/packages/ui/src/components/va-modal/VaModal.demo.vue
+++ b/packages/ui/src/components/va-modal/VaModal.demo.vue
@@ -334,7 +334,7 @@
           Show second modal
         </button>
 
-        <va-modal :isShowNestedOverlay="true" v-model="showModalNested4" :message="message">
+        <va-modal :isShowNestedOverlay="true" v-model="showModalNested4" :message="mediumMessage">
           Second Modal
         </va-modal>
       </va-modal>
@@ -457,6 +457,7 @@ export default {
       showModalCloseOutside: false,
       c: false,
       message: this.$vb.lorem(),
+      mediumMessage: this.$vb.lorem(50),
       longMessage: this.$vb.lorem(5000),
       collapseValue: false,
     }

--- a/packages/ui/src/components/va-modal/VaModal.demo.vue
+++ b/packages/ui/src/components/va-modal/VaModal.demo.vue
@@ -324,6 +324,21 @@
         </va-modal>
       </va-modal>
     </VbCard>
+    <VbCard title="nested modals with each overlay">
+      <button @click="showModalNested3 = !showModalNested3">
+        Show first modal
+      </button>
+
+      <va-modal :isShowNestedOverlay="true" v-model="showModalNested3" :message="message" hide-default-actions>
+        <button class="mt-8" @click="showModalNested4 = !showModalNested4" color="secondary">
+          Show second modal
+        </button>
+
+        <va-modal :isShowNestedOverlay="true" v-model="showModalNested4" :message="message">
+          Second Modal
+        </va-modal>
+      </va-modal>
+    </VbCard>
     <VbCard title="vaModal return by click">
       <button @click="buttonClick">init vaModal</button>
     </VbCard>
@@ -431,6 +446,8 @@ export default {
       showModalCustomBackground: false,
       showModalNested1: false,
       showModalNested2: false,
+      showModalNested3: false,
+      showModalNested4: false,
       showNoPaddingModal: false,
       showModalFocusTrap1: false,
       showModalFocusTrap2: false,

--- a/packages/ui/src/components/va-modal/VaModal.vue
+++ b/packages/ui/src/components/va-modal/VaModal.vue
@@ -198,6 +198,7 @@ export default defineComponent({
     withoutTransitions: { type: Boolean, default: false },
     overlay: { type: Boolean, default: true },
     overlayOpacity: { type: [Number, String], default: 0.6 },
+    isShowNestedOverlay: { type: Boolean, default: false },
     blur: { type: Boolean, default: false },
     zIndex: { type: [Number, String], default: undefined },
     backgroundColor: { type: String, default: 'background-secondary' },
@@ -242,12 +243,15 @@ export default defineComponent({
       // Supposedly solves some case when background wasn't shown.
       // As a side effect removes background from nested modals.
 
-      if (!props.overlay || !isLowestLevelModal.value) { return }
+      if (!props.overlay) { return }
 
-      return {
-        'background-color': `rgba(0, 0, 0, ${props.overlayOpacity})`,
-        'z-index': props.zIndex && Number(props.zIndex) - 1,
-      } as StyleValue
+      if (isTopLevelModal.value || props.isShowNestedOverlay) {
+        return {
+          'background-color': `rgba(0, 0, 0, ${props.overlayOpacity})`,
+          'z-index': props.zIndex && Number(props.zIndex) - 1,
+        } as StyleValue
+      }
+      return ''
     })
 
     const show = () => { valueComputed.value = true }

--- a/packages/ui/src/components/va-modal/VaModal.vue
+++ b/packages/ui/src/components/va-modal/VaModal.vue
@@ -12,7 +12,7 @@
     </div>
 
     <teleport :to="attachElement" :disabled="$props.disableAttachment">
-      <modal-element
+      <WithTransition
         name="va-modal"
         :isTransition="!$props.withoutTransitions"
         appear
@@ -112,7 +112,7 @@
             </div>
           </div>
         </div>
-      </modal-element>
+      </WithTransition>
     </teleport>
   </div>
 </template>
@@ -149,7 +149,7 @@ import { VaIcon } from '../va-icon'
 
 import { useBlur } from './hooks/useBlur'
 
-const ModalElement = defineComponent({
+const WithTransition = defineComponent({
   name: 'ModalElement',
   inheritAttrs: false,
   props: {
@@ -164,7 +164,7 @@ const ModalElement = defineComponent({
 export default defineComponent({
   name: 'VaModal',
   inheritAttrs: false,
-  components: { VaButton, VaIcon, ModalElement },
+  components: { VaButton, VaIcon, WithTransition },
   emits: [
     ...useStatefulEmits,
     'cancel', 'ok', 'before-open', 'open', 'before-close', 'close', 'click-outside',

--- a/packages/ui/src/components/va-modal/VaModal.vue
+++ b/packages/ui/src/components/va-modal/VaModal.vue
@@ -198,7 +198,7 @@ export default defineComponent({
     withoutTransitions: { type: Boolean, default: false },
     overlay: { type: Boolean, default: true },
     overlayOpacity: { type: [Number, String], default: 0.6 },
-    ShowNestedOverlay: { type: Boolean, default: false },
+    showNestedOverlay: { type: Boolean, default: false },
     blur: { type: Boolean, default: false },
     zIndex: { type: [Number, String], default: undefined },
     backgroundColor: { type: String, default: 'background-secondary' },
@@ -245,10 +245,10 @@ export default defineComponent({
 
       if (!props.overlay) { return }
 
-      if (isTopLevelModal.value || props.ShowNestedOverlay) {
+      if (isTopLevelModal.value || props.showNestedOverlay) {
         return {
           'background-color': 'var(--va-modal-overlay-color)',
-          opacity: `${props.ShowNestedOverlay ? 'var(--va-modal-overlay-nested-opacity)' : 'var(--va-modal-overlay-opacity)'} `,
+          opacity: `${props.showNestedOverlay ? 'var(--va-modal-overlay-nested-opacity)' : 'var(--va-modal-overlay-opacity)'} `,
           'z-index': props.zIndex && Number(props.zIndex) - 1,
         } as StyleValue
       }

--- a/packages/ui/src/components/va-modal/VaModal.vue
+++ b/packages/ui/src/components/va-modal/VaModal.vue
@@ -198,7 +198,7 @@ export default defineComponent({
     withoutTransitions: { type: Boolean, default: false },
     overlay: { type: Boolean, default: true },
     overlayOpacity: { type: [Number, String], default: 0.6 },
-    isShowNestedOverlay: { type: Boolean, default: false },
+    ShowNestedOverlay: { type: Boolean, default: false },
     blur: { type: Boolean, default: false },
     zIndex: { type: [Number, String], default: undefined },
     backgroundColor: { type: String, default: 'background-secondary' },
@@ -245,9 +245,10 @@ export default defineComponent({
 
       if (!props.overlay) { return }
 
-      if (isTopLevelModal.value || props.isShowNestedOverlay) {
+      if (isTopLevelModal.value || props.ShowNestedOverlay) {
         return {
-          'background-color': `rgba(0, 0, 0, ${props.overlayOpacity})`,
+          'background-color': 'var(--va-modal-overlay-color)',
+          opacity: `${props.ShowNestedOverlay ? 'var(--va-modal-overlay-nested-opacity)' : 'var(--va-modal-overlay-opacity)'} `,
           'z-index': props.zIndex && Number(props.zIndex) - 1,
         } as StyleValue
       }

--- a/packages/ui/src/components/va-modal/VaModal.vue
+++ b/packages/ui/src/components/va-modal/VaModal.vue
@@ -243,17 +243,21 @@ export default defineComponent({
       'va-modal__overlay--lowest': isLowestLevelModal.value,
       'va-modal__overlay--top': isTopLevelModal.value,
     }))
-    const computedOverlayStyles = computed(() => {
-      // NOTE Not sure exactly what that does.
-      // Supposedly solves some case when background wasn't shown.
-      // As a side effect removes background from nested modals.
 
+    const getOverlayOpacity = () => {
+      if (props.showNestedOverlay && !isLowestLevelModal.value) {
+        return 'var(--va-modal-overlay-nested-opacity)'
+      }
+      return 'var(--va-modal-overlay-opacity)'
+    }
+
+    const computedOverlayStyles = computed(() => {
       if (!props.overlay) { return }
 
       if (isTopLevelModal.value || props.showNestedOverlay) {
         return {
           'background-color': 'var(--va-modal-overlay-color)',
-          opacity: `${props.showNestedOverlay ? 'var(--va-modal-overlay-nested-opacity)' : 'var(--va-modal-overlay-opacity)'} `,
+          opacity: getOverlayOpacity(),
           'z-index': props.zIndex && Number(props.zIndex) - 1,
         } as StyleValue
       }

--- a/packages/ui/src/components/va-modal/VaModal.vue
+++ b/packages/ui/src/components/va-modal/VaModal.vue
@@ -23,11 +23,12 @@
         @beforeLeave="onBeforeLeaveTransition"
         @afterLeave="onAfterLeaveTransition"
       >
-        <div class="va-modal" v-if="valueComputed">
+        <div class="va-modal" :class="computedClass" v-if="valueComputed">
           <div
             v-if="$props.overlay"
             class="va-modal__overlay"
             :style="computedOverlayStyles"
+            :class="computedOverlayClass"
           />
           <div
             class="va-modal__container"
@@ -36,7 +37,6 @@
             <div
               ref="modalDialog"
               class="va-modal__dialog"
-              :class="computedClass"
               :style="computedDialogStyle"
             >
               <va-icon
@@ -238,6 +238,11 @@ export default defineComponent({
       color: textColorComputed.value,
       background: getColor(props.backgroundColor),
     }))
+
+    const computedOverlayClass = computed(() => ({
+      'va-modal__overlay--lowest': isLowestLevelModal.value,
+      'va-modal__overlay--top': isTopLevelModal.value,
+    }))
     const computedOverlayStyles = computed(() => {
       // NOTE Not sure exactly what that does.
       // Supposedly solves some case when background wasn't shown.
@@ -366,6 +371,9 @@ export default defineComponent({
     }
 
     return {
+      isLowestLevelModal,
+      isTopLevelModal,
+      computedOverlayClass,
       getColor,
       rootElement,
       modalDialog,
@@ -448,57 +456,75 @@ export default defineComponent({
     z-index: var(--va-modal-overlay-z-index);
     width: var(--va-modal-overlay-width);
     height: var(--va-modal-overlay-height);
+    will-change: opacity;
   }
 
-  &-enter-from &__overlay,
-  &-leave-to &__overlay {
-    opacity: 0;
+  &-enter-from,
+  &-leave-to {
+    .va-modal__overlay--lowest {
+      opacity: 0 !important;
+    }
   }
 
-  &-enter-active &__overlay,
-  &-leave-active &_overlay {
-    transition: var(--va-modal-overlay-opacity-transition);
+  &-leave-active, &-enter-active {
+    .va-modal__overlay.va-modal__overlay--lowest {
+      transition: opacity var(--va-modal-opacity-transition);
+    }
+  }
+
+  &-leave-active {
+    .va-modal__overlay:not(.va-modal__overlay--lowest) {
+      display: none;
+    }
   }
 
   &--fullscreen {
-    min-width: 100vw !important;
-    max-width: 100vw;
-    min-height: 100vh !important;
-    border-radius: 0;
-    margin: 0;
+    .va-modal__dialog {
+      min-width: 100vw !important;
+      max-width: 100vw;
+      min-height: 100vh !important;
+      border-radius: 0;
+      margin: 0;
+    }
   }
 
   &--mobile-fullscreen {
-    @media all and (max-width: map-get($grid-breakpoints, sm)) {
-      margin: 0 !important;
-      min-width: 100vw !important;
-      min-height: 100vh !important;
-      border-radius: 0;
+    .va-modal__dialog {
+      @media all and (max-width: map-get($grid-breakpoints, sm)) {
+        margin: 0 !important;
+        min-width: 100vw !important;
+        min-height: 100vh !important;
+        border-radius: 0;
+      }
     }
   }
 
   &--size {
     &-small {
-      max-width: map_get($grid-breakpoints, sm);
-
-      @media all and (max-width: map-get($grid-breakpoints, sm)) {
-        max-width: 100vw !important;
-      }
-
-      .va-modal__inner {
+      .va-modal__dialog {
         max-width: map_get($grid-breakpoints, sm);
 
         @media all and (max-width: map-get($grid-breakpoints, sm)) {
           max-width: 100vw !important;
         }
+
+        .va-modal__inner {
+          max-width: map_get($grid-breakpoints, sm);
+
+          @media all and (max-width: map-get($grid-breakpoints, sm)) {
+            max-width: 100vw !important;
+          }
+        }
       }
     }
 
     &-large {
-      max-width: map-get($grid-breakpoints, lg);
-
-      .va-modal__inner {
+      .va-modal__dialog {
         max-width: map-get($grid-breakpoints, lg);
+
+        .va-modal__inner {
+          max-width: map-get($grid-breakpoints, lg);
+        }
       }
     }
   }

--- a/packages/ui/src/components/va-modal/_variables.scss
+++ b/packages/ui/src/components/va-modal/_variables.scss
@@ -43,7 +43,7 @@
   --va-modal-overlay-opacity-transition: opacity math.div(2 * var(--va-modal-basic-duration), 3) cubic-bezier(1, 0.5, 0.8, 1);
   --va-modal-overlay-color: rgb(0, 0, 0);
   --va-modal-overlay-opacity: 0.6;
-  --va-modal-overlay-nested-opacity: 0.9;
+  --va-modal-overlay-nested-opacity: 0.1;
 
   /* Footer */
   --va-modal-footer-justify-content: flex-end;

--- a/packages/ui/src/components/va-modal/_variables.scss
+++ b/packages/ui/src/components/va-modal/_variables.scss
@@ -41,6 +41,9 @@
   --va-modal-overlay-width: 100vw;
   --va-modal-overlay-height: 100vh;
   --va-modal-overlay-opacity-transition: opacity math.div(2 * var(--va-modal-basic-duration), 3) cubic-bezier(1, 0.5, 0.8, 1);
+  --va-modal-overlay-color: rgb(0, 0, 0);
+  --va-modal-overlay-opacity: 0.6;
+  --va-modal-overlay-nested-opacity: 0.9;
 
   /* Footer */
   --va-modal-footer-justify-content: flex-end;

--- a/packages/ui/src/components/va-modal/_variables.scss
+++ b/packages/ui/src/components/va-modal/_variables.scss
@@ -40,7 +40,7 @@
   --va-modal-overlay-z-index: calc(var(--va-modal-container-z-index) - 1);
   --va-modal-overlay-width: 100vw;
   --va-modal-overlay-height: 100vh;
-  --va-modal-overlay-opacity-transition: opacity math.div(2 * var(--va-modal-basic-duration), 3) cubic-bezier(1, 0.5, 0.8, 1);
+  --va-modal-overlay-opacity-transition: opacity calc(2 * var(--va-modal-basic-duration) / 3) cubic-bezier(1, 0.5, 0.8, 1);
   --va-modal-overlay-color: rgb(0, 0, 0);
   --va-modal-overlay-opacity: 0.6;
   --va-modal-overlay-nested-opacity: 0.1;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Added a props `isShowNestedOverlay` props by default, this props is set to 'false'. When you enable it for a modal, an overlay will be displayed for that modal and will not get removed in any case.
<!-- Describe your changes in detail -->

Discussion : #1870 


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
