### PR TITLE
fix(docs): fixed hyperlink url in layout page

### DIFF
--- a/packages/docs/page-config/ui-elements/layout/index.ts
+++ b/packages/docs/page-config/ui-elements/layout/index.ts
@@ -41,7 +41,7 @@ VaLayout component could be used in pair with [VaSidebar](/ui-elements/sidebar)[
 
     block.example('MobileFriendly', {
       title: 'Mobile friendly',
-      description: 'It is recommended to make `left` and `right` areas absolute on mobile devices. You can use `absolute` prop to do it in pair with [useBreakpoint](http://localhost:3000/services/breakpoints)[[target=_blank]] composable.',
+      description: 'It is recommended to make `left` and `right` areas absolute on mobile devices. You can use `absolute` prop to do it in pair with [useBreakpoint](/services/breakpoints)[[target=_blank]] composable.',
     }),
 
     block.subtitle('Accessibility'),


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail -->
 In section [https://ui.vuestic.dev/ui-elements/layout#mobile-friendly](url)
fixed the URL of the hyperlink _useBreakpoint_, that leads to localhost:3000

## Markup:
<!-- Paste your markup here. -->
<details>

```vue
description: 'It is recommended to make `left` and `right` areas absolute on mobile devices. You can use `absolute` prop to do it in pair with [useBreakpoint](/services/breakpoints)[[target=_blank]] composable.',

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
