### PR TITLE
fix/3930 Vabutton now has padding with 2 icons as well as 1 (preset = primary)

### DIFF
--- a/packages/ui/src/components/va-button/VaButton.demo.vue
+++ b/packages/ui/src/components/va-button/VaButton.demo.vue
@@ -172,7 +172,7 @@
           <td>
             <va-button border-color="primary" preset="primary" icon="create">Secondary</va-button>
             <va-button border-color="primary" preset="secondary" iconRight="clear">Secondary</va-button>
-            <va-button border-color="primary" preset="plain" icon="create" iconRight="clear">
+            <va-button border-color="primary" preset="primary" icon="create" iconRight="clear">
               Secondary
             </va-button>
           </td>

--- a/packages/ui/src/components/va-button/VaButton.demo.vue
+++ b/packages/ui/src/components/va-button/VaButton.demo.vue
@@ -168,13 +168,9 @@
         </tr>
 
         <tr>
-          <td>Outline Buttons</td>
+          <td>Border Color</td>
           <td>
-            <va-button border-color="primary" preset="primary" icon="create">Secondary</va-button>
-            <va-button border-color="primary" preset="secondary" iconRight="clear">Secondary</va-button>
-            <va-button border-color="primary" preset="primary" icon="create" iconRight="clear">
-              Secondary
-            </va-button>
+            <va-button border-color="primary" :backgroundOpacity="0">Button</va-button>
           </td>
         </tr>
 


### PR DESCRIPTION
close #3930

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail -->
After reviewing the code base and attempting to create JavaScript logic in order to allow padding for the presence of both icon and icon right inside of a Vabutton component, I realized a simpler fix. I read over the documentation and saw that the Vabutton presets prop was able to allow the button to have both icons with padding as long as the preset was set to "primary" instead of "plain". In the end, this is all I changed in the demo file. When creating future Vabuttons it could be noted that if the user wants to have 2 icons they must use the primary preset and not the plain preset.

## Markup:
<!-- Paste your markup here. -->
<details>

```vue
// Your code
lines 175-177 in Vabutton.demo.vue

<va-button border-color="primary" preset="primary" icon="create" iconRight="clear">
              Secondary
            </va-button>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
