### PR TITLE
bug: updated the color-input pop-up positon for chrome and edge browser to bottom right

### DIFF
--- a/packages/ui/src/components/va-color-input/VaColorInput.vue
+++ b/packages/ui/src/components/va-color-input/VaColorInput.vue
@@ -90,6 +90,7 @@ const { tp } = useTranslation()
 .va-color-input {
   display: flex;
   align-items: center !important;
+  position: relative;
 
   .form-group {
     margin-bottom: 0;
@@ -111,6 +112,22 @@ const { tp } = useTranslation()
     overflow: hidden;
     position: absolute;
     pointer-events: none;
+    bottom: 0;
+  }
+
+  // Currently I could only determine the width of the color modal on Edge and Chrome
+  @supports (-ms-ime-align:auto) {
+    /* Edge specific */
+    &__hidden-input {
+      right: 14.7rem; // For Edge and Chrome the color picker modal size is 14.7rem
+    }
+  }
+
+  @media screen and (-webkit-min-device-pixel-ratio: 0) {
+    /* Chrome specific */
+    &__hidden-input {
+      right: 14.7rem; // For Edge and Chrome the color picker modal size is 14.7rem
+    }
   }
 }
 </style>


### PR DESCRIPTION
…o bottom right

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail -->
- [x] updated the color-input pop-up positon for chrome and edge browser to bottom right of the input

## Screenshots
- Edge
![Screenshot 2024-04-17 at 08 10 24](https://github.com/epicmaxco/vuestic-ui/assets/166782331/afa7c2f1-6097-4cd6-b41f-b989c509a056)
- Chrome
![Screenshot 2024-04-17 at 08 22 43](https://github.com/epicmaxco/vuestic-ui/assets/166782331/81511409-0610-4f66-bec0-adb4738163dd)

## Issue
https://github.com/epicmaxco/vuestic-ui/issues/3454

## Markup:
<!-- Paste your markup here. -->
<details>

```vue
<style lang="scss">
.va-color-input {
  display: flex;
  align-items: center !important;
  position: relative;

  .form-group {
    margin-bottom: 0;
  }

  &__input {
    margin-bottom: 0;
    min-width: 5.6rem;

    &__pointer {
      cursor: pointer;
    }
  }

  &__hidden-input {
    visibility: hidden;
    width: 0;
    height: 0;
    overflow: hidden;
    position: absolute;
    pointer-events: none;
    bottom: 0;
  }

  // Currently I could only determine the width of the color modal on Edge and Chrome
  @supports (-ms-ime-align:auto) {
    /* Edge specific */
    &__hidden-input {
      right: 14.7rem; // For Edge and Chrome the color picker modal size is 14.7rem
    }
  }

  @media screen and (-webkit-min-device-pixel-ratio: 0) {
    /* Chrome specific */
    &__hidden-input {
      right: 14.7rem; // For Edge and Chrome the color picker modal size is 14.7rem
    }
  }
}
</style>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
