### PR TITLE
fix(textarea): resize with height

### DIFF
--- a/packages/ui/src/components/va-input-wrapper/VaInputWrapper.demo.vue
+++ b/packages/ui/src/components/va-input-wrapper/VaInputWrapper.demo.vue
@@ -190,6 +190,16 @@ const date = getStaticDate()
         <div style="width: 100%;">
           <VaInputWrapper label="Label Label Label Label Label Label Label Label Label Label Label Label Label " />
         </div>
+
+        <label>Large height div</label>
+        <div style="height: 100px;">
+          <VaInputWrapper label="Label Label Label Label Label Label Label Label Label Label Label Label Label " />
+        </div>
+
+        <label>Large height va-input</label>
+        <div>
+          <VaInputWrapper style="height: 100px;" label="Label Label Label Label Label Label Label Label Label Label Label Label Label " />
+        </div>
       </div>
     </VbCard>
   </VbDemo>

--- a/packages/ui/src/components/va-input-wrapper/VaInputWrapper.vue
+++ b/packages/ui/src/components/va-input-wrapper/VaInputWrapper.vue
@@ -257,12 +257,14 @@ export default defineComponent({
 
     display: flex;
     flex-direction: column;
+    height: 100%;
   }
 
   &__container {
     display: flex;
     align-items: center;
     gap: var(--va-input-content-items-gap);
+    flex: 1;
   }
 
   &__field {
@@ -280,6 +282,7 @@ export default defineComponent({
     z-index: 0;
     overflow: hidden;
     color: v-bind(textColorComputed);
+    align-self: stretch;
 
     @include va-background(var(--va-input-wrapper-background), var(--va-input-wrapper-background-opacity), -1);
 
@@ -307,6 +310,7 @@ export default defineComponent({
     min-height: var(--va-input-line-height);
     display: flex;
     align-items: center;
+    align-self: stretch;
     overflow: hidden;
     caret-color: var(--va-input-wrapper-text-color);
     color: var(--va-input-wrapper-text-color);
@@ -328,6 +332,7 @@ export default defineComponent({
       font-stretch: var(--va-input-font-stretch);
       letter-spacing: var(--va-input-letter-spacing);
       cursor: inherit;
+      align-self: stretch;
 
       &::placeholder {
         color: inherit;
@@ -377,7 +382,6 @@ export default defineComponent({
   // styles
   &--labeled-inner {
     .va-input-wrapper__text {
-      height: 100%;
       padding-top: 12px;
       box-sizing: content-box;
     }

--- a/packages/ui/src/components/va-textarea/VaTextarea.stories.ts
+++ b/packages/ui/src/components/va-textarea/VaTextarea.stories.ts
@@ -98,3 +98,9 @@ export const CounterSlot = () => ({
   </VaTextarea>
 `,
 })
+
+export const CustomHeight = () => ({
+  components: { VaTextarea },
+  data: () => ({ value: 'Lorem Ipsum' }),
+  template: '<VaTextarea style="height: 300px" :max-length="30" v-model="value" />',
+})

--- a/packages/ui/src/components/va-textarea/VaTextarea.vue
+++ b/packages/ui/src/components/va-textarea/VaTextarea.vue
@@ -175,6 +175,7 @@ export default defineComponent({
     display: flex;
     overflow: hidden;
     width: 100%;
+    align-self: stretch;
 
     &--resizable {
       resize: vertical;


### PR DESCRIPTION
closes https://github.com/epicmaxco/vuestic-ui/issues/3901

Textarea:
<img width="380" alt="image" src="https://github.com/epicmaxco/vuestic-ui/assets/23530004/dd0e6db5-d67a-4296-a983-5fa7c8033267">

Input:
<img width="335" alt="image" src="https://github.com/epicmaxco/vuestic-ui/assets/23530004/05637ebe-b08f-4e02-8bf2-4cfd75a1dbd2">
