### PR TITLE
Added documentation that addresses issues when using text-by.

### DIFF
--- a/packages/docs/page-config/ui-elements/select/index.ts
+++ b/packages/docs/page-config/ui-elements/select/index.ts
@@ -20,7 +20,7 @@ export default definePageConfig({
     block.example("Decorators", { title: "Decorators" }),
     block.example("ObjectOptions", {
       title: "Objects as options",
-      description: "You can use objects as options. Text will be showing from `text-by` property from object. Value can be also returned from select using `value-by` instead of whole object. Comparing object values is done by `track-by` prop or `value-by` if it is not provided.",
+      description: "You can use objects as options. Text will be showing from `text-by` property from object. Value can be also returned from select using `value-by` instead of whole object. Comparing object values is done by `track-by` prop or `value-by` if it is not provided. <br /> <em>Note: Using `text-by` without a `value-by` or `track-by` may cause inconsistencies in expected behavior.",
     }),
     block.example("TrackBy", {
       title: "Track by",


### PR DESCRIPTION
## Description
This addresses an issue we faced where using text-by caused our select to start display at the bottom of the list instead of the top.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
