### PR TITLE
Fix: vaChip story example with link

### DIFF
--- a/packages/ui/src/components/va-chip/VaChip.stories.ts
+++ b/packages/ui/src/components/va-chip/VaChip.stories.ts
@@ -73,7 +73,7 @@ export const Closeable = () => ({
 
 export const Link = () => ({
   components: { VaChip },
-  template: '<VaChip to="/?path=/docs/vachip--docs">text</VaChip>',
+  template: '<VaChip href="/?path=/docs/vachip--docs" target="_blank">text</VaChip>',
 })
 
 export const Disabled = () => ({


### PR DESCRIPTION
PR closes #4072 

In storybook example with link was router-link so it was doing nothing. Updated it so it will open the same storybook page in the new tab so it demonstrates functionality. 

P.S I think making cursor for VaChip pointer when it is a link or clickable element is a way to go