### PR TITLE
Stories typechecking fix (#4042)

### DIFF
--- a/packages/ui/.storybook/vuestic-config/demo-icon-aliases.ts
+++ b/packages/ui/.storybook/vuestic-config/demo-icon-aliases.ts
@@ -1,4 +1,4 @@
-import { IconConfiguration } from '../../services/icon/types'
+import {IconConfiguration} from "@/services/icon";
 
 const DemoAliases: IconConfiguration[] = [
   {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -29,7 +29,8 @@
   "scripts": {
     "serve:production": "vue-cli-service serve --mode production",
     "build": "tsx build/build.ts",
-    "build:types": "vue-tsc --declaration --emitDeclarationOnly --outDir dist/types",
+    "build:types": "vue-tsc --declaration --emitDeclarationOnly --outDir dist/types --project tsconfig.build.json",
+    "typecheck": "vue-tsc --noEmit",
     "lint": "vue-cli-service lint",
     "lint:style": "stylelint '**/*.{vue,html,css,scss}' --fix",
     "test:e2e": "vue-cli-service test:e2e",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -37,7 +37,7 @@
     "test:unit": "vitest",
     "push": "npm publish --tag=next",
     "push-production": "npm publish --tag=latest",
-    "precommit": "lint-staged --concurrent=false && yarn test:unit --run",
+    "precommit": "lint-staged --concurrent=false && yarn typecheck && yarn test:unit --run",
     "server:webapp": "npx http-server dist --push-state",
     "serve:storybook": "storybook dev -p 6006",
     "build:storybook": "storybook build",

--- a/packages/ui/src/components/va-accordion/VaAccordion.stories.ts
+++ b/packages/ui/src/components/va-accordion/VaAccordion.stories.ts
@@ -1,5 +1,6 @@
 import { VaAccordion } from './'
 import { VaCollapse } from '../va-collapse'
+import { StoryFn } from '@storybook/vue3'
 import { within, userEvent } from '@storybook/testing-library'
 import { expect } from '@storybook/jest'
 import { sleep } from '../../utils/sleep'
@@ -10,7 +11,7 @@ export default {
   tags: ['autodocs'],
 }
 
-export const Default = () => ({
+export const Default: StoryFn = () => ({
   components: { VaAccordion, VaCollapse },
   data: () => ({ value: [] }),
   template: `
@@ -52,7 +53,7 @@ Default.play = async ({ canvasElement, step }) => {
   })
 }
 
-export const Stateful = () => ({
+export const Stateful: StoryFn = () => ({
   components: { VaAccordion, VaCollapse },
   template: `
     <p>[true] - should open</p>
@@ -87,7 +88,7 @@ Stateful.play = async ({ canvasElement, step }) => {
   })
 }
 
-export const Multiple = () => ({
+export const Multiple: StoryFn = () => ({
   components: { VaAccordion, VaCollapse },
   data: () => ({ value: [] }),
   template: `
@@ -117,7 +118,7 @@ Multiple.play = async ({ canvasElement, step }) => {
   })
 }
 
-export const vModel = () => ({
+export const vModel: StoryFn = () => ({
   components: { VaAccordion, VaCollapse },
   data: () => ({ value: [true, false, true] }),
   template: `

--- a/packages/ui/src/components/va-affix/VaAffix.stories.ts
+++ b/packages/ui/src/components/va-affix/VaAffix.stories.ts
@@ -1,12 +1,13 @@
 import { VaAffix } from './'
 import { expect } from '@storybook/jest'
+import { StoryFn } from '@storybook/vue3'
 
 export default {
   title: 'VaAffix',
   component: VaAffix,
 }
 
-export const FixedTop = () => ({
+export const FixedTop: StoryFn = () => ({
   components: { VaAffix },
   template: `
     <div class="w-1/4">
@@ -28,7 +29,7 @@ FixedTop.play = async ({ canvasElement, step }) => {
   })
 }
 
-export const FixedBottom = () => ({
+export const FixedBottom: StoryFn = () => ({
   components: { VaAffix },
   template: `
     <div class="w-1/4">

--- a/packages/ui/src/components/va-alert/VaAlert.stories.ts
+++ b/packages/ui/src/components/va-alert/VaAlert.stories.ts
@@ -3,6 +3,7 @@ import { VaButton } from '../va-button'
 import { userEvent } from '../../../.storybook/interaction-utils/userEvent'
 import { within } from '@storybook/testing-library'
 import { expect } from '@storybook/jest'
+import { StoryFn } from '@storybook/vue3'
 
 export default {
   title: 'VaAlert',
@@ -89,7 +90,7 @@ export const CloseIcon = () => ({
   `,
 })
 
-export const Stateful = () => ({
+export const Stateful: StoryFn = () => ({
   components: { VaAlert },
   template: `
     [true]
@@ -187,7 +188,7 @@ export const Slotted = () => ({
   `,
 })
 
-export const HideAndShow = () => ({
+export const HideAndShow: StoryFn = () => ({
   components: { VaAlert, VaButton },
   data: () => ({ isVisible: true }),
   template: `

--- a/packages/ui/src/components/va-app-bar/VaAppBar.stories.ts
+++ b/packages/ui/src/components/va-app-bar/VaAppBar.stories.ts
@@ -1,4 +1,5 @@
 import { VaAppBar } from './'
+import { StoryFn } from '@storybook/vue3'
 
 export default {
   title: 'VaAppBar',
@@ -53,7 +54,7 @@ export const FixedBottom = () => ({
   `,
 })
 
-export const HideOnScroll = () => ({
+export const HideOnScroll: StoryFn = () => ({
   components: { VaAppBar },
   template: `
     <div class="flex flex-col relative max-h-32 overflow-hidden">
@@ -78,7 +79,7 @@ HideOnScroll.play = async ({ canvasElement, step }) => {
   target.scrollTo({ top: target.clientHeight })
 }
 
-export const ShadowOnScroll = () => ({
+export const ShadowOnScroll: StoryFn = () => ({
   components: { VaAppBar },
   template: `
     <div class="flex flex-col relative max-h-32 overflow-hidden">
@@ -103,7 +104,7 @@ ShadowOnScroll.play = async ({ canvasElement, step }) => {
   target.scrollTo({ top: target.clientHeight })
 }
 
-export const ShadowColor = () => ({
+export const ShadowColor: StoryFn = () => ({
   components: { VaAppBar },
   template: `
     <div class="flex flex-col relative max-h-32 overflow-hidden">

--- a/packages/ui/src/components/va-backtop/VaBacktop.stories.ts
+++ b/packages/ui/src/components/va-backtop/VaBacktop.stories.ts
@@ -3,19 +3,20 @@ import { VaRadio } from '../va-radio'
 import { userEvent, within } from '@storybook/testing-library'
 import { expect } from '@storybook/jest'
 import { sleep } from '../../utils/sleep'
+import { StoryFn } from '@storybook/vue3'
 
 export default {
   title: 'VaBacktop',
   component: VaBacktop,
 }
 
-const getBacktop = (): HTMLElement | undefined => document.querySelector('.va-backtop')
+const getBacktop = () => document.querySelector<HTMLElement>('.va-backtop')!
 const scroll = async () => {
   window.scrollTo({ top: 400 })
   await sleep()
 }
 
-export const Default = () => ({
+export const Default: StoryFn = () => ({
   components: { VaBacktop },
   template: `
     <p class="m-1">{{ $vb.lorem(10000) }}</p>
@@ -73,7 +74,7 @@ Offset.play = async () => {
   scroll()
 }
 
-export const Position = () => ({
+export const Position: StoryFn = () => ({
   components: { VaBacktop, VaRadio },
   data: () => {
     const OPTIONS_X = ['left', 'right']
@@ -105,7 +106,7 @@ Position.play = async ({ canvasElement, step }) => {
   canvas.getByTestId('controls').scrollIntoView()
 }
 
-export const ClickEvent = () => ({
+export const ClickEvent: StoryFn = () => ({
   components: { VaBacktop },
   data: () => ({ clicked: false }),
   template: `
@@ -120,13 +121,13 @@ ClickEvent.play = async ({ canvasElement, step }) => {
   await scroll()
 
   await step('Click triggered', async () => {
-    getBacktop().click()
+    getBacktop()?.click()
     await sleep()
     expect(clicked.innerText).toBe('true')
   })
 }
 
-export const Target = () => ({
+export const Target: StoryFn = () => ({
   components: { VaBacktop },
   template: `
     [not the target]

--- a/packages/ui/src/components/va-carousel/VaCarousel.stories.ts
+++ b/packages/ui/src/components/va-carousel/VaCarousel.stories.ts
@@ -4,6 +4,7 @@ import { within } from '@storybook/testing-library'
 import { VaCarousel } from '../va-carousel'
 import { expect } from '@storybook/jest'
 import { sleep } from '../../utils/sleep'
+import { StoryFn } from '@storybook/vue3'
 
 const getItems = () => [
   'https://picsum.photos/id/10/2500',
@@ -33,7 +34,7 @@ export const Vertical = () => ({
   `,
 })
 
-export const ZeroOneTwoSlides = () => ({
+export const ZeroOneTwoSlides: StoryFn = () => ({
   components: { VaCarousel },
   data: () => ({ items: getItems() }),
   template: `
@@ -72,7 +73,7 @@ export const Swipe = () => ({
   `,
 })
 
-export const Arrows = () => ({
+export const Arrows: StoryFn = () => ({
   components: { VaCarousel },
   data: () => ({ items: getItems(), current: 0 }),
   template: `
@@ -94,7 +95,7 @@ Arrows.play = async ({ canvasElement, step }) => {
   })
 }
 
-export const Indicators = () => ({
+export const Indicators: StoryFn = () => ({
   components: { VaCarousel },
   data: () => ({ items: getItems() }),
   template: `
@@ -116,7 +117,7 @@ Indicators.play = async ({ canvasElement, step }) => {
   })
 }
 
-export const IndicatorsTrigger = () => ({
+export const IndicatorsTrigger: StoryFn = () => ({
   components: { VaCarousel },
   data: () => ({ items: getItems() }),
   template: `
@@ -161,7 +162,7 @@ IndicatorsTrigger.play = async ({ canvasElement, step }) => {
   })
 }
 
-export const Infinite = () => ({
+export const Infinite: StoryFn = () => ({
   components: { VaCarousel },
   data: () => ({ items: getItems() }),
   template: `
@@ -187,7 +188,7 @@ Infinite.play = async ({ canvasElement, step }) => {
   })
 }
 
-export const Stateful = () => ({
+export const Stateful: StoryFn = () => ({
   components: { VaCarousel },
   data: () => ({ items: getItems() }),
   template: `
@@ -214,7 +215,7 @@ Stateful.play = async ({ canvasElement, step }) => {
   })
 }
 
-export const Autoscroll = () => ({
+export const Autoscroll: StoryFn = () => ({
   components: { VaCarousel },
   data: () => ({ items: getItems() }),
   template: `

--- a/packages/ui/src/components/va-counter/VaCounter.stories.ts
+++ b/packages/ui/src/components/va-counter/VaCounter.stories.ts
@@ -2,6 +2,7 @@ import { addText } from '../../../.storybook/interaction-utils/addText'
 import { userEvent } from '../../../.storybook/interaction-utils/userEvent'
 import { expect } from '@storybook/jest'
 import { VaCounter } from './'
+import { StoryFn } from '@storybook/vue3'
 
 export default {
   title: 'VaCounter',
@@ -9,7 +10,7 @@ export default {
   tags: ['autodocs'],
 }
 
-export const Default = () => ({
+export const Default: StoryFn = () => ({
   components: { VaCounter },
   data: () => ({ value: 0 }),
   template: `
@@ -47,7 +48,7 @@ export const LongPressDelay = () => ({
   `,
 })
 
-export const Stateful = () => ({
+export const Stateful: StoryFn = () => ({
   components: { VaCounter },
   template: `
     <p>[true]</p>
@@ -72,7 +73,7 @@ Stateful.play = async ({ step }) => {
   })
 }
 
-export const Min = () => ({
+export const Min: StoryFn = () => ({
   components: { VaCounter },
   template: `
     <VaCounter
@@ -90,7 +91,7 @@ Min.play = async ({ step }) => {
   })
 }
 
-export const Max = () => ({
+export const Max: StoryFn = () => ({
   components: { VaCounter },
   template: `
     <VaCounter
@@ -108,7 +109,7 @@ Max.play = async ({ step }) => {
   })
 }
 
-export const Step = () => ({
+export const Step: StoryFn = () => ({
   components: { VaCounter },
   template: `
     <VaCounter

--- a/packages/ui/src/components/va-data-table/VaDataTable.new.demo.vue
+++ b/packages/ui/src/components/va-data-table/VaDataTable.new.demo.vue
@@ -268,7 +268,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 import cloneDeep from 'lodash/cloneDeep.js'
-import { DataTableSelectMode, DataTableSortingOrder, VaDataTable } from './'
+import { DataTableColumn, DataTableSelectMode, DataTableSortingOrder, VaDataTable } from './'
 import { VaChip } from '../va-chip'
 import { VaAlert } from '../va-alert'
 import { faker } from '@faker-js/faker'
@@ -401,7 +401,7 @@ export default defineComponent({
       },
     ]
 
-    const columns = [
+    const columns: DataTableColumn[] = [
       { key: 'username', sortable: true },
       { key: 'email', sortable: true },
       { key: 'name', sortable: true },
@@ -411,7 +411,7 @@ export default defineComponent({
     ]
 
     return {
-      items: faker.seed(1) && faker.helpers.shuffle(cloneDeep(users)),
+      items: faker.seed(1) ? faker.helpers.shuffle(cloneDeep(users)) : [],
       itemsHuge: new Array(500).fill(null).map((_, idx) => idx % 2 ? users[0] : users[1]),
       columns,
 

--- a/packages/ui/src/components/va-date-input/VaDateInput.demo.vue
+++ b/packages/ui/src/components/va-date-input/VaDateInput.demo.vue
@@ -96,7 +96,7 @@
 
     <VbCard title="weekends">
       <va-date-input v-model="value" label="Highlight weekend" highlight-weekends class="mb-6" />
-      <va-date-input v-model="value" label="Every second day is weekend" highlight-weekends :weekends="(date) => date.getDay() % 2 === 0" class="mb-6" />
+      <va-date-input v-model="value" label="Every second day is weekend" highlight-weekends :weekends="(date: Date) => date.getDay() % 2 === 0" class="mb-6" />
     </VbCard>
 
     <VbCard title="dropdown">
@@ -148,7 +148,7 @@
     </VbCard>
 
     <VbCard title="disable dates">
-      <va-date-input v-model="value" label="Disable all Tuesday and Thursday" :allowedDays="(date) => date.getDay() !== 2 && date.getDay() !== 4" />
+      <va-date-input v-model="value" label="Disable all Tuesday and Thursday" :allowedDays="(date: Date) => date.getDay() !== 2 && date.getDay() !== 4" />
     </VbCard>
 
     <VbCard title="Manual Input">
@@ -210,6 +210,9 @@ import { VaDateInput } from './index'
 import { VaChip } from '../va-chip'
 import { VaButton } from '../va-button'
 import { getStaticDate } from '../../../.storybook/interaction-utils/addText'
+import { ValidationRule } from '@/composables'
+import { DateInputModelValue } from '@/components/va-date-input/types'
+import { DatePickerView } from '@/components/va-date-picker/types'
 
 const datePlusDay = (date: Date, days: number) => {
   const d = new Date(date)
@@ -225,19 +228,19 @@ export default {
       value: getStaticDate(),
       range: { start: getStaticDate(), end: nextWeek },
       dates: [getStaticDate(), nextWeek],
-      dayView: { type: 'day', month: 3, year: 2013 },
+      dayView: { type: 'day', month: 3, year: 2013 } as DatePickerView,
       string: getStaticDate().toString(),
-      strings: [getStaticDate().getTime() + 1e9, getStaticDate().toString()],
-      stringRange: { start: getStaticDate().toString(), end: getStaticDate().getTime() + 1e9 },
+      strings: [getStaticDate().getTime() + 1e9, getStaticDate().toString()] as DateInputModelValue,
+      stringRange: { start: getStaticDate().toString(), end: getStaticDate().getTime() + 1e9 } as unknown as DateInputModelValue,
 
       validationRules1: [(value: Date) => {
         return !!value || 'Should be value'
-      }],
+      }] as ValidationRule<DateInputModelValue>[],
 
       validationRules2: [(value: Date) => {
         if (!value) { return true }
         return value.getDate?.() === 10 || 'Should be 10th day'
-      }],
+      }] as ValidationRule<DateInputModelValue>[],
 
       // Dropdown
       isOpen: false,

--- a/packages/ui/src/components/va-date-input/VaDateInput.demo.vue
+++ b/packages/ui/src/components/va-date-input/VaDateInput.demo.vue
@@ -231,7 +231,7 @@ export default {
       dayView: { type: 'day', month: 3, year: 2013 } as DatePickerView,
       string: getStaticDate().toString(),
       strings: [getStaticDate().getTime() + 1e9, getStaticDate().toString()] as DateInputModelValue,
-      stringRange: { start: getStaticDate().toString(), end: getStaticDate().getTime() + 1e9 } as unknown as DateInputModelValue,
+      stringRange: { start: getStaticDate().toString(), end: getStaticDate().getTime() + 1e9 } as DateInputModelValue,
 
       validationRules1: [(value: Date) => {
         return !!value || 'Should be value'

--- a/packages/ui/src/components/va-date-input/types.ts
+++ b/packages/ui/src/components/va-date-input/types.ts
@@ -1,4 +1,4 @@
-export type DateInputDate = string | Date
+export type DateInputDate = string | number | Date
 export type DateInputRange<T> = { start?: T | null, end?: T | null }
 export type DateInputValue = Date | Date[] | DateInputRange<Date>
 export type DateInputModelValue = DateInputDate | DateInputDate[] | DateInputRange<DateInputDate> | undefined | null

--- a/packages/ui/src/components/va-date-picker/VaDatePicker.demo.vue
+++ b/packages/ui/src/components/va-date-picker/VaDatePicker.demo.vue
@@ -161,6 +161,7 @@
 import { VaDatePicker } from './index'
 import { VaChip } from '../va-chip'
 import { getStaticDate } from '../../../.storybook/interaction-utils/addText'
+import { DatePickerView } from '@/components/va-date-picker/types'
 
 const datePlusDay = (date: Date, days: number) => {
   const d = new Date(date)
@@ -181,9 +182,9 @@ export default {
       monthRange: { start: getStaticDate(), end: datePlusDay(getStaticDate(), 62) },
       months: [getStaticDate(), datePlusDay(getStaticDate(), 62)],
 
-      dayView: { type: 'day', month: 6, year: 2020 },
-      monthView: { type: 'month' },
-      yearView: { type: 'year' },
+      dayView: { type: 'day', month: 6, year: 2020 } as DatePickerView,
+      monthView: { type: 'month' } as DatePickerView,
+      yearView: { type: 'year' } as DatePickerView,
     }
   },
 }

--- a/packages/ui/src/components/va-form/VaForm.stories.ts
+++ b/packages/ui/src/components/va-form/VaForm.stories.ts
@@ -47,7 +47,7 @@ export const Default = () => ({
   `,
 })
 
-export const Autofocus = () => ({
+export const Autofocus: StoryFn = () => ({
   components: { VaForm, VaInput },
   template: `
     <va-form autofocus>
@@ -71,7 +71,7 @@ Autofocus.play = async ({ canvasElement, step }) => {
   })
 }
 
-export const Stateful = () => ({
+export const Stateful: StoryFn = () => ({
   components: { VaForm, VaCheckbox },
   template: `
     [true]
@@ -101,7 +101,7 @@ Stateful.play = async ({ canvasElement, step }) => {
   })
 }
 
-export const Immediate = () => ({
+export const Immediate: StoryFn = () => ({
   components: { VaForm, VaInput },
 
   template: `
@@ -160,7 +160,7 @@ HideErrorMessages.play = async ({ step, canvasElement }) => {
   })
 }
 
-export const HideErrors = () => ({
+export const HideErrors: StoryFn = () => ({
   components: { VaForm, VaInput },
   template: `
     [true]
@@ -186,7 +186,7 @@ HideErrors.play = async ({ step }) => {
   })
 }
 
-export const Focus = () => ({
+export const Focus: StoryFn = () => ({
   components: { VaForm, VaInput, VaButton },
   template: `
     <va-form ref="form">
@@ -210,7 +210,7 @@ Focus.play = async ({ canvasElement, step }) => {
   })
 }
 
-export const FocusInvalid = () => ({
+export const FocusInvalid: StoryFn = () => ({
   components: { VaForm, VaInput, VaButton },
   template: `
     <va-form ref="form">
@@ -235,7 +235,7 @@ FocusInvalid.play = async ({ canvasElement, step }) => {
   })
 }
 
-export const ValidateAndResetValidation = () => ({
+export const ValidateAndResetValidation: StoryFn = () => ({
   components: { VaForm, VaInput, VaButton },
   template: `
     <va-form ref="form">
@@ -267,7 +267,7 @@ ValidateAndResetValidation.play = async ({ canvasElement, step }) => {
   })
 }
 
-export const Reset = () => ({
+export const Reset: StoryFn = () => ({
   components: { VaForm, VaInput, VaButton },
   data: () => ({ data: '' }),
   methods: {

--- a/packages/ui/src/components/va-input/VaInput.demo.vue
+++ b/packages/ui/src/components/va-input/VaInput.demo.vue
@@ -690,7 +690,7 @@ export default defineComponent({
   computed: {
     numProxy: {
       get () { return this.num },
-      set (v) { this.num = v > 10 ? 10 : v },
+      set (v: number) { this.num = v > 10 ? 10 : v },
     },
   },
 })

--- a/packages/ui/src/components/va-select/VaSelect.stories.ts
+++ b/packages/ui/src/components/va-select/VaSelect.stories.ts
@@ -29,7 +29,7 @@ export const Validation: StoryFn = () => ({
   components: { VaSelect },
 
   data () {
-    return { value: '', options: ['one', 'two', 'tree'], rules: [(v) => (v && v === 'one') || 'Must be one'] }
+    return { value: '', options: ['one', 'two', 'tree'], rules: [(v: string) => (v && v === 'one') || 'Must be one'] }
   },
 
   template: '<VaSelect v-model="value" :options="options" :rules="rules" />',
@@ -46,7 +46,7 @@ export const ImmediateValidation: StoryFn = () => ({
   components: { VaSelect },
 
   data () {
-    return { value: '', options: ['one', 'two', 'tree'], rules: [(v) => (v && v === 'one') || 'Must be one'] }
+    return { value: '', options: ['one', 'two', 'tree'], rules: [(v: string) => (v && v === 'one') || 'Must be one'] }
   },
 
   template: '<VaSelect v-model="value" :options="options" :rules="rules" immediate-validation />',
@@ -63,7 +63,7 @@ export const DirtyValidation: StoryFn = () => ({
   components: { Component: VaSelect },
 
   data () {
-    return { value: '', dirty: false, haveError: false, options: ['one', 'two', 'tree'], rules: [(v) => (v && v === 'one') || 'Must be one'] }
+    return { value: '', dirty: false, haveError: false, options: ['one', 'two', 'tree'], rules: [(v: string) => (v && v === 'one') || 'Must be one'] }
   },
 
   template: `
@@ -104,7 +104,7 @@ export const DirtyImmediateValidation: StoryFn = () => ({
   components: { Component: VaSelect },
 
   data () {
-    return { value: '', dirty: false, haveError: false, options: ['one', 'two', 'tree'], rules: [(v) => (v && v === 'one') || 'Must be one'] }
+    return { value: '', dirty: false, haveError: false, options: ['one', 'two', 'tree'], rules: [(v: string) => (v && v === 'one') || 'Must be one'] }
   },
 
   template: `

--- a/packages/ui/src/components/va-stepper/VaStepper.demo.vue
+++ b/packages/ui/src/components/va-stepper/VaStepper.demo.vue
@@ -172,6 +172,6 @@ const stepsWithNextAction = ref([
   { label: 'One' },
   { label: 'Two', beforeLeave: (step) => { step.hasError = true } },
   { label: 'Three', beforeLeave: (step) => model.value.c !== '' },
-  { label: 'Four', hasError: (step) => model.value.d === '' },
+  { label: 'Four', hasError: (step: any) => model.value.d === '' },
 ] as Step[])
 </script>

--- a/packages/ui/src/components/va-stepper/VaStepper.demo.vue
+++ b/packages/ui/src/components/va-stepper/VaStepper.demo.vue
@@ -129,7 +129,7 @@ const steps = [
   { label: 'Five' },
 ]
 
-const linearSteps = ref([
+const linearSteps = ref<Step[]>([
   {
     label: 'One',
     beforeLeave: (step) => {
@@ -150,7 +150,7 @@ const linearSteps = ref([
   { label: 'Two', beforeLeave: (step) => { step.hasError = model.value.b === '' } },
   { label: 'Three', disabled: true },
   { label: 'Four' },
-] as Step[])
+])
 
 const stepsWithDisabled = [
   { label: 'One' },
@@ -168,10 +168,10 @@ const stepsWithCustomIcons = [
   { label: 'Five', icon: 'list' },
 ]
 
-const stepsWithNextAction = ref([
+const stepsWithNextAction = ref<Step[]>([
   { label: 'One' },
   { label: 'Two', beforeLeave: (step) => { step.hasError = true } },
   { label: 'Three', beforeLeave: (step) => model.value.c !== '' },
-  { label: 'Four', hasError: (step: any) => model.value.d === '' },
-] as Step[])
+  { label: 'Four', hasError: (step) => model.value.d === '' },
+])
 </script>

--- a/packages/ui/src/components/va-stepper/types.ts
+++ b/packages/ui/src/components/va-stepper/types.ts
@@ -2,9 +2,9 @@ export type Step = {
   label: string
   icon?: string
   disabled?: boolean
-  beforeLeave?: (currentStep: Omit<Step, 'beforeLeave'>, toStep: Omit<Step, 'beforeLeave'>) => boolean
+  beforeLeave?: (currentStep: Omit<Step, 'beforeLeave'>, toStep: Omit<Step, 'beforeLeave'>) => boolean | void
   /** Will be set to true if user completed step with validation error */
-  hasError?: boolean
+  hasError?: boolean | ((currentStep: Omit<Step, 'hasError'>) => boolean | void)
   /**
    * Used in linear stepper to indicate if step is complete.
    * You can set it manually to false to prevent moving to next step.

--- a/packages/ui/src/components/va-switch/VaSwitch.stories.ts
+++ b/packages/ui/src/components/va-switch/VaSwitch.stories.ts
@@ -21,9 +21,9 @@ export const ChangeEvent: StoryFn = () => ({
   data: () => ({ value: false, changeCount: 0, lastEventValue: null }),
 
   methods: {
-    onChange (e) {
+    onChange (e: InputEvent) {
       this.changeCount++
-      this.lastEventValue = e.target.checked
+      this.lastEventValue = (e.target as HTMLInputElement).checked
     },
   },
 

--- a/packages/ui/src/components/va-tree-view/VaTreeView.stories.ts
+++ b/packages/ui/src/components/va-tree-view/VaTreeView.stories.ts
@@ -3,6 +3,8 @@ import { VaRadio } from '../va-radio'
 import { VaColorPalette } from '../va-color-palette'
 import { VaInput } from '../va-input'
 import { VaCheckbox } from '../va-checkbox'
+import { StoryFn } from '@storybook/vue3'
+import { TreeViewFilterMethod } from './types'
 
 export default {
   title: 'VaTreeView',
@@ -435,7 +437,7 @@ const filterableNodes = () => [
   { id: 5, label: 'Five' },
 ]
 
-export const Filter = () => ({
+export const Filter: StoryFn = () => ({
   components: { VaTreeView, VaInput, VaCheckbox },
   data: () => ({
     filterValue: '',
@@ -443,9 +445,9 @@ export const Filter = () => ({
     filterableNodes: filterableNodes(),
   }),
   computed: {
-    customFilterMethod () {
+    customFilterMethod (): TreeViewFilterMethod | undefined {
       return this.isFilterCaseSensitive
-        ? (node, filter, textBy) => node[textBy].includes(filter)
+        ? (node, filter, textBy) => node[textBy as string].includes(filter)
         : undefined
     },
   },

--- a/packages/ui/src/components/va-tree-view/VaTreeViewKeyboardNavigation.stories.ts
+++ b/packages/ui/src/components/va-tree-view/VaTreeViewKeyboardNavigation.stories.ts
@@ -1,4 +1,5 @@
-import { VaTreeView } from '.'
+import { TreeNode, VaTreeView } from '.'
+import { StoryFn } from '@storybook/vue3'
 
 export default {
   title: 'VaTreeViewKeyboardNavigation',
@@ -180,14 +181,14 @@ export const WavesLikeNavigation = () => ({
   `,
 })
 
-export const Selection = () => ({
+export const Selection: StoryFn = () => ({
   components: { VaTreeView },
   data: () => ({
     selectedNode: null,
     triangle: triangle(),
   }),
   methods: {
-    onSelectNode (node) {
+    onSelectNode (node: TreeNode) {
       this.selectedNode = node ? `${node.id} ${node.label}` : null
     },
   },

--- a/packages/ui/src/components/va-value/VaValue.stories.ts
+++ b/packages/ui/src/components/va-value/VaValue.stories.ts
@@ -4,6 +4,7 @@ import { VaButton } from '../va-button'
 import { within, userEvent } from '@storybook/testing-library'
 import { expect } from '@storybook/jest'
 import { sleep } from '../../utils/sleep'
+import { StoryFn } from '@storybook/vue3'
 
 export default {
   title: 'VaValue',
@@ -11,7 +12,7 @@ export default {
   tags: ['autodocs'],
 }
 
-export const Default = () => ({
+export const Default: StoryFn = () => ({
   components: { VaValue, VaButton },
   template: `
     <VaValue #default="v">

--- a/packages/ui/src/components/va-viewer/VaViewer.stories.ts
+++ b/packages/ui/src/components/va-viewer/VaViewer.stories.ts
@@ -5,6 +5,7 @@ import { VaIcon } from '../va-icon'
 import { userEvent } from '@storybook/testing-library'
 import { expect } from '@storybook/jest'
 import { sleep } from '../../utils/sleep'
+import { StoryFn } from '@storybook/vue3'
 
 export default {
   title: 'VaViewer',
@@ -12,9 +13,9 @@ export default {
   tags: ['autodocs'],
 }
 
-const getImagePath = (width, height = 0) => `https://picsum.photos/id/450/${width}/${height || width}`
+const getImagePath = (width = 0, height = 0) => `https://picsum.photos/id/450/${width}/${height || width}`
 
-export const Default = () => ({
+export const Default: StoryFn = () => ({
   components: { VaViewer, VaImage },
   data: () => ({ getImagePath }),
   template: `
@@ -32,7 +33,7 @@ export const Default = () => ({
 })
 
 Default.play = async ({ canvasElement, step }) => {
-  const viewer = canvasElement.querySelector('.va-viewer')
+  const viewer = canvasElement.querySelector('.va-viewer')!
   await step('Click on image to show a magnified view', async () => {
     const beforeClick = document.querySelector('.va-viewer-content')
     expect(beforeClick).toBeNull()

--- a/packages/ui/src/components/va-virtual-scroller/VaVirtualScroller.stories.ts
+++ b/packages/ui/src/components/va-virtual-scroller/VaVirtualScroller.stories.ts
@@ -2,6 +2,7 @@ import { VaVirtualScroller } from './'
 import { VaButton } from '../va-button'
 import { within } from '@storybook/testing-library'
 import { expect } from '@storybook/jest'
+import { StoryFn } from '@storybook/vue3'
 
 const getHugeArray = () => new Array(1000).fill(null).map((_, index) => index)
 
@@ -52,7 +53,7 @@ export const Horizontal = () => ({
   `,
 })
 
-export const Bench = () => ({
+export const Bench: StoryFn = () => ({
   components: { VaVirtualScroller },
   data: () => ({ hugeArray: getHugeArray() }),
   template: `

--- a/packages/ui/src/composables/useElementBackground.stories.ts
+++ b/packages/ui/src/composables/useElementBackground.stories.ts
@@ -6,12 +6,13 @@ import UseElementBackgroundDummy from './UseElementBackgroundDummy.vue'
 import { within } from '@storybook/testing-library'
 import { sleep } from '../utils/sleep'
 import { expect } from '@storybook/jest'
+import { StoryFn } from '@storybook/vue3'
 
 export default {
   title: 'composables/useElementBackground',
 }
 
-export const Default = () => ({
+export const Default: StoryFn = () => ({
   components: { VaButton, UseElementBackgroundDummy },
   data () {
     return {

--- a/packages/ui/src/services/color/ColorCSSVariablesUpdater.stories.ts
+++ b/packages/ui/src/services/color/ColorCSSVariablesUpdater.stories.ts
@@ -9,7 +9,7 @@ export const Default = () => ({
   components: { VaChip, VaButton },
   setup () {
     const colors = useColors()
-    const change = (color) => {
+    const change = (color: string) => {
       colors.setColors({ danger: color })
     }
 

--- a/packages/ui/tsconfig.build.json
+++ b/packages/ui/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
+  "exclude": [
+    "../node_modules",
+    "node_modules",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.disabled.ts",
+    "src/components/wip-*/**.*",
+    "src/services/api-docs",
+    "src/**/*.demo.vue",
+    "src/**/*.stories.ts",
+    "src/**/*.new.stories.ts",
+    ".storybook"
+  ]
+}

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -6,7 +6,6 @@
     "jsx": "preserve",
     "importHelpers": true,
     "moduleResolution": "node",
-    "rootDir": "src",
     "skipLibCheck": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
@@ -14,6 +13,9 @@
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
     "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
     "declarationMap": false,
     "allowJs": true,
     // https://vitejs.dev/guide/features.html#typescript-compiler-options
@@ -21,7 +23,9 @@
     // "isolatedModules": true,
     "types": [
       "webpack-env",
-      "vite/client"
+      "vite/client",
+      "jest",
+      "@testing-library/jest-dom"
     ],
     "lib": [
       "esnext",
@@ -43,9 +47,6 @@
     "src/**/*.spec.disabled.ts",
     "src/components/wip-*/**.*",
     "src/services/api-docs",
-    "src/**/*.demo.vue",
-    "src/**/*.stories.ts",
-    "src/**/*.new.stories.ts",
     ".storybook",
   ]
 }


### PR DESCRIPTION
Closes: #4042

## Description
Setup proper type checking in stories and eliminated preexisting TS errors

## What was done

- Fixed problem that importing .vue files in stories raised TS error "Cannot find module or its corresponding type declarations." via including *.stories.ts files in tsconfig.json #4042
- Added separate tsconfig.build.json to pass to `build:types` so that stories still don't end up in generated type declarations
- Added `typecheck` script for type checking all project code including stories and hooked in precommit stage
- Fixed more TS errors that popped up on `typecheck`, namely:
  - Typed all stories with interactions `play` with `StoryFn`
  - Added "@testing-library/jest-dom" types to tsconfig to have jest-dom assertions methods on expect properly typed 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
