### PR TITLE
fix(stateful): use provided prop instead of default value if provided.

### DIFF
--- a/packages/ui/src/components/va-carousel/VaCarousel.vue
+++ b/packages/ui/src/components/va-carousel/VaCarousel.vue
@@ -166,7 +166,7 @@ export default defineComponent({
   emits: [...useStatefulEmits],
 
   setup (props, { emit }) {
-    const { valueComputed: currentSlide } = useStateful(props, emit, 'modelValue', { defaultValue: 0 })
+    const { valueComputed: currentSlide } = useStateful(props, emit, 'modelValue')
 
     const {
       goTo, next, prev,

--- a/packages/ui/src/components/va-form/VaForm.stories.ts
+++ b/packages/ui/src/components/va-form/VaForm.stories.ts
@@ -23,6 +23,7 @@ import {
   VaRadio,
 } from '../'
 import { sleep } from '../../utils/sleep'
+import { useForm } from '../../composables'
 
 export default {
   title: 'VaForm',
@@ -475,3 +476,66 @@ addText(
   'This is old demo resqued to have visual tests, but we want to rewrite it eventually.',
   'stale',
 )
+
+export const FormDataInitialValue = () => ({
+  components: {
+    VaForm,
+    VaInput,
+    VaSelect,
+    VaDateInput,
+    VaTimeInput,
+    VaOptionList,
+    VaButton,
+  },
+  data: () => ({
+    input: 'value',
+    checkbox: true,
+    date: new Date(0),
+    time: new Date(0),
+    options: OPTIONS,
+    select: OPTIONS[0],
+    validationRules: [false],
+  }),
+  setup () {
+    const form = useForm('formEl')
+
+    return {
+      form,
+    }
+  },
+  template: `
+    [form data]: <pre>{{ form.formData }}</pre>
+
+    <va-form ref="formEl" stateful>
+      <va-checkbox
+        v-model="checkbox"
+        :rules="validationRules"
+        name="checkbox"
+      />
+      <va-date-input
+        v-model="date"
+        :rules="validationRules"
+        name="date"
+      />
+      <va-input
+        v-model="input"
+        :rules="validationRules"
+        name="text"
+      />
+      <va-select
+        v-model="select"
+        :options="options"
+        :rules="validationRules"
+        name="select"
+      />
+      <va-time-input
+        v-model="time"
+        :rules="validationRules"
+        name="time"
+      />
+    </va-form>
+    <va-button @click="$refs.form.reset()">
+      Reset form
+    </va-button>
+  `,
+})

--- a/packages/ui/src/components/va-input/VaInput.stories.ts
+++ b/packages/ui/src/components/va-input/VaInput.stories.ts
@@ -1,3 +1,4 @@
+import { ref } from 'vue'
 import VaInputDemo from './VaInput.demo.vue'
 import VaInput from './VaInput.vue'
 import { expect } from '@storybook/jest'
@@ -17,6 +18,11 @@ export const OldDemos = () => ({
 export const Loading = () => ({
   components: { VaInput },
   template: '<VaInput loading />',
+})
+
+export const Stateful = () => ({
+  components: { VaInput },
+  template: '<VaInput stateful />',
 })
 
 export const Clearable = () => ({

--- a/packages/ui/src/components/va-input/VaInput.vue
+++ b/packages/ui/src/components/va-input/VaInput.vue
@@ -103,7 +103,7 @@ export default defineComponent({
     // input
     placeholder: { type: String, default: '' },
     tabindex: { type: [String, Number], default: 0 },
-    modelValue: { type: [String, Number] },
+    modelValue: { type: [Number, String], default: '' },
     type: { type: String as AnyStringPropType<'text' | 'password'>, default: 'text' },
     inputClass: { type: String, default: '' },
     pattern: { type: String },
@@ -132,7 +132,7 @@ export default defineComponent({
 
     const input = shallowRef<HTMLInputElement>()
 
-    const { valueComputed } = useStateful(props, emit, 'modelValue', { defaultValue: '' })
+    const { valueComputed } = useStateful(props, emit, 'modelValue')
 
     const reset = () => withoutValidation(() => {
       emit('update:modelValue', props.clearValue)

--- a/packages/ui/src/components/va-select/VaSelect.stories.ts
+++ b/packages/ui/src/components/va-select/VaSelect.stories.ts
@@ -29,7 +29,7 @@ export const Validation: StoryFn = () => ({
   components: { VaSelect },
 
   data () {
-    return { value: '', options: ['one', 'two', 'tree'], rules: [(v: string) => (v && v === 'one') || 'Must be one'] }
+    return { value: '', options: ['one', 'two', 'three'], rules: [(v: string) => (v && v === 'one') || 'Must be one'] }
   },
 
   template: '<VaSelect v-model="value" :options="options" :rules="rules" />',
@@ -46,7 +46,7 @@ export const ImmediateValidation: StoryFn = () => ({
   components: { VaSelect },
 
   data () {
-    return { value: '', options: ['one', 'two', 'tree'], rules: [(v: string) => (v && v === 'one') || 'Must be one'] }
+    return { value: '', options: ['one', 'two', 'three'], rules: [(v: string) => (v && v === 'one') || 'Must be one'] }
   },
 
   template: '<VaSelect v-model="value" :options="options" :rules="rules" immediate-validation />',
@@ -63,7 +63,7 @@ export const DirtyValidation: StoryFn = () => ({
   components: { Component: VaSelect },
 
   data () {
-    return { value: '', dirty: false, haveError: false, options: ['one', 'two', 'tree'], rules: [(v: string) => (v && v === 'one') || 'Must be one'] }
+    return { value: '', dirty: false, haveError: false, options: ['one', 'two', 'three'], rules: [(v: string) => (v && v === 'one') || 'Must be one'] }
   },
 
   template: `
@@ -104,7 +104,7 @@ export const DirtyImmediateValidation: StoryFn = () => ({
   components: { Component: VaSelect },
 
   data () {
-    return { value: '', dirty: false, haveError: false, options: ['one', 'two', 'tree'], rules: [(v: string) => (v && v === 'one') || 'Must be one'] }
+    return { value: '', dirty: false, haveError: false, options: ['one', 'two', 'three'], rules: [(v: string) => (v && v === 'one') || 'Must be one'] }
   },
 
   template: `
@@ -124,3 +124,24 @@ DirtyImmediateValidation.play = async ({ canvasElement, step }) => {
     expect(error).not.toBeNull()
   })
 }
+
+export const Autocomplete: StoryFn = () => ({
+  components: { VaSelect },
+
+  data () {
+    // Test if initial value is correctly set
+    return { value: 'one', options: ['one', 'two', 'three'] }
+  },
+
+  template: '<VaSelect v-model="value" :options="options" autocomplete />',
+})
+
+export const AutocompleteMultiple: StoryFn = () => ({
+  components: { VaSelect },
+
+  data () {
+    return { value: ['one', 'two'], options: ['one', 'two', 'three'] }
+  },
+
+  template: '<VaSelect v-model="value" :options="options" autocomplete multiple />',
+})

--- a/packages/ui/src/components/va-select/hooks/useAutocomplete.ts
+++ b/packages/ui/src/components/va-select/hooks/useAutocomplete.ts
@@ -17,6 +17,11 @@ export const useAutocomplete = (
 ) => {
   const getLastOptionText = (v: SelectOption[]) => v?.length ? getText(v.at(-1)!) : ''
 
+  if (props.autocomplete && !props.multiple) {
+    // Set current value as autocomplete value text
+    autocompleteValue.value = getLastOptionText(value.value)
+  }
+
   watch(value, (newValue, oldValue) => {
     if (!props.autocomplete) { return }
 

--- a/packages/ui/src/components/va-stepper/VaStepper.vue
+++ b/packages/ui/src/components/va-stepper/VaStepper.vue
@@ -116,7 +116,7 @@ export default defineComponent({
   emits: ['update:modelValue', 'finish', 'update:steps'],
   setup (props, { emit }) {
     const stepperNavigation = shallowRef<HTMLElement>()
-    const { valueComputed: modelValue }: { valueComputed: Ref<number> } = useStateful(props, emit, 'modelValue', { defaultValue: 0 })
+    const { valueComputed: modelValue }: { valueComputed: Ref<number> } = useStateful(props, emit, 'modelValue')
 
     const focusedStep = ref({ trigger: false, stepIndex: props.navigationDisabled ? -1 : props.modelValue })
 

--- a/packages/ui/src/composables/tests/useStateful.spec.ts
+++ b/packages/ui/src/composables/tests/useStateful.spec.ts
@@ -30,13 +30,18 @@ describe('useStateful', () => {
     [ true,      true,        true      ],
     [ false,     true,        undefined ],
     /* eslint-enable */
-  ])('stateful %s', async (stateful: boolean, valueToSet: boolean, internalValue?: true) => {
-    const wrapper = mount(TestComponentRich, { props: { stateful } })
+  ])('stateful %s', async (stateful: boolean, valueToSet: boolean, internalValue?: boolean) => {
+    const wrapper = mount(TestComponentRich, { props: { stateful } as any })
     wrapper.vm.valueComputed = valueToSet
     expect(wrapper.emitted()['update:modelValue']).toBeTruthy()
     expect(wrapper.vm.valueComputed).toBe(internalValue)
 
     await wrapper.setProps({ modelValue: false })
     expect(wrapper.vm.valueComputed).toBe(false)
+  })
+
+  it('should react to prop change', async () => {
+    const wrapper = mount(TestComponentRich, { props: { stateful: true, modelValue: 'Hello!' } })
+    expect(wrapper.vm.valueComputed).toBe('Hello!')
   })
 })

--- a/packages/ui/src/composables/tests/useUserProvidedProp.spec.ts
+++ b/packages/ui/src/composables/tests/useUserProvidedProp.spec.ts
@@ -1,0 +1,27 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import { defineComponent } from 'vue'
+import { NOT_PROVIDED, useUserProvidedProp } from '../useUserProvidedProp'
+
+const TestComponentRich = defineComponent({
+  template: '<p></p>',
+  props: { modelValue: { type: String } },
+  setup (props) {
+    const providedProp = useUserProvidedProp('modelValue', props)
+
+    return {
+      providedProp,
+    }
+  },
+  emits: ['update:modelValue'],
+})
+
+describe('useUserProvidedProp', () => {
+  it('should react to prop change', async () => {
+    const wrapper = mount(TestComponentRich, { props: { stateful: true } } as any)
+    expect(wrapper.vm.providedProp).toBe(NOT_PROVIDED)
+
+    await wrapper.setProps({ modelValue: 'Hello' })
+    expect(wrapper.vm.providedProp).toBe('Hello')
+  })
+})

--- a/packages/ui/src/composables/useSelectable.ts
+++ b/packages/ui/src/composables/useSelectable.ts
@@ -15,6 +15,7 @@ export type SelectableProps<V = any> = StatefulProps & LoadingProps & ExtractPro
   indeterminateValue: V | null,
   disabled: boolean,
   readonly: boolean,
+  modelValue: unknown
 }
 
 export type Elements = {

--- a/packages/ui/src/composables/useUserProvidedProp.ts
+++ b/packages/ui/src/composables/useUserProvidedProp.ts
@@ -1,0 +1,14 @@
+import { computed, getCurrentInstance } from 'vue'
+
+export const NOT_PROVIDED = Symbol('NOT_PROVIDED')
+
+export const useUserProvidedProp = <Name extends string, Props extends Record<Name, any>>(propName: Name, props: Props) => {
+  const vm = getCurrentInstance()!
+
+  return computed(() => {
+    if (!vm?.vnode.props) { return null }
+    const originalProp = props[propName]
+    // If vnode doesn't have this prop it mean default value is used
+    return propName in vm.vnode.props ? originalProp as Props[Name] : NOT_PROVIDED
+  })
+}


### PR DESCRIPTION
> I see how I can create form data with a new form, but how would I prepopulate data? 
> 
> I cant do myForm.formData.value = {} as SomeType, because .value is readonly. Is formData only able to used to create records and not edit them? I was wondering about this approach because I'm experiencing issues with clearing a form by setting the v-model object to empty or null which immediately fires the form validation. This happens wether or not I call reset() or try and use resetValidation() to clear messages.

Fix this example: https://ui-experimental.vuestic.dev/play#eNp9Ustu2zAQ/BVCFydAZAHJzVACNE0CpGjdoi1y4oWWVzYTvsCHY8PQv2dJWpLzgC+SODszO1ztvvhmzHQToJgVtWssN5448MEQwdTqmhbe0eKGKkK4NNp6sifBwYO2knSktVqSCYqd500Z+ISqyGy0cpHYIuuOeYbM6151NpG7+J6cU1VXuSHa48GDNIJ5SM3qJ5Z6WGgxQ5bQgjiPhDYI0gjmXKwsykvSCtimR9loQVbMlJeHzMnoUZngidRLEE9MBEDZL/bidtFQMRnPLbfOz/EbIcEWIBB7iBg5gNVJuzkstVvDZjTEeB/9fiL0hR0OCLLlLHmWm4OpglcSi2fno+2CW7++Y7sj29sIkWXCsm1d5eGlseIxiL6b4Df5VtFuRvbjL5oOEyBdV1dIHCUp+GdFf8XPgiHSe0Ef/lhQVyldXR39faqKiyJvWymZmT47rXA795FPDwVcSjTPLWkxbmCEabH23rhZVQVewtaA5RKUZyKueeRNl7Cpeo0OvpKMK2xDi2jYUdVhAO9wjVu++tC+0dJwAfa38RzX/F0MJoR+/ZEwbwNc9HizhublC/zZbXPePxYc2A1uxlDzzK7A5/L9vzls8Xso4qIEgewTxb/gtAgxY6bdBrXE2Ee8lPYxTZOr1X93v/WgXH+pGDRNI/HTiL+fuPoY92p6NUyxewPj83Vs