### PR TITLE
fix: va-counter isolate readonly attribute from disabled

### DIFF
--- a/packages/ui/src/components/va-counter/VaCounter.vue
+++ b/packages/ui/src/components/va-counter/VaCounter.vue
@@ -259,11 +259,11 @@ export default defineComponent({
     const tabIndexComputed = computed(() => props.disabled ? -1 : 0)
 
     const isDecreaseActionDisabled = computed(() => (
-      isMinReached.value || props.readonly || props.disabled
+      isMinReached.value || props.disabled
     ))
 
     const isIncreaseActionDisabled = computed(() => (
-      isMaxReached.value || props.readonly || props.disabled
+      isMaxReached.value || props.disabled
     ))
 
     const decreaseCount = () => {
@@ -295,6 +295,7 @@ export default defineComponent({
       icon: props.decreaseIcon,
       plain: true,
       disabled: isDecreaseActionDisabled.value,
+      readonly: props.readonly,
       tabindex: -1,
       'aria-label': tp(props.ariaDecreaseLabel),
       ...(!isDecreaseActionDisabled.value && { onClick: decreaseCount }),
@@ -306,6 +307,7 @@ export default defineComponent({
       icon: props.increaseIcon,
       plain: true,
       disabled: isIncreaseActionDisabled.value,
+      readonly: props.readonly,
       tabindex: -1,
       'aria-label': tp(props.ariaIncreaseLabel),
       ...(!isIncreaseActionDisabled.value && { onClick: increaseCount }),


### PR DESCRIPTION
## Description
This is a PR to fix [#3999](https://github.com/epicmaxco/vuestic-ui/issues/3999)

This PR isolates `readonly` from `disabled` attribute, now the computed properties `isDecreaseActionDisabled` &  `isIncreaseActionDisabled` are only checking if disabled and min o max value is reached.

`readonly` is appended in `increaseIconProps` and `decreaseIconProps` directly from the props.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
