### PR TITLE
fix(VaSelect): show selected item properly when it's not multiple

### DIFF
--- a/packages/ui/src/components/va-select/components/VaSelectContent/VaSelectContent.vue
+++ b/packages/ui/src/components/va-select/components/VaSelectContent/VaSelectContent.vue
@@ -8,7 +8,7 @@
     </span>
 
     <slot
-      v-else-if="!(props.autocomplete && !props.multiple)"
+      v-else-if="!(props.autocomplete && props.multiple)"
       name="content"
       v-bind="{
         value: slotValue,


### PR DESCRIPTION
## Description
When you have a non autocomplete and non-multiple select, the selected option gets rendered a list of ',,,,'. This is because the current logic allows to enter into a block that should only be used if the multiple prop is true.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
