### PR TITLE
fix(#4132): remove getCurrentInstance from computed

### DIFF
--- a/packages/ui/src/composables/useAppContext.ts
+++ b/packages/ui/src/composables/useAppContext.ts
@@ -8,7 +8,9 @@ import { getCurrentApp } from '../services/current-app'
  * (for example in api.ts)
  */
 export const useAppContext = () => {
+  const currentInstance = getCurrentInstance()
+
   return computed(() => {
-    return getCurrentApp()?._context || getCurrentInstance()?.appContext
+    return getCurrentApp()?._context || currentInstance?.appContext
   })
 }

--- a/packages/ui/src/composables/useRouterLink.ts
+++ b/packages/ui/src/composables/useRouterLink.ts
@@ -16,7 +16,9 @@ export const useRouterLinkProps = {
 }
 
 export const useRouterLink = (props: ExtractPropTypes<typeof useRouterLinkProps>) => {
-  const globalProperties = computed(() => getCurrentInstance()?.appContext.config.globalProperties)
+  const currentInstance = getCurrentInstance()
+
+  const globalProperties = computed(() => currentInstance?.appContext.config.globalProperties)
   const vueRouter = computed(() => globalProperties.value?.$router)
   const vueRoute = computed(() => globalProperties.value?.$route)
 


### PR DESCRIPTION
closes #4132 

Must be available in 1.8.4