### PR TITLE
Update useClickOutside.ts

### DIFF
--- a/packages/ui/src/composables/useClickOutside.ts
+++ b/packages/ui/src/composables/useClickOutside.ts
@@ -17,7 +17,7 @@ type MaybeArray<T> = T | T[]
 const safeArray = <T>(a: MaybeArray<T>) => Array.isArray(a) ? a : [a]
 
 export const useClickOutside = (elements: MaybeArray<MaybeRef<HTMLElement | undefined>>, cb: (el: HTMLElement) => void) => {
-  useCaptureEvent('click', (event: MouseEvent) => {
+  useCaptureEvent('mousedown', (event: MouseEvent) => {
     const clickTarget = event.target as HTMLElement
 
     if ((event.target as HTMLElement).shadowRoot) {


### PR DESCRIPTION
closes #3987

## Description
Updated useClickOutside composable, instead of detecting any click event outside the modal. It now only closes if a mousedown event occurs outside the modal.

This allows the mouse to go up outside the modal, fixing the modal closing when trying to copy text in a modal!


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
