### PR TITLE
fix(docs):added missing imports in examples

### DIFF
--- a/packages/docs/page-config/services/colors-config/examples/change-colors.vue
+++ b/packages/docs/page-config/services/colors-config/examples/change-colors.vue
@@ -13,6 +13,8 @@
 </template>
 
 <script setup>
+import { useColors } from 'vuestic-ui';
+
 const { getComputedColor } = useColors();
 
 const colorsToChange = [

--- a/packages/docs/page-config/styles/colors/examples/ThemeSwitcher.vue
+++ b/packages/docs/page-config/styles/colors/examples/ThemeSwitcher.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { useColors } from "vuestic-ui";
 
 const { applyPreset, currentPresetName, colors } = useColors();

--- a/packages/docs/page-config/ui-elements/config/examples/Colors.vue
+++ b/packages/docs/page-config/ui-elements/config/examples/Colors.vue
@@ -20,6 +20,8 @@
 </template>
 
 <script setup lang="ts">
+  import { ref } from 'vue';
+
   const color = ref('#f0f')
   const presetName = ref('light')
 </script>

--- a/packages/docs/page-config/ui-elements/config/examples/Components.vue
+++ b/packages/docs/page-config/ui-elements/config/examples/Components.vue
@@ -35,5 +35,7 @@
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue';
+
 const config = ref();
 </script>

--- a/packages/docs/page-config/ui-elements/data-table/examples/AdvancedFiltering.vue
+++ b/packages/docs/page-config/ui-elements/data-table/examples/AdvancedFiltering.vue
@@ -25,6 +25,8 @@
 </template>
 
 <script setup>
+import { ref } from 'vue';
+
 const items = [
   {
     id: 1,

--- a/packages/docs/page-config/ui-elements/form/examples/Default.vue
+++ b/packages/docs/page-config/ui-elements/form/examples/Default.vue
@@ -93,7 +93,8 @@
 </template>
 
 <script setup lang="ts">
-  import { useForm } from 'vuestic-ui'
+  import { reactive } from 'vue';
+  import { useForm } from 'vuestic-ui';
 
   const { isValid, validate, reset, resetValidation } = useForm('formRef')
 

--- a/packages/docs/page-config/ui-elements/form/examples/HideErrors.vue
+++ b/packages/docs/page-config/ui-elements/form/examples/HideErrors.vue
@@ -29,6 +29,7 @@
 </template>
 
 <script setup lang="ts">
+import { reactive } from "vue";
 import { useForm } from "vuestic-ui";
 
 const form = reactive({

--- a/packages/docs/page-config/ui-elements/layout/examples/Absolute.vue
+++ b/packages/docs/page-config/ui-elements/layout/examples/Absolute.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+  import { ref } from 'vue';
+  
   const showSidebar = ref(true)
 </script>
 

--- a/packages/docs/page-config/ui-elements/layout/examples/Fixed.vue
+++ b/packages/docs/page-config/ui-elements/layout/examples/Fixed.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+  import { ref } from 'vue';
+
   const showSidebar = ref(true)
 
   const menu = [

--- a/packages/docs/page-config/ui-elements/layout/examples/MobileFriendly.vue
+++ b/packages/docs/page-config/ui-elements/layout/examples/MobileFriendly.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+  import { ref } from 'vue';
+  import { useBreakpoint } from 'vuestic-ui';
+
   const showSidebar = ref(true)
 
   const breakpoints = useBreakpoint()

--- a/packages/docs/page-config/ui-elements/layout/examples/Order.vue
+++ b/packages/docs/page-config/ui-elements/layout/examples/Order.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+  import { ref, reactive } from 'vue';
+  import { useBreakpoint } from 'vuestic-ui';
+
   const showLeftSidebar = ref(true)
   const showRightSidebar = ref(true)
 

--- a/packages/docs/page-config/ui-elements/value/examples/WithInputs.vue
+++ b/packages/docs/page-config/ui-elements/value/examples/WithInputs.vue
@@ -16,6 +16,8 @@
 </template>
 
 <script setup lang="ts">
+  import { reactive } from 'vue';
+
   const form = reactive({
     name: 'Maksim',
     surname: 'Nedoshev'


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail -->
There is some places in docs where examples in playground cant be run because of missing imports, like 'ref' or composables from 'vuestic-ui'. Looked through all the places and added necessary imports 

## Markup:
<!-- Paste your markup here. -->
<details>

```vue
import { * } from 'vue'; 
import { * } from 'vuestic-ui';
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
