### PR TITLE
fix:Workaround for using arrays as default options in nuxt module closes #4213

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -9,6 +9,8 @@ import { useConfigFile } from './composables/use-config-file'
 
 import type { VuesticOptions } from './types'
 
+const VUESTIC_DEFAULT_CSS = ['smart-helpers', 'typography'] as VuesticOptions['css']
+
 export default defineNuxtModule<VuesticOptions>({
   meta: {
     name: '@vuestic/nuxt',
@@ -20,12 +22,15 @@ export default defineNuxtModule<VuesticOptions>({
 
   defaults: {
     config: {},
-    css: ['smart-helpers', 'typography'],
+    css: [],
     fonts: true,
     themeCookieKey: 'vuestic-theme',
   },
 
   setup (options) {
+    if (Array.isArray(options.css) && options.css.length === 0) {
+      options.css = VUESTIC_DEFAULT_CSS
+    }
     useConfigFile()
     useVuesticCSS(options)
     useVuesticPlugin(options)


### PR DESCRIPTION
## Description
Vuestic's option "css" accepts an array of  css modules as an input. 
The default value of that option is ['smart-helpers', 'typography']. 
The problem is that nuxt won't override the default array with an array passed by user (it's a known issue). Instaed two arrays will be concatenated. 

For example, I want to use only a typography css module, so I set the css option to ['typography'].
![image](https://github.com/epicmaxco/vuestic-ui/assets/40028882/60904389-4059-49ba-b46e-c3b7f0d9a8f3)
In that case I expect the css option to be ['typography'] according to documentations.
Instead i have this:
![image](https://github.com/epicmaxco/vuestic-ui/assets/40028882/97ae60b0-4d1d-497c-a884-742ba6beacb7)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
