### PR TITLE
Fix: Overflow behaviour of VaCollapse

### DIFF
--- a/packages/ui/src/components/va-collapse/VaCollapse.stories.ts
+++ b/packages/ui/src/components/va-collapse/VaCollapse.stories.ts
@@ -1,12 +1,36 @@
+import { StoryFn } from '@storybook/vue3'
 import { defineComponent } from 'vue'
-import VaCollapse from './VaCollapse.demo.vue'
+import VaCollapseDemo from './VaCollapse.demo.vue'
+import { VaCollapse } from './index'
+import { userEvent } from '@storybook/testing-library'
+import { expect } from '@storybook/jest'
 
 export default {
   title: 'VaCollapse',
   component: VaCollapse,
+  tags: ['autodocs'],
 }
 
-export const Default = defineComponent({
+export const OldDemos = () => defineComponent({
+  components: { VaCollapseDemo },
+  template: '<VaCollapseDemo />',
+})
+
+export const Overflow: StoryFn = () => defineComponent({
   components: { VaCollapse },
-  template: '<VaCollapse/>',
+
+  data: () => ({ open: true }), // Open be default
+
+  template: `
+    <VaCollapse v-model="open" style="width: 200px; height: 300px; border: 1px solid red;">
+      <template #header-content>
+        <div style="border: 1px solid blue">Header</div>
+      </template>
+      <template #content>
+        <div style="height: 600px; width: 300px; background: var(--va-primary); color: var(--va-on-primary);">
+          Content
+        </div>
+      </template>
+    </VaCollapse>
+  `,
 })

--- a/packages/ui/src/components/va-collapse/VaCollapse.vue
+++ b/packages/ui/src/components/va-collapse/VaCollapse.vue
@@ -224,7 +224,7 @@ export default defineComponent({
 
   &__body-wrapper {
     transition: var(--va-collapse-body-wrapper-transition);
-    overflow: scroll;
+    overflow: auto;
 
     &--bordered {
       border-bottom: 1px solid var(--va-background-border);

--- a/packages/ui/src/components/va-collapse/VaCollapse.vue
+++ b/packages/ui/src/components/va-collapse/VaCollapse.vue
@@ -57,6 +57,7 @@
         'va-collapse__body-wrapper--bordered': !$slots.body && !$slots.header,
       }"
       :style="contentStyle"
+      @transitionend="onTransitionEnd"
     >
       <div
         class="va-collapse__body"
@@ -78,7 +79,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref, shallowRef } from 'vue'
+import { computed, defineComponent, ref, shallowRef, watch } from 'vue'
 import pick from 'lodash/pick.js'
 
 import {
@@ -166,12 +167,27 @@ export default defineComponent({
       role: 'button',
     }))
 
+    const isHeightChanging = ref(false)
+
+    watch(height, (newValue, oldValue) => {
+      // If no transition happened, just got initial height value
+      if (oldValue === undefined) { return }
+      isHeightChanging.value = true
+    })
+
+    const onTransitionEnd = (e: TransitionEvent) => {
+      if (e.propertyName === 'height' && e.target === e.currentTarget) {
+        isHeightChanging.value = false
+      }
+    }
+
     const computedClasses = useBem('va-collapse', () => ({
       ...pick(props, ['disabled']),
       expanded: computedModelValue.value,
       active: computedModelValue.value,
       popout: !!(accordionProps.value.popout && computedModelValue.value),
       inset: !!(accordionProps.value.inset && computedModelValue.value),
+      'height-changing': isHeightChanging.value,
       'colored-body': Boolean(contentBackground.value),
       'colored-header': Boolean(headerBackground.value),
     }))
@@ -182,6 +198,7 @@ export default defineComponent({
     }
 
     return {
+      onTransitionEnd,
       body,
       height,
 
@@ -303,6 +320,14 @@ export default defineComponent({
 
   &--disabled {
     @include va-disabled();
+  }
+
+  &--height-changing {
+    .va-collapse {
+      &__body-wrapper {
+        overflow: hidden;
+      }
+    }
   }
 }
 </style>

--- a/packages/ui/src/components/va-collapse/VaCollapse.vue
+++ b/packages/ui/src/components/va-collapse/VaCollapse.vue
@@ -224,7 +224,7 @@ export default defineComponent({
 
   &__body-wrapper {
     transition: var(--va-collapse-body-wrapper-transition);
-    overflow: hidden;
+    overflow: scroll;
 
     &--bordered {
       border-bottom: 1px solid var(--va-background-border);

--- a/packages/ui/src/components/va-collapse/VaCollapse.vue
+++ b/packages/ui/src/components/va-collapse/VaCollapse.vue
@@ -221,6 +221,8 @@ export default defineComponent({
 .va-collapse {
   transition: var(--va-collapse-transition, var(--va-swing-transition));
   font-family: var(--va-font-family);
+  display: flex;
+  flex-direction: column;
 
   &__body-wrapper {
     transition: var(--va-collapse-body-wrapper-transition);
@@ -228,6 +230,7 @@ export default defineComponent({
 
     &--bordered {
       border-bottom: 1px solid var(--va-background-border);
+      box-sizing: content-box;
 
       .va-collapse--colored-header:not(.va-collapse--expanded) & {
         border-bottom: none;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->
closes #3931 

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->
Fix overflow behaviour of VaCollapse
## Description
<!-- Describe your changes in detail -->
The VaCollapse body wrapper had a overflow hidden which would have been causing the extra content to be clipped. Changed the overflow behaviour to auto so that users will get a scrollbar when the size exceeds more than allotted.
## Markup:
<!-- Paste your markup here. -->
<details>

```vue
&__body-wrapper {
    transition: var(--va-collapse-body-wrapper-transition);
    overflow: scroll;   // Changed this to scroll from hidden

    &--bordered {
      border-bottom: 1px solid var(--va-background-border);

      .va-collapse--colored-header:not(.va-collapse--expanded) & {
        border-bottom: none;
      }

      .va-collapse--colored-body.va-collapse--expanded & {
        border-bottom: none;
      }
    }
  }
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
