### PR TITLE
fix(va-avatar-group): render avatar group with rest count based on max prop

### DIFF
--- a/packages/ui/src/components/va-avatar-group/VaAvatarGroup.stories.ts
+++ b/packages/ui/src/components/va-avatar-group/VaAvatarGroup.stories.ts
@@ -28,11 +28,6 @@ export const Default = () => ({
     <va-avatar-group :options="avatars"/>
   `,
 })
-addText(
-  Default,
-  'This looks very broken - why do we have +3 even though we have 3 avatars?',
-  'broken',
-)
 
 export const RestColor = () => ({
   components: { VaAvatarGroup },
@@ -40,7 +35,10 @@ export const RestColor = () => ({
     avatars: getAvatars(),
   }),
   template: `
-    <va-avatar-group :options="avatars" restColor="warning"/>
+    <strong>[secondary]</strong>
+    <va-avatar-group :options="avatars" :max="2"/>
+    <strong>[warning]</strong>
+    <va-avatar-group :options="avatars" restColor="warning" :max="2"/>
   `,
 })
 
@@ -50,19 +48,16 @@ export const Max = () => ({
     avatars: getAvatars(),
   }),
   template: `
-    [2]
+    <strong>[0]</strong>
+    <va-avatar-group :options="avatars"/>
+    <strong>[1]</strong>
+    <va-avatar-group :options="avatars" :max="1"/>
+    <strong>[2]</strong>
     <va-avatar-group :options="avatars" :max="2"/>
-    [3]
+    <strong>[3]</strong>
     <va-avatar-group :options="avatars" :max="3"/>
-    [4]
-    <va-avatar-group :options="avatars" :max="4"/>
   `,
 })
-addText(
-  Max,
-  '+-3 o.o?',
-  'broken',
-)
 
 export const Vertical = () => ({
   components: { VaAvatarGroup },

--- a/packages/ui/src/components/va-avatar-group/VaAvatarGroup.vue
+++ b/packages/ui/src/components/va-avatar-group/VaAvatarGroup.vue
@@ -10,7 +10,7 @@
       v-bind="{ ...avatarProps, ...option }"
       role="listitem"
     />
-    <slot name="rest" v-bind="avatarProps">
+    <slot v-if="restOptionsCount > 0" name="rest" v-bind="avatarProps">
       <va-avatar
         v-bind="avatarProps"
         :color="restColor"
@@ -72,7 +72,7 @@ export default defineComponent({
 
     const maxOptions = computed(() => props.max && props.max <= props.options.length ? props.options.slice(0, props.max) : props.options)
     const visibleItemsCount = computed(() => props.max ? props.max + 1 : 1)
-    const restOptionsCount = computed(() => props.options.length - (props.max || 0))
+    const restOptionsCount = computed(() => props.options.length > 0 && maxOptions.value.length < props.options.length ? props.options.length - (props.max || 0) : 0)
     const { sizeComputed, fontSizeComputed } = useSize(props, 'VaAvatarGroup')
 
     const filteredAvatarProps = filterComponentProps(VaAvatarProps)

--- a/packages/ui/src/components/va-avatar-group/VaAvatarGroup.vue
+++ b/packages/ui/src/components/va-avatar-group/VaAvatarGroup.vue
@@ -48,7 +48,7 @@ export default defineComponent({
 
     max: {
       type: Number,
-      default: undefined,
+      default: 0,
     },
     vertical: {
       type: Boolean,
@@ -72,7 +72,13 @@ export default defineComponent({
 
     const maxOptions = computed(() => props.max && props.max <= props.options.length ? props.options.slice(0, props.max) : props.options)
     const visibleItemsCount = computed(() => props.max ? props.max + 1 : 1)
-    const restOptionsCount = computed(() => props.options.length > 0 && maxOptions.value.length < props.options.length ? props.options.length - (props.max || 0) : 0)
+    const restOptionsCount = computed(() => {
+      const hasOptions = props.options.length > 0
+      const canAddMoreOptions = maxOptions.value.length < props.options.length
+      const remainingOptions = props.options.length - (props.max || 0)
+
+      return hasOptions && canAddMoreOptions ? remainingOptions : 0
+    })
     const { sizeComputed, fontSizeComputed } = useSize(props, 'VaAvatarGroup')
 
     const filteredAvatarProps = filterComponentProps(VaAvatarProps)

--- a/packages/ui/src/components/va-avatar-group/VaAvatarGroup.vue
+++ b/packages/ui/src/components/va-avatar-group/VaAvatarGroup.vue
@@ -70,7 +70,7 @@ export default defineComponent({
       ...pick(props, ['vertical']),
     }))
 
-    const maxOptions = computed(() => props.options.slice(0, props.max))
+    const maxOptions = computed(() => props.max && props.max <= props.options.length ? props.options.slice(0, props.max) : props.options)
     const visibleItemsCount = computed(() => props.max ? props.max + 1 : 1)
     const restOptionsCount = computed(() => props.options.length - (props.max || 0))
     const { sizeComputed, fontSizeComputed } = useSize(props, 'VaAvatarGroup')


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail -->

partial  #3879 

However this PR does not fix the storybook edits ( #3800 ) that described the issue

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
