### PR TITLE
fix(#3990): use fallback if no src

### DIFF
--- a/packages/ui/src/components/va-avatar/VaAvatar.stories.ts
+++ b/packages/ui/src/components/va-avatar/VaAvatar.stories.ts
@@ -10,8 +10,8 @@ export default {
 export const Default = () => ({
   components: { VaAvatar },
   template: `
-    <VaAvatar 
-      src="https://randomuser.me/api/portraits/women/5.jpg" 
+    <VaAvatar
+      src="https://randomuser.me/api/portraits/women/5.jpg"
       alt="image"
     />
   `,
@@ -62,21 +62,21 @@ export const SizesConfig = () => ({
   components: { VaAvatar },
   template: `
     [small: 16px]
-    <VaAvatar 
+    <VaAvatar
       :sizesConfig="{ 'defaultSize': 24, 'sizes': { 'small': 16, 'medium': 24, 'large': 32 } }"
       size="small"
     >
       Text
     </VaAvatar>
     [medium: 24px]
-    <VaAvatar 
+    <VaAvatar
       :sizesConfig="{ 'defaultSize': 24, 'sizes': { 'small': 16, 'medium': 24, 'large': 32 } }"
       size="medium"
     >
       Text
     </VaAvatar>
     [large: 32px]
-    <VaAvatar 
+    <VaAvatar
       :sizesConfig="{ 'defaultSize': 24, 'sizes': { 'small': 16, 'medium': 24, 'large': 32 } }"
       size="large"
     >
@@ -121,6 +121,11 @@ export const FallbackSrc = () => ({
 export const FallbackText = () => ({
   components: { VaAvatar },
   template: '<VaAvatar src="https://not-exist" fallbackText="Text"/>',
+})
+
+export const FallbackTextNoSrc = () => ({
+  components: { VaAvatar },
+  template: '<VaAvatar fallbackText="Text" />',
 })
 
 export const fallbackRender = () => ({

--- a/packages/ui/src/components/va-avatar/VaAvatar.vue
+++ b/packages/ui/src/components/va-avatar/VaAvatar.vue
@@ -24,6 +24,9 @@
         v-else-if="$props.icon"
         :name="$props.icon"
       />
+      <slot v-else name="fallback">
+        <va-fallback v-bind="VaFallbackProps" @fallback="$emit('fallback')" />
+      </slot>
     </slot>
   </div>
 </template>


### PR DESCRIPTION
closes https://github.com/epicmaxco/vuestic-ui/issues/3990

<img width="80" alt="image" src="https://github.com/epicmaxco/vuestic-ui/assets/23530004/07d54384-bec8-4d56-a098-2f3a97c9eb88">


```ts
export const FallbackTextNoSrc = () => ({
  components: { VaAvatar },
  template: '<VaAvatar fallbackText="Text" />',
})
```