### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/packages/docs/modules/banner/runtime/banner.ts
+++ b/packages/docs/modules/banner/runtime/banner.ts
@@ -1,4 +1,4 @@
-import { defineNuxtPlugin } from '#app';
+import { defineNuxtPlugin } from '#imports';
 export default defineNuxtPlugin((nuxt) => {
   if (nuxt.ssrContext) { return }
 

--- a/packages/docs/modules/google-analytics/runtime/plugin.ts
+++ b/packages/docs/modules/google-analytics/runtime/plugin.ts
@@ -1,4 +1,4 @@
-import { defineNuxtPlugin } from '#app';
+import { defineNuxtPlugin } from '#imports';
 import VueGtag from 'vue-gtag'
 
 export default defineNuxtPlugin((nuxt) => {

--- a/packages/nuxt/nuxt.shim.d.ts
+++ b/packages/nuxt/nuxt.shim.d.ts
@@ -14,6 +14,7 @@ declare module 'vuestci-ui' {
 
 declare module '#imports' {
   export * from '@unhead/vue'
+  export { defineNuxtPlugin, useCookie } from 'nuxt/app'
 }
 
 declare module '#vuestic-config' {

--- a/packages/nuxt/src/runtime/plugin.ts
+++ b/packages/nuxt/src/runtime/plugin.ts
@@ -9,9 +9,7 @@ import {
   type PartialGlobalConfig
 } from 'vuestic-ui'
 import { markRaw, computed, watch, type Ref } from 'vue'
-
-import { defineNuxtPlugin, useCookie } from '#imports'
-import { useHead, ReactiveHead } from '#imports'
+import { useHead, ReactiveHead, defineNuxtPlugin, useCookie  } from '#imports'
 import NuxtLink from '#app/components/nuxt-link'
 import configFromFile from '#vuestic-config'
 

--- a/packages/nuxt/src/runtime/plugin.ts
+++ b/packages/nuxt/src/runtime/plugin.ts
@@ -10,7 +10,7 @@ import {
 } from 'vuestic-ui'
 import { markRaw, computed, watch, type Ref } from 'vue'
 
-import { defineNuxtPlugin, useCookie } from '#app'
+import { defineNuxtPlugin, useCookie } from '#imports'
 import { useHead, ReactiveHead } from '#imports'
 import NuxtLink from '#app/components/nuxt-link'
 import configFromFile from '#vuestic-config'


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
