### PR TITLE
Fix error with null values in VaTextarea.vue

### DIFF
--- a/packages/ui/src/components/va-textarea/VaTextarea.vue
+++ b/packages/ui/src/components/va-textarea/VaTextarea.vue
@@ -123,7 +123,7 @@ export default defineComponent({
         return undefined
       }
 
-      const rows = valueComputed.value.toString().split('\n').length
+      const rows = valueComputed.value ? valueComputed.value.toString().split('\n').length : 1
 
       if (!props.maxRows) {
         return rows


### PR DESCRIPTION
Fix #3958

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Checks that the computedValue exists before trying to access the toString function

## Markup:
<!-- Paste your markup here. -->
<details>

```vue
      const rows = valueComputed.value ? valueComputed.value.toString().split('\n').length : 1
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
