### PR TITLE
fix(#4068): use text-color prop in collapse

### DIFF
--- a/packages/ui/src/components/va-collapse/VaCollapse.stories.ts
+++ b/packages/ui/src/components/va-collapse/VaCollapse.stories.ts
@@ -34,3 +34,71 @@ export const Overflow: StoryFn = () => defineComponent({
     </VaCollapse>
   `,
 })
+
+export const Color: StoryFn = () => defineComponent({
+  components: { VaCollapse },
+
+  data: () => ({ open: true }), // Open be default
+
+  template: `
+    <VaCollapse v-model="open" color="warning">
+      <template #header-content>
+        Header
+      </template>
+      <template #content>
+        Content
+      </template>
+    </VaCollapse>
+  `,
+})
+
+export const TextColor: StoryFn = () => defineComponent({
+  components: { VaCollapse },
+
+  data: () => ({ open: true }), // Open be default
+
+  template: `
+    <VaCollapse v-model="open" text-color="warning">
+      <template #header-content>
+        Header
+      </template>
+      <template #content>
+        Content
+      </template>
+    </VaCollapse>
+  `,
+})
+
+export const TextColorWithBackground: StoryFn = () => defineComponent({
+  components: { VaCollapse },
+
+  data: () => ({ open: true }), // Open be default
+
+  template: `
+    <VaCollapse v-model="open" color="warning" text-color="primary">
+      <template #header-content>
+        Header
+      </template>
+      <template #content>
+        Content
+      </template>
+    </VaCollapse>
+  `,
+})
+
+export const BodyTextColorWithBackground: StoryFn = () => defineComponent({
+  components: { VaCollapse },
+
+  data: () => ({ open: true }), // Open be default
+
+  template: `
+    <VaCollapse v-model="open" body-color="warning" body-text-color="primary">
+      <template #header-content>
+        Header
+      </template>
+      <template #content>
+        Content
+      </template>
+    </VaCollapse>
+  `,
+})

--- a/packages/ui/src/components/va-collapse/VaCollapse.vue
+++ b/packages/ui/src/components/va-collapse/VaCollapse.vue
@@ -113,6 +113,7 @@ export default defineComponent({
     color: { type: String, default: undefined },
     bodyColor: { type: String, default: undefined },
     textColor: { type: String, default: '' },
+    bodyTextColor: { type: String, default: '' },
     iconColor: { type: String, default: 'secondary' },
     colorAll: { type: Boolean, default: false },
     stateful: { type: Boolean, default: true },
@@ -197,6 +198,27 @@ export default defineComponent({
       computedModelValue.value = !computedModelValue.value
     }
 
+    const { textColorComputed } = useTextColor(headerBackground)
+
+    const headerStyle = computed(() => ({
+      color: textColorComputed.value,
+      backgroundColor: headerBackground.value,
+    }))
+
+    const contentStyle = computed(() => {
+      return {
+        visibility: bodyHeight.value > 0 ? 'visible' as const : 'hidden' as const,
+        height: `${height.value}px`,
+        transitionDuration: getTransition(),
+        background: computedModelValue.value ? contentBackground.value : '',
+        color: props.bodyTextColor
+          ? getColor(props.bodyTextColor)
+          : contentBackground.value
+            ? getColor(getTextColor(contentBackground.value))
+            : 'currentColor',
+      }
+    })
+
     return {
       onTransitionEnd,
       body,
@@ -212,20 +234,9 @@ export default defineComponent({
 
       computedClasses,
 
-      headerStyle: computed(() => ({
-        color: headerBackground.value ? getColor(getTextColor(headerBackground.value)) : 'currentColor',
-        backgroundColor: headerBackground.value,
-      })),
+      headerStyle,
 
-      contentStyle: computed(() => {
-        return {
-          visibility: bodyHeight.value > 0 ? 'visible' as const : 'hidden' as const,
-          height: `${height.value}px`,
-          transitionDuration: getTransition(),
-          background: computedModelValue.value ? contentBackground.value : '',
-          color: contentBackground.value ? getColor(getTextColor(contentBackground.value)) : 'currentColor',
-        }
-      }),
+      contentStyle,
     }
   },
 })


### PR DESCRIPTION
closes #4068

<img width="764" alt="image" src="https://github.com/epicmaxco/vuestic-ui/assets/23530004/d323b7a9-f94b-4e71-b3e1-3b831048fb9a">
<img width="778" alt="image" src="https://github.com/epicmaxco/vuestic-ui/assets/23530004/da0dac3b-194c-407d-881b-17088f42a2fa">
<img width="778" alt="image" src="https://github.com/epicmaxco/vuestic-ui/assets/23530004/f6feb803-4ff4-414a-aabd-40d3c71e3264">
