### PR TITLE
fix(VaSelect): fix `objects-as-options` cannot set status correctly(#4198)

### DIFF
--- a/packages/ui/src/components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/va-select/VaSelect.vue
@@ -422,7 +422,7 @@ const selectOption = (option: SelectOption) => {
       valueComputed.value = addOption(option)
     }
   } else {
-    valueComputed.value = typeof option !== 'object' ? option : { ...option }
+    valueComputed.value = option
     hideAndFocus()
   }
 


### PR DESCRIPTION
closed #4198 

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail -->

Objects should always retain their references because the default method of checking object equality relies on comparing object references when the value of 'valueBy' does not exist, thereby comparing two object references.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
