### PR TITLE
feat(VaPopper): support content-class attribute(#4182)

### DIFF
--- a/packages/ui/src/components/va-dropdown/VaDropdown.vue
+++ b/packages/ui/src/components/va-dropdown/VaDropdown.vue
@@ -76,6 +76,7 @@ export default defineComponent({
     keyboardNavigation: { type: Boolean, default: false },
     ariaLabel: { type: String, default: '$t:toggleDropdown' },
     role: { type: String as PropType<StringWithAutocomplete<'button' | 'none'>>, default: 'button' },
+    contentClass: { type: String, default: '' },
   },
 
   emits: [...useStatefulEmits, 'anchor-click', 'anchor-right-click', 'content-click', 'click-outside', 'focus-outside', 'close', 'open', 'anchor-dblclick'],
@@ -302,7 +303,7 @@ export default defineComponent({
 
     const floatingSlotNode = this.showFloating && renderSlotNode(this.$slots.default, slotBind, {
       ref: 'floating',
-      class: 'va-dropdown__content-wrapper',
+      class: ['va-dropdown__content-wrapper', this.$props.contentClass],
       style: [this.floatingStyles, { zIndex: this.zIndex }],
       ...this.teleportedAttrs,
       ...this.floatingListeners,

--- a/packages/ui/src/components/va-popover/VaPopover.demo.vue
+++ b/packages/ui/src/components/va-popover/VaPopover.demo.vue
@@ -188,6 +188,18 @@
             </va-popover>
           </td>
         </tr>
+        <tr>
+          <td>Content Class</td>
+          <td>
+            <va-popover
+              message="Popover Content Class with Large padding"
+              class="mr-6"
+              content-class="demo-popper-content-class"
+            >
+              <va-button>Content Class</va-button>
+            </va-popover>
+          </td>
+        </tr>
       </table>
     </VbCard>
   </VbDemo>
@@ -205,5 +217,11 @@ export default {
 .table {
   border-collapse: separate;
   border-spacing: 1rem;
+}
+</style>
+
+<style>
+.demo-popper-content-class {
+  --va-popover-content-padding: 2rem;
 }
 </style>

--- a/packages/ui/src/components/va-popover/VaPopover.vue
+++ b/packages/ui/src/components/va-popover/VaPopover.vue
@@ -11,6 +11,7 @@
         :style="computedPopoverStyle"
         class="va-popover__content"
         role="tooltip"
+        :class="$props.contentClass"
       >
         <div
           v-if="showIconComputed"
@@ -65,6 +66,7 @@ const props = defineProps({
   message: { type: String, default: '' },
   autoHide: { type: Boolean, default: true },
   offset: { type: [Array, Number] as PropType<number | [number, number]>, default: 4 },
+  contentClass: { type: String, default: '' },
 })
 
 const VaDropdownPropValues = filterComponentProps(VaDropdownProps)

--- a/packages/ui/src/components/va-popover/VaPopover.vue
+++ b/packages/ui/src/components/va-popover/VaPopover.vue
@@ -4,6 +4,7 @@
     :model-value="modelValue"
     :close-on-click-outside="autoHide"
     :offset="$props.offset"
+    :content-class="$props.contentClass"
     class="va-popover"
   >
     <template #default>
@@ -11,7 +12,6 @@
         :style="computedPopoverStyle"
         class="va-popover__content"
         role="tooltip"
-        :class="$props.contentClass"
       >
         <div
           v-if="showIconComputed"


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail -->

Add content-class properties to the VaPopover component to enable a method for changing the popover content on the body element.

closed #4182 

## Markup:
<!-- Paste your markup here. -->
<details>

```vue
<va-popover
              message="Popover Content Class with Large padding"
              class="mr-6"
              content-class="demo-popper-content-class"
            >
              <va-button>Content Class</va-button>
</va-popover>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
