### PR TITLE
Refactor Textarea autosize prop to handle when a single line takes up multiple rows

### DIFF
--- a/packages/ui/src/components/va-textarea/VaTextarea.vue
+++ b/packages/ui/src/components/va-textarea/VaTextarea.vue
@@ -116,25 +116,23 @@ export default defineComponent({
     const isResizable = computed(() => {
       return props.resize && !props.autosize
     })
+
     const textareaHeight = ref('auto')
 
     const updateTextareaHeight = () => {
       if (!textarea.value) {
         return false
       }
-      console.log('updateTextareaHeight')
+
       textarea.value.style.height = '0'
-      const scrollHeight = textarea.value?.scrollHeight
+
+      const totalHeight = textarea.value?.scrollHeight
+
       const lineHeight = parseInt(
         window.getComputedStyle(textarea.value)?.lineHeight,
         10,
       )
-      let rows = scrollHeight / lineHeight
-
-      console.log('scrollHeight', scrollHeight)
-      console.log('lineHeight', lineHeight)
-      console.log('rows', rows)
-      console.log('Rounded Rows = ', Math.round(scrollHeight / lineHeight))
+      let rows = totalHeight / lineHeight
 
       if (props.maxRows) {
         rows = Math.max(props.minRows, Math.min(rows, props.maxRows))
@@ -145,8 +143,6 @@ export default defineComponent({
       }
 
       const height = rows * lineHeight + 'px'
-
-      console.log('height = ', height)
 
       textareaHeight.value = '' + height
     }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
When using `autosize`, the previous calculation for rows was based on finding new line characters "\n" in the textbox value. This meant the height didn't adjust when a single line wrapped around to a new line. 

This changes the computation to use lineHeight and scrollHeight to determine the number of visible rows for the textbox regardless of new line characters. It still respects `min-rows` and `max-rows` props when provided.

## Markup:
<!-- Paste your markup here. -->
<details>

```vue
...
    //removed computedRowsCount

    const textareaHeight = ref('auto')

    const updateTextareaHeight = () => {
      if (!textarea.value) {
        return false
      }

      textarea.value.style.height = '0'

      const totalHeight = textarea.value?.scrollHeight

      const lineHeight = parseInt(
        window.getComputedStyle(textarea.value)?.lineHeight,
        10,
      )
      let rows = totalHeight / lineHeight

      if (props.maxRows) {
        rows = Math.max(props.minRows, Math.min(rows, props.maxRows))
      }

      if (props.minRows) {
        rows = Math.max(props.minRows, rows)
      }

      const height = rows * lineHeight + 'px'

      textareaHeight.value = '' + height
    }

    watch([valueComputed, textarea], updateTextareaHeight, { immediate: true })

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
