### PR TITLE
fix: Change icon name in VaInnerLoading

### DIFF
--- a/packages/ui/src/components/va-inner-loading/VaInnerLoading.vue
+++ b/packages/ui/src/components/va-inner-loading/VaInnerLoading.vue
@@ -36,7 +36,7 @@ export default defineComponent({
     ...useLoadingProps,
     ...useComponentPresetProp,
     color: { type: String },
-    icon: { type: String, default: 'autorenew' },
+    icon: { type: String, default: 'va-loading' },
     size: { type: Number, default: 30 },
   },
   setup (props) {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
In VaInnerLoading component the icon name autorenew was changed to va-loading.
closes #3830 

## Markup:
<!-- Paste your markup here. -->
<details>

```vue

   - icon: { type: String, default: 'autorenew' },
   + icon: { type: String, default: 'va-loading' },

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
