### PR TITLE
fix(build#3955): append css to template block if component doesn't ha…

### DIFF
--- a/packages/ui/build/common-config.ts
+++ b/packages/ui/build/common-config.ts
@@ -35,6 +35,12 @@ export const resolve = {
   },
 }
 
+const rollupOutputOptions = {
+  entryFileNames: '[name].mjs',
+  chunkFileNames: '[name].mjs',
+  assetFileNames: '[name].[ext]',
+}
+
 const rollupMjsBuildOptions: RollupOptions = {
   input: resolver(process.cwd(), 'src/main.ts'),
 
@@ -42,9 +48,7 @@ const rollupMjsBuildOptions: RollupOptions = {
     sourcemap: true,
     dir: 'dist/esm-node',
     format: 'esm',
-    entryFileNames: '[name].mjs',
-    chunkFileNames: '[name].mjs',
-    assetFileNames: '[name].[ext]',
+    ...rollupOutputOptions,
   },
 }
 
@@ -76,17 +80,7 @@ export default function createViteConfig (format: BuildFormat) {
       // target: 'esnext',
 
       // default esbuild, not available for esm format in lib mode
-      minify: 'terser',
-
-      terserOptions: {
-        // https://stackoverflow.com/questions/57720816/rails-webpacker-terser-keep-fnames
-
-        // disable mangling class names (for vue class component)
-        keep_classnames: true,
-
-        // disable mangling functions names
-        keep_fnames: true,
-      },
+      minify: isEsm ? false : 'esbuild',
 
       lib: libBuildOptions(isNode ? 'es' : format),
     },
@@ -105,7 +99,14 @@ export default function createViteConfig (format: BuildFormat) {
   isEsm && config.plugins.push(removeSideEffectedChunks())
   isEsm && config.plugins.push(componentVBindFix())
 
-  config.build.rollupOptions = isNode ? { ...external, ...rollupMjsBuildOptions } : external
+  if (isNode) {
+    config.build.rollupOptions = { ...external, ...rollupMjsBuildOptions }
+  } else {
+    config.build.rollupOptions = {
+      ...external,
+      output: rollupOutputOptions,
+    }
+  }
 
   return config
 }

--- a/packages/ui/build/common-config.ts
+++ b/packages/ui/build/common-config.ts
@@ -35,7 +35,7 @@ export const resolve = {
   },
 }
 
-const rollupOutputOptions = {
+const rollupOutputOptions: RollupOptions['output'] = {
   entryFileNames: '[name].mjs',
   chunkFileNames: '[name].mjs',
   assetFileNames: '[name].[ext]',

--- a/packages/ui/build/plugins/append-component-css.ts
+++ b/packages/ui/build/plugins/append-component-css.ts
@@ -13,16 +13,35 @@ const parsePath = (path: string) => {
 }
 
 /**
- * Checks if file is Vuestic component script source
- * Component always have script which is stored in file with name like Va[ComponentName].vue_vue_type_script_lang
+ * Checks if file is Vuestic component template source
+ * If file is script source, but there is not template then add css to script.
+ * Component usually have script which is stored in file with name like Va[ComponentName].vue_vue_type_script_lang
+ *
+ * @notice Component can have render function without template block. It also can have only template without script block.
  */
 const isVuesticComponent = (filename: string) => {
-  // Va[ComponentName]-[hash].mjs
-  return /Va\w*-\w*\.mjs$/.test(filename)
+  // Va[ComponentName].vue_vue_type_script_lang.mjs
+  const isScriptFile = /Va\w*.vue_vue_type_script_lang.mjs$/.test(filename)
+
+  if (isScriptFile) {
+    return true
+  }
+
+  // Va[ComponentName].mjs
+  const isTemplateFile = /Va\w*\.mjs$/.test(filename)
+
+  // Va[ComponentName].vue_vue_type_script_lang.mjs
+  const scriptFilePath = filename.replace('.mjs', '.vue_vue_type_script_lang.mjs')
+
+  if (isTemplateFile && !existsSync(scriptFilePath)) {
+    return true
+  }
+
+  return false
 }
 
 const extractVuesticComponentName = (filename: string) => {
-  return filename.match(/(Va\w*)-\w*/)?.[1]
+  return filename.match(/(Va\w*)/)?.[1]
 }
 
 const SOURCE_MAP_COMMENT_FRAGMENT = '//# sourceMappingURL='

--- a/packages/ui/build/plugins/append-component-css.ts
+++ b/packages/ui/build/plugins/append-component-css.ts
@@ -21,8 +21,8 @@ const parsePath = (path: string) => {
  */
 const isVuesticComponent = (filename: string) => {
   // Va[ComponentName].vue_vue_type_script_lang.mjs
-  const isScriptFile = /Va\w*.vue_vue_type_script_lang.mjs$/.test(filename)
-
+  // Va[ComponentName].vue_vue_type_script_setup_true_lang.mjs
+  const isScriptFile = /Va\w*.vue_vue_type_script\w*_lang.mjs$$/.test(filename)
   if (isScriptFile) {
     return true
   }
@@ -32,8 +32,11 @@ const isVuesticComponent = (filename: string) => {
 
   // Va[ComponentName].vue_vue_type_script_lang.mjs
   const scriptFilePath = filename.replace('.mjs', '.vue_vue_type_script_lang.mjs')
+  const scriptSetupFilePath = filename.replace('.mjs', '.vue_vue_type_script_setup_true_lang.mjs')
 
-  if (isTemplateFile && !existsSync(scriptFilePath)) {
+  const haveScript = existsSync(scriptFilePath) || existsSync(scriptSetupFilePath)
+
+  if (isTemplateFile && !haveScript) {
     return true
   }
 


### PR DESCRIPTION
closes https://github.com/epicmaxco/vuestic-ui/issues/3955

Now css appended to script block by default, but added to template block in case if there is not script block.

Issue:
For breadcrumbs template is omited, because it doesn't have any exports.
<img width="890" alt="image" src="https://github.com/epicmaxco/vuestic-ui/assets/23530004/b9bc7b8d-6cc0-4bab-8c5c-f678d67810c2">

So component is actually located in scrip block:
<img width="776" alt="image" src="https://github.com/epicmaxco/vuestic-ui/assets/23530004/54e16981-cc80-49ac-8923-6e384df4eb51">

It is because there is no template block for breadcrumbs - it uses render function.

Other example is VaLayoutAbsoluteWrapper - it doesn't have script block, but have template and styles. So in this case, css import will be added to template.
<img width="830" alt="image" src="https://github.com/epicmaxco/vuestic-ui/assets/23530004/b17ae70c-c13f-49d3-b454-39cb936bc640">

Should also work with script setup.