### PR TITLE
Update useSortable.ts

### DIFF
--- a/packages/ui/src/components/va-data-table/hooks/useSortable.ts
+++ b/packages/ui/src/components/va-data-table/hooks/useSortable.ts
@@ -14,7 +14,7 @@ export const useSortableProps = {
   ...useThrottleProps,
   sortBy: { type: String as PropType<string | undefined> },
   columnSorted: { type: Object as PropType<any | undefined> },
-  sortingOrder: { type: String as PropType<DataTableSortingOrder | null | undefined> },
+  sortingOrder: { type: [String, null] as PropType<DataTableSortingOrder | undefined> },
 }
 
 export type TSortedArgs = { sortBy: string, sortingOrder: DataTableSortingOrder, items: DataTableItem[], itemsIndexes: number[] }

--- a/packages/ui/src/components/va-data-table/hooks/useSortable.ts
+++ b/packages/ui/src/components/va-data-table/hooks/useSortable.ts
@@ -14,7 +14,7 @@ export const useSortableProps = {
   ...useThrottleProps,
   sortBy: { type: String as PropType<string | undefined> },
   columnSorted: { type: Object as PropType<any | undefined> },
-  sortingOrder: { type: String as PropType<DataTableSortingOrder | undefined> },
+  sortingOrder: { type: String as PropType<DataTableSortingOrder | null | undefined> },
 }
 
 export type TSortedArgs = { sortBy: string, sortingOrder: DataTableSortingOrder, items: DataTableItem[], itemsIndexes: number[] }


### PR DESCRIPTION
closes #4063

## Description
I added null as a prop option on the sortingOrder

## Markup:
<details>

```vue
export const useSortableProps = {
  ...useThrottleProps,
  sortBy: { type: String as PropType<string | undefined> },
  columnSorted: { type: Object as PropType<any | undefined> },
  sortingOrder: { type: String as PropType<DataTableSortingOrder | null | undefined> },
}
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
