### PR TITLE
Made only the active breadcrumb take active color

### DIFF
--- a/packages/ui/src/components/va-breadcrumbs/VaBreadcrumbs.vue
+++ b/packages/ui/src/components/va-breadcrumbs/VaBreadcrumbs.vue
@@ -12,7 +12,8 @@ export default defineComponent({
     ...useAlignProps,
     ...useComponentPresetProp,
     separator: { type: String, default: '/' },
-    color: { type: String, default: 'secondary' },
+    color: { type: String, default: null },
+    disabledColor: { type: String, default: 'secondary' },
     activeColor: { type: String, default: null },
     separatorColor: { type: String, default: null },
     ariaLabel: { type: String, default: '$t:breadcrumbs' },
@@ -22,10 +23,11 @@ export default defineComponent({
 
     const { getColor } = useColors()
     const computedThemesSeparatorColor = computed(() => {
-      return props.separatorColor ? getColor(props.separatorColor) : getColor(props.color)
+      return props.separatorColor ? getColor(props.separatorColor) : null
     })
+    const computedThemesColor = computed(() => props.color ? getColor(props.color) : null)
     const computedThemesActiveColor = computed(() => {
-      return props.activeColor ? getColor(props.activeColor) : getColor(props.color)
+      return props.activeColor ? getColor(props.activeColor) : null
     })
 
     const childNodeFilter = (result: VNode[], node: VNode) => {
@@ -81,10 +83,12 @@ export default defineComponent({
 
       const createChildComponent = (child: VNode, index: number) => h(
         'span', {
-          class: 'va-breadcrumbs__item',
+          class: ['va-breadcrumbs__item', { 'va-breadcrumbs__item--disabled': isDisabledChild(child) }],
           'aria-current': (isLastIndexChildNodes(index) && isChildLink(child)) ? 'location' : false,
           style: {
-            color: (isLastIndexChildNodes(index) && !isDisabledChild(child)) ? computedThemesActiveColor.value : null,
+            color: isDisabledChild(child)
+              ? getColor(props.disabledColor)
+              : isLastIndexChildNodes(index) ? computedThemesActiveColor.value : computedThemesColor.value,
           },
         },
         [child],

--- a/packages/ui/src/components/va-breadcrumbs/VaBreadcrumbs.vue
+++ b/packages/ui/src/components/va-breadcrumbs/VaBreadcrumbs.vue
@@ -84,7 +84,7 @@ export default defineComponent({
           class: 'va-breadcrumbs__item',
           'aria-current': (isLastIndexChildNodes(index) && isChildLink(child)) ? 'location' : false,
           style: {
-            color: (!isLastIndexChildNodes(index) && !isDisabledChild(child)) ? computedThemesActiveColor.value : null,
+            color: (isLastIndexChildNodes(index) && !isDisabledChild(child)) ? computedThemesActiveColor.value : null,
           },
         },
         [child],


### PR DESCRIPTION

## Description
This PR closes #4000 
Fixes the active color on non-active breadcrumbs

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
