### PR TITLE
fix(VaDataTable): use background color and opacity without mixin

### DIFF
--- a/packages/ui/src/components/va-data-table/VaDataTable.vue
+++ b/packages/ui/src/components/va-data-table/VaDataTable.vue
@@ -531,8 +531,8 @@ const cellData = (cellData: DataTableCell, internalColumnData: DataTableColumnIn
               td {
                 // Position relative doesn't work on tr in Safari
                 position: relative;
-
-                @include va-background(var(--va-data-table-striped-tr-background-color), var(--va-data-table-striped-tr-opacity), -1);
+                background: var(--va-data-table-striped-tr-background-color);
+                opacity: var(--va-data-table-striped-tr-opacity);
               }
             }
           }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->
## Description
used background color and opacity without mixin
![Screenshot 2024-04-25 at 06 39 05](https://github.com/epicmaxco/vuestic-ui/assets/166782331/c4ac2488-c47c-402a-9795-0174cc881f14)
![Screenshot 2024-04-25 at 06 39 12](https://github.com/epicmaxco/vuestic-ui/assets/166782331/6b0d33b1-7cbf-4f16-9fd9-198f7c1808eb)

closes #4236 

## Markup:
<details>

```vue
    &.striped {
      .va-data-table__table-tbody {
        .va-data-table__table-tr {
          &:nth-of-type(2n) {
            &:not(.selected) {
              td {
                // Position relative doesn't work on tr in Safari
                position: relative;
                background: var(--va-data-table-striped-tr-background-color);
                opacity: var(--va-data-table-striped-tr-opacity);
              }
            }
          }
        }
      }
    }
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
