### PR TITLE
fix(web-components): styles and cache issue

### DIFF
--- a/packages/sandbox/web-components/src/main.ts
+++ b/packages/sandbox/web-components/src/main.ts
@@ -1,8 +1,5 @@
-import { createApp } from 'vue';
 import { registerVuesticWebComponents } from 'vuestic-ui/web-components'
 import 'vuestic-ui/css'
-import App from './App.vue'
-import { createI18n } from 'vue-i18n'
 import demos from './demos'
 
 const demosEl = document.querySelector('.demos')
@@ -10,13 +7,5 @@ const demosEl = document.querySelector('.demos')
 demos.forEach((demo) => {
   demosEl.appendChild(demo)
 })
-
-
-export const i18n = createI18n({
-  locale: 'en',
-  fallbackLocale: 'en',
-  messages: {},
-})
-
 
 registerVuesticWebComponents({})

--- a/packages/ui/build/configs/vite.web-components.ts
+++ b/packages/ui/build/configs/vite.web-components.ts
@@ -50,6 +50,7 @@ export default () => defineConfig({
   plugins: [
     vue({
       customElement: true,
+      isProduction: true,
     }),
     chunkSplitPlugin({ strategy: 'unbundle' }),
     removeSideEffectedChunks(),

--- a/packages/ui/build/plugins/web-components-nested-styles.ts
+++ b/packages/ui/build/plugins/web-components-nested-styles.ts
@@ -33,6 +33,10 @@ const generateComponentStylesAccessCode = (list: string[]) => {
   return list.map((name) => [`...(${name}.styles || [])`]).join(', ')
 }
 
+const generateComponentStyles = (sfcMain: string) => {
+  return `...(${sfcMain}.components ? Object.values(${sfcMain}.components) : []).map((c) => c.styles || []).flat()`
+}
+
 /** Merge styles to custom element from child components */
 export const webComponentsNestedStyles = createDistTransformPlugin({
   name: 'vuestic:web-components-nested-styles',
@@ -40,22 +44,30 @@ export const webComponentsNestedStyles = createDistTransformPlugin({
   dir: (outDir) => `${outDir}/src/components`,
 
   transform: async (componentContent) => {
-    /** Component store own styles from `<style>` in variables with `_style_` prefix */
+    // /** Component store own styles from `<style>` in variables with `_style_` prefix */
     const vars = [...componentContent.matchAll(/[const|var] (_style_.*) = /gm)].map(([a, b]) => b)
 
-    const componentList = getComponentsList(componentContent)
+    // const componentList = getComponentsList(componentContent)
 
-    if (componentList.length === 0) { return }
+    // if (componentList.length === 0) { return }
 
     return componentContent
-      // Might be with styles or without styles
       // _export_sfc(_sfc_main, [["render", _sfc_render], ["styles", [/* variables */]]])
-      .replace(/_export_sfc\(.*, \["styles", \[(.*)\]\]\]\)/, (str, substr) => {
-        return str.replace(substr, generateComponentStylesAccessCode(componentList) + ', ' + vars.join(', '))
+      .replace(/_export_sfc\((\w*).*, \["styles", \[(.*)\]\]\]\)/, (str, sfcMain, substr) => {
+        return str.replace(substr, generateComponentStyles(sfcMain) + ', ' + vars.join(', '))
       })
       // _export_sfc(_sfc_main, [["render", _sfc_render]])
-      .replace(/_export_sfc\(.*(\[\["render", _sfc_render\]\])\)/, (str, substr) => {
-        return str.replace(substr, `[["render", _sfc_render], ["styles", [${generateComponentStylesAccessCode(componentList)}, ${vars.join(', ')}]]]`)
+      .replace(/_export_sfc\((\w*).*(\[\["render", _sfc_render\]\])\)/, (str, sfcMain, substr) => {
+        return str.replace(substr, `[["render", _sfc_render], ["styles", [${generateComponentStyles(sfcMain)}]]]`)
       })
+      // // Might be with styles or without styles
+      // // _export_sfc(_sfc_main, [["render", _sfc_render], ["styles", [/* variables */]]])
+      // .replace(/_export_sfc\(.*, \["styles", \[(.*)\]\]\]\)/, (str, substr) => {
+      //   return str.replace(substr, generateComponentStylesAccessCode(componentList) + ', ' + vars.join(', '))
+      // })
+      // // _export_sfc(_sfc_main, [["render", _sfc_render]])
+      // .replace(/_export_sfc\(.*(\[\["render", _sfc_render\]\])\)/, (str, substr) => {
+      //   return str.replace(substr, `[["render", _sfc_render], ["styles", [${generateComponentStylesAccessCode(componentList)}, ${vars.join(', ')}]]]`)
+      // })
   },
 })

--- a/packages/ui/src/components/va-dropdown/VaDropdown.vue
+++ b/packages/ui/src/components/va-dropdown/VaDropdown.vue
@@ -110,6 +110,17 @@ export default defineComponent({
         return target.value
       }
 
+      if (anchor.value) {
+        const root = anchor.value.getRootNode()
+        if (root instanceof ShadowRoot) {
+          const el = [...root.children].find((c) => c.tagName !== 'STYLE')
+
+          if (el) {
+            return el as HTMLElement
+          }
+        }
+      }
+
       return body.value
     })
 

--- a/packages/ui/src/composables/useCache.ts
+++ b/packages/ui/src/composables/useCache.ts
@@ -1,11 +1,14 @@
 import { inject } from '../services/current-app'
 import { VaAppCachePluginKey } from '../services/cache/plugin/index'
+import { AppCache } from '../services/cache/types'
 
-export const useCache = () => {
+export const useCache = (): AppCache => {
   const cache = inject(VaAppCachePluginKey)
 
   if (!cache) {
-    throw new Error('Vuestic cache plugin is not registered!')
+    return {
+      colorContrast: {},
+    }
   }
 
   return cache

--- a/packages/ui/src/composables/useComponentUuid.ts
+++ b/packages/ui/src/composables/useComponentUuid.ts
@@ -3,5 +3,10 @@ import { getCurrentInstance } from 'vue'
 export const useComponentUuid = () => {
   const vm = getCurrentInstance()!
 
+  // WebComponents build
+  if (!vm.appContext.app) {
+    return vm.uid
+  }
+
   return vm.uid + vm.appContext.app._uid
 }

--- a/packages/ui/src/composables/useCurrentComponentId.ts
+++ b/packages/ui/src/composables/useCurrentComponentId.ts
@@ -2,6 +2,12 @@ import { getCurrentInstance } from 'vue'
 
 export const useCurrentComponentId = () => {
   const instance = getCurrentInstance()!
+
+  // WebComponents build
+  if (!instance.appContext.app) {
+    return String(instance.uid)
+  }
+
   // Return ID with app, so it will be unique for each vue app
   return `${instance.appContext.app._uid}_${instance.uid}`
 }

--- a/packages/ui/src/services/cache/plugin/index.ts
+++ b/packages/ui/src/services/cache/plugin/index.ts
@@ -10,7 +10,6 @@ export const CachePlugin = defineVuesticPlugin(() => ({
   install (app) {
     const cache: AppCache = {
       colorContrast: {},
-      bgTempCache: new TempMap(),
     }
 
     app.provide(VaAppCachePluginKey, cache)

--- a/packages/ui/src/services/cache/types.ts
+++ b/packages/ui/src/services/cache/types.ts
@@ -1,6 +1,3 @@
-import { TempMap } from '../../utils/temp-map'
-
 export type AppCache = {
   colorContrast: Record<string, number>,
-  bgTempCache: TempMap<HTMLElement, string>,
 }


### PR DESCRIPTION
There was a regression after updating vue compiler, components: {} changed to resolveComponent, so we need a different mechanism for nested styles. Also, there was issue with unregistered cache plugin, we just mock it with empty object in web components, cuz we're not able to register any vue plugin here to store cache globally. Maybe we can move cache to window, but I don't care about it for now.