### PR TITLE
fix(#4003): add custom loader component via slot

### DIFF
--- a/packages/ui/src/components/va-inner-loading/VaInnerLoading.demo.vue
+++ b/packages/ui/src/components/va-inner-loading/VaInnerLoading.demo.vue
@@ -1,14 +1,13 @@
 <template>
   <vb-demo>
-    <vb-card width="400px">
-      <va-button
+    <va-button
         size="small"
         color="info"
         @click="loading = !loading"
       >
         {{ loading ? 'Stop loading' : 'Start loading ' }}
-      </va-button>
-
+    </va-button>
+    <vb-card width="400px"  title="Default">
       <va-inner-loading :loading="loading">
         <va-card>
           <va-card-title text-color="primary">
@@ -30,12 +29,41 @@
         </va-card>
       </va-inner-loading>
     </vb-card>
+
+    <vb-card width="400px"  title="Custom loader slot">
+      <va-inner-loading :loading="loading">
+        <va-card>
+          <va-card-title text-color="primary">
+            Epicmax
+            <va-spacer />
+            <va-button icon="email" />
+            <va-button icon="local_phone" />
+          </va-card-title>
+
+          <va-card-content>
+            <p>NO BUREAUCRACY. NO MIDDLEMEN. NO WASTE OF TIME.</p>
+
+            <p>
+              Epicmax is a team of talented people ready to care about your product.
+              We love coding. We love beautiful design. We love doing our job better than possible.
+              Every product we craft is a challenge we are excited about.
+            </p>
+          </va-card-content>
+        </va-card>
+        <template #loading>
+          <div class="custom-loader__container">
+            <va-progress-bar  indeterminate />
+          </div>
+        </template>
+      </va-inner-loading>
+    </vb-card>
   </vb-demo>
 </template>
 
 <script>
 import { VaButton } from '../va-button'
 import { VaCard, VaCardTitle, VaCardContent } from '../va-card'
+import { VaProgressBar } from '../va-progress-bar'
 import { VaSpacer } from '../va-spacer'
 import { VaInnerLoading } from './index'
 
@@ -45,6 +73,7 @@ export default {
     VaCard,
     VaCardTitle,
     VaCardContent,
+    VaProgressBar,
     VaSpacer,
     VaInnerLoading,
   },
@@ -55,3 +84,9 @@ export default {
   },
 }
 </script>
+
+<style scoped lang="scss">
+.custom-loader__container {
+  width: 100px;
+}
+</style>

--- a/packages/ui/src/components/va-inner-loading/VaInnerLoading.demo.vue
+++ b/packages/ui/src/components/va-inner-loading/VaInnerLoading.demo.vue
@@ -7,7 +7,7 @@
       >
         {{ loading ? 'Stop loading' : 'Start loading ' }}
     </va-button>
-    <vb-card width="400px"  title="Default">
+    <vb-card width="400px" title="Default">
       <va-inner-loading :loading="loading">
         <va-card>
           <va-card-title text-color="primary">
@@ -30,7 +30,7 @@
       </va-inner-loading>
     </vb-card>
 
-    <vb-card width="400px"  title="Custom loader slot">
+    <vb-card width="400px" title="Custom loader slot">
       <va-inner-loading :loading="loading">
         <va-card>
           <va-card-title text-color="primary">
@@ -52,7 +52,7 @@
         </va-card>
         <template #loading>
           <div class="custom-loader__container">
-            <va-progress-bar  indeterminate />
+            <va-progress-bar indeterminate />
           </div>
         </template>
       </va-inner-loading>

--- a/packages/ui/src/components/va-inner-loading/VaInnerLoading.vue
+++ b/packages/ui/src/components/va-inner-loading/VaInnerLoading.vue
@@ -11,13 +11,15 @@
       class="va-inner-loading__overlay"
       aria-hidden="true"
     >
-      <va-icon
-        class="va-inner-loading__spinner"
-        spin
-        :color="colorComputed"
-        :size="$props.size"
-        :name="$props.icon"
-      />
+      <slot name="loading">
+        <va-icon
+          class="va-inner-loading__spinner"
+          spin
+          :color="colorComputed"
+          :size="$props.size"
+          :name="$props.icon"
+        />
+      </slot>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Description
This PR [#4003](https://github.com/epicmaxco/vuestic-ui/issues/4003) adds custom loader components on `va-inner-loading` via slot.

Also it adds a new example in storybook for custom loader. `Default` and `custom` loaders share the same loading trigger button. 

## Extra Notes
The name of the slot is `loading` as `vaInfiniteScroll` also contains a loader slot and it is named `loading`. For consistency, I´ve chosen the same name. Personally, I think a more explicit name would be `loader` as it is a loader component what we will pass through the slot. I would use `loading` more for state cases.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
