### PR TITLE
fix: Make line-height work in title work again

### DIFF
--- a/packages/ui/src/styles/typography/typography.scss
+++ b/packages/ui/src/styles/typography/typography.scss
@@ -9,7 +9,6 @@
 }
 
 .va-typography-block {
-  line-height: $line-height;
   font-family: var(--va-font-family);
 
   @for $i from 1 through 6 {


### PR DESCRIPTION
Remove line-height at `.va-typography-block` so as not to overrides line-height in va-h(1, 2, ... 6).
Fixing #3962.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
