### PR TITLE
Allow custom strings in i18n config (#4243)

### DIFF
--- a/.ws-context
+++ b/.ws-context
@@ -1,0 +1,3 @@
+{
+  "framework": "vue"
+}

--- a/packages/ui/src/components/va-backtop/VaBacktop.vue
+++ b/packages/ui/src/components/va-backtop/VaBacktop.vue
@@ -21,7 +21,7 @@
 
 <script lang="ts" setup>
 import { PropType, ref, computed, onMounted, onBeforeUnmount } from 'vue'
-import { useComponentPresetProp, useTranslation, useNumericProp } from '../../composables'
+import { useComponentPresetProp, useTranslation, useTranslationProp, useNumericProp } from '../../composables'
 import { VaButton } from '../va-button'
 import { isServer } from '../../utils/ssr'
 import { warn } from '../../utils/console'
@@ -51,7 +51,7 @@ const props = defineProps({
     default: 'bottom',
     validator: (value: string) => ['bottom', 'top'].includes(value),
   },
-  ariaLabel: { type: String, default: '$t:backToTop' },
+  ariaLabel: useTranslationProp('$t:backToTop'),
 })
 
 const targetScrollValue = ref(0)
@@ -133,7 +133,7 @@ if (!server) {
   onBeforeUnmount(() => targetElement?.removeEventListener('scroll', handleScroll))
 }
 
-const { tp, t } = useTranslation()
+const { tp } = useTranslation()
 </script>
 
 <style lang="scss">

--- a/packages/ui/src/components/va-breadcrumbs/VaBreadcrumbs.vue
+++ b/packages/ui/src/components/va-breadcrumbs/VaBreadcrumbs.vue
@@ -1,7 +1,13 @@
 <script lang="ts">
 import { computed, defineComponent, Fragment, h, ref, VNode } from 'vue'
 
-import { useComponentPresetProp, useAlign, useAlignProps, useColors, useTranslation } from '../../composables'
+import {
+  useComponentPresetProp,
+  useAlign,
+  useAlignProps,
+  useColors,
+  useTranslation, useTranslationProp,
+} from '../../composables'
 
 import { hasOwnProperty } from '../../utils/has-own-property'
 import { resolveSlot } from '../../utils/resolveSlot'
@@ -16,7 +22,7 @@ export default defineComponent({
     disabledColor: { type: String, default: 'secondary' },
     activeColor: { type: String, default: null },
     separatorColor: { type: String, default: null },
-    ariaLabel: { type: String, default: '$t:breadcrumbs' },
+    ariaLabel: useTranslationProp('$t:breadcrumbs'),
   },
   setup (props, { slots }) {
     const { alignComputed } = useAlign(props)

--- a/packages/ui/src/components/va-button-dropdown/VaButtonDropdown.vue
+++ b/packages/ui/src/components/va-button-dropdown/VaButtonDropdown.vue
@@ -87,7 +87,7 @@ import {
   useStateful, useStatefulProps,
   useEmitProxy,
   usePlacementAliasesProps,
-  useTranslation,
+  useTranslation, useTranslationProp,
 } from '../../composables'
 
 import { VaButton } from '../va-button'
@@ -139,7 +139,7 @@ const props = defineProps({
   loading: { type: Boolean, default: false },
   label: { type: String },
 
-  ariaLabel: { type: String, default: '$t:toggleDropdown' },
+  ariaLabel: useTranslationProp('$t:toggleDropdown'),
 })
 
 const emit = defineEmits(['update:modelValue', ...createEmits(), ...createMainButtonEmits()])

--- a/packages/ui/src/components/va-carousel/VaCarousel.vue
+++ b/packages/ui/src/components/va-carousel/VaCarousel.vue
@@ -103,7 +103,7 @@ import { useCarouselColor } from './hooks/useCarouselColors'
 import {
   useStateful, useStatefulProps, useStatefulEmits,
   useSwipe, useSwipeProps, useComponentPresetProp,
-  useTranslation, useNumericProp,
+  useTranslation, useTranslationProp, useNumericProp,
 } from '../../composables'
 
 import { VaImage } from '../va-image'
@@ -158,11 +158,11 @@ const props = defineProps({
   color: { type: String, default: 'primary' },
   ratio: { type: [Number, String] },
 
-  ariaLabel: { type: String, default: '$t:carousel' },
-  ariaPreviousLabel: { type: String, default: '$t:goPreviousSlide' },
-  ariaNextLabel: { type: String, default: '$t:goNextSlide' },
-  ariaGoToSlideLabel: { type: String, default: '$t:goSlide' },
-  ariaSlideOfLabel: { type: String, default: '$t:slideOf' },
+  ariaLabel: useTranslationProp('$t:carousel'),
+  ariaPreviousLabel: useTranslationProp('$t:goPreviousSlide'),
+  ariaNextLabel: useTranslationProp('$t:goNextSlide'),
+  ariaGoToSlideLabel: useTranslationProp('$t:goSlide'),
+  ariaSlideOfLabel: useTranslationProp('$t:slideOf'),
 })
 
 const emit = defineEmits([...useStatefulEmits])

--- a/packages/ui/src/components/va-chip/VaChip.vue
+++ b/packages/ui/src/components/va-chip/VaChip.vue
@@ -59,7 +59,7 @@ import {
   useHover,
   useTextColor,
   useBem,
-  useTranslation,
+  useTranslation, useTranslationProp,
 } from '../../composables'
 
 import { VaIcon } from '../va-icon'
@@ -89,7 +89,7 @@ const props = defineProps({
     validator: (value: string) => ['small', 'medium', 'large'].includes(value),
   },
 
-  ariaCloseLabel: { type: String, default: '$t:close' },
+  ariaCloseLabel: useTranslationProp('$t:close'),
 })
 
 const emit = defineEmits([...useStatefulEmits, 'focus'])

--- a/packages/ui/src/components/va-color-input/VaColorInput.vue
+++ b/packages/ui/src/components/va-color-input/VaColorInput.vue
@@ -36,7 +36,7 @@
 <script lang="ts">
 import { PropType, shallowRef, computed } from 'vue'
 
-import { useComponentPresetProp, useStateful, useStatefulProps, useStatefulEmits, useTranslation } from '../../composables'
+import { useComponentPresetProp, useStateful, useStatefulProps, useStatefulEmits, useTranslation, useTranslationProp } from '../../composables'
 
 import { VaColorIndicator } from '../va-color-indicator'
 import { VaInput } from '../va-input'
@@ -63,7 +63,7 @@ const props = defineProps({
     default: 'dot',
     validator: (value: string) => ['dot', 'square'].includes(value),
   },
-  ariaOpenColorPickerLabel: { type: String, default: '$t:openColorPicker' },
+  ariaOpenColorPickerLabel: useTranslationProp('$t:openColorPicker'),
 })
 
 const emit = defineEmits([...useStatefulEmits])

--- a/packages/ui/src/components/va-color-palette/VaColorPalette.vue
+++ b/packages/ui/src/components/va-color-palette/VaColorPalette.vue
@@ -22,7 +22,7 @@
 <script lang="ts" setup>
 import { PropType } from 'vue'
 
-import { useComponentPresetProp, useStateful, useStatefulProps, useStatefulEmits, useTranslation } from '../../composables'
+import { useComponentPresetProp, useStateful, useStatefulProps, useStatefulEmits, useTranslation, useTranslationProp } from '../../composables'
 
 import { VaColorIndicator } from '../va-color-indicator'
 
@@ -40,8 +40,8 @@ const props = defineProps({
     default: 'dot',
     validator: (value: string) => ['dot', 'square'].includes(value),
   },
-  ariaLabel: { type: String, default: '$t:colorSelection' },
-  ariaIndicatorLabel: { type: String, default: '$t:color' },
+  ariaLabel: useTranslationProp('$t:colorSelection'),
+  ariaIndicatorLabel: useTranslationProp('$t:color'),
 })
 
 const emit = defineEmits([...useStatefulEmits])

--- a/packages/ui/src/components/va-counter/VaCounter.vue
+++ b/packages/ui/src/components/va-counter/VaCounter.vue
@@ -109,7 +109,7 @@ import {
   useFocus, useFocusEmits,
   useStateful, useStatefulProps,
   useColors,
-  useTranslation,
+  useTranslation, useTranslationProp,
   useLongPress,
   useTemplateRef,
   useValidation,
@@ -168,9 +168,9 @@ const props = defineProps({
   margins: { type: [String, Number], default: '4px' },
   longPressDelay: { type: [Number, String], default: 500 },
 
-  ariaLabel: { type: String, default: '$t:counterValue' },
-  ariaDecreaseLabel: { type: String, default: '$t:decreaseCounter' },
-  ariaIncreaseLabel: { type: String, default: '$t:increaseCounter' },
+  ariaLabel: useTranslationProp('$t:counterValue'),
+  ariaDecreaseLabel: useTranslationProp('$t:decreaseCounter'),
+  ariaIncreaseLabel: useTranslationProp('$t:increaseCounter'),
 })
 
 const emit = defineEmits([

--- a/packages/ui/src/components/va-data-table/VaDataTable.vue
+++ b/packages/ui/src/components/va-data-table/VaDataTable.vue
@@ -214,7 +214,7 @@ import { useFilterable, useFilterableProps } from './hooks/useFilterable'
 import { useSortable, useSortableProps } from './hooks/useSortable'
 import { useTableScroll, useTableScrollProps, useTableScrollEmits } from './hooks/useTableScroll'
 
-import { useComponentPresetProp, useTranslation, useThrottleProps } from '../../composables'
+import { useComponentPresetProp, useTranslation, useTranslationProp, useThrottleProps } from '../../composables'
 
 import { extractComponentProps, filterComponentProps } from '../../utils/component-options'
 
@@ -281,7 +281,7 @@ const props = defineProps({
   gridColumns: { type: [Number, String], default: 0 },
   wrapperSize: { type: [Number, String] as PropType<number | string | 'auto'>, default: 'auto' },
 
-  ariaSelectRowLabel: { type: String, default: '$t:selectRowByIndex' },
+  ariaSelectRowLabel: useTranslationProp('$t:selectRowByIndex'),
 })
 
 const emit = defineEmits([

--- a/packages/ui/src/components/va-data-table/components/VaDataTableThRow.vue
+++ b/packages/ui/src/components/va-data-table/components/VaDataTableThRow.vue
@@ -72,7 +72,7 @@ import { useStylable, useStylableProps } from '../hooks/useStylable'
 
 import type { TSortIcon } from '../hooks/useSortable'
 
-import { useTranslation } from '../../../composables'
+import { useTranslation, useTranslationProp } from '../../../composables'
 
 import {
   DataTableSortingOrder,
@@ -98,8 +98,8 @@ const props = defineProps({
   sortingOrderIconName: { type: String as PropType<TSortIcon>, required: true },
   sortingOrderSync: { type: String as PropType<DataTableSortingOrder | null>, default: null },
 
-  ariaSelectAllRowsLabel: { type: String, default: '$t:selectAllRows' },
-  ariaSortColumnByLabel: { type: String, default: '$t:sortColumnBy' },
+  ariaSelectAllRowsLabel: useTranslationProp('$t:selectAllRows'),
+  ariaSortColumnByLabel: useTranslationProp('$t:sortColumnBy'),
 })
 
 const emit = defineEmits([

--- a/packages/ui/src/components/va-date-input/VaDateInput.vue
+++ b/packages/ui/src/components/va-date-input/VaDateInput.vue
@@ -92,7 +92,7 @@ import {
   useDropdownable,
   useDropdownableProps,
   useDropdownableEmits,
-  useFocus, useFocusEmits, useTranslation, useFocusDeep, useTrapFocus,
+  useFocus, useFocusEmits, useTranslation, useTranslationProp, useFocusDeep, useTrapFocus,
 } from '../../composables'
 import { useRangeModelValueGuard } from './hooks/range-model-value-guard'
 import { useDateParser } from './hooks/input-text-parser'
@@ -148,9 +148,9 @@ const props = defineProps({
   leftIcon: { type: Boolean, default: false },
   icon: { type: String, default: 'va-calendar' },
 
-  ariaToggleDropdownLabel: { type: String, default: '$t:toggleDropdown' },
-  ariaResetLabel: { type: String, default: '$t:resetDate' },
-  ariaSelectedDateLabel: { type: String, default: '$t:selectedDate' },
+  ariaToggleDropdownLabel: useTranslationProp('$t:toggleDropdown'),
+  ariaResetLabel: useTranslationProp('$t:resetDate'),
+  ariaSelectedDateLabel: useTranslationProp('$t:selectedDate'),
 })
 
 const emit = defineEmits([

--- a/packages/ui/src/components/va-date-picker/components/VaDatePickerHeader/VaDatePickerHeader.vue
+++ b/packages/ui/src/components/va-date-picker/components/VaDatePickerHeader/VaDatePickerHeader.vue
@@ -64,7 +64,7 @@ import { useView } from '../../hooks/view'
 import { DatePickerView } from '../../types'
 
 import { VaButton } from '../../../va-button'
-import { useCurrentElement, useElementTextColor, useElementBackground, useTranslation } from '../../../../composables'
+import { useCurrentElement, useElementTextColor, useElementBackground, useTranslation, useTranslationProp } from '../../../../composables'
 
 defineOptions({
   name: 'VaDatePickerHeader',
@@ -76,9 +76,9 @@ const props = defineProps({
   color: { type: String },
   disabled: { type: Boolean, default: false },
 
-  ariaNextPeriodLabel: { type: String, default: '$t:nextPeriod' },
-  ariaPreviousPeriodLabel: { type: String, default: '$t:previousPeriod' },
-  ariaSwitchViewLabel: { type: String, default: '$t:switchView' },
+  ariaNextPeriodLabel: useTranslationProp('$t:nextPeriod'),
+  ariaPreviousPeriodLabel: useTranslationProp('$t:previousPeriod'),
+  ariaSwitchViewLabel: useTranslationProp('$t:switchView'),
 })
 
 const emit = defineEmits(['update:view'])

--- a/packages/ui/src/components/va-dropdown/VaDropdown.vue
+++ b/packages/ui/src/components/va-dropdown/VaDropdown.vue
@@ -22,7 +22,7 @@ import {
   useIsMounted,
   useStateful,
   useStatefulEmits,
-  useTranslation,
+  useTranslation, useTranslationProp,
   usePlacementAliasesProps,
 } from '../../composables'
 import { renderSlotNode } from '../../utils/headless'
@@ -73,7 +73,7 @@ export default defineComponent({
     teleport: { type: [String, Object] as PropType<MaybeHTMLElementOrSelector>, default: undefined },
     /** Not reactive */
     keyboardNavigation: { type: Boolean, default: true },
-    ariaLabel: { type: String, default: '$t:toggleDropdown' },
+    ariaLabel: useTranslationProp('$t:toggleDropdown'),
     role: { type: String as PropType<StringWithAutocomplete<'button' | 'none'>>, default: 'button' },
     contentClass: { type: String, default: '' },
   },

--- a/packages/ui/src/components/va-file-upload/VaFileUpload.vue
+++ b/packages/ui/src/components/va-file-upload/VaFileUpload.vue
@@ -60,7 +60,7 @@
 <script lang="ts">
 import { computed, onMounted, ref, toRef, shallowRef, provide, PropType, ComputedRef } from 'vue'
 
-import { useColors, useComponentPresetProp, useBem, useTranslation, useNumericProp } from '../../composables'
+import { useColors, useComponentPresetProp, useBem, useTranslation, useTranslationProp, useNumericProp } from '../../composables'
 
 import { VaFileUploadKey, VaFile } from './types'
 
@@ -87,10 +87,10 @@ const props = defineProps({
   disabled: { type: Boolean, default: false },
   undo: { type: Boolean, default: false },
   undoDuration: { type: [Number, String], default: 3000 },
-  undoButtonText: { type: String, default: '$t:undo' },
-  dropZoneText: { type: String, default: '$t:dropzone' },
-  uploadButtonText: { type: String, default: '$t:uploadFile' },
-  deletedFileMessage: { type: String, default: '$t:fileDeleted' },
+  undoButtonText: useTranslationProp('$t:undo'),
+  dropZoneText: useTranslationProp('$t:dropzone'),
+  uploadButtonText: useTranslationProp('$t:uploadFile'),
+  deletedFileMessage: useTranslationProp('$t:fileDeleted'),
   modelValue: {
     type: [Object, Array] as PropType<VaFile | VaFile[]>,
     default: () => [],

--- a/packages/ui/src/components/va-file-upload/VaFileUploadGalleryItem/VaFileUploadGalleryItem.vue
+++ b/packages/ui/src/components/va-file-upload/VaFileUploadGalleryItem/VaFileUploadGalleryItem.vue
@@ -51,7 +51,7 @@
 import { onMounted, PropType, ref, watch, computed, toRef } from 'vue'
 
 import { colorToRgba } from '../../../services/color'
-import { useFocus, useBem, useStrictInject, useTranslation } from '../../../composables'
+import { useFocus, useBem, useStrictInject, useTranslation, useTranslationProp } from '../../../composables'
 
 import { VaFileUploadKey, ConvertedFile } from '../types'
 import { useTextColor } from '../../../composables/useTextColor'
@@ -72,7 +72,7 @@ const props = defineProps({
   file: { type: Object as PropType<ConvertedFile>, default: null },
   color: { type: String, default: 'success' },
 
-  ariaRemoveFileLabel: { type: String, default: '$t:removeFile' },
+  ariaRemoveFileLabel: useTranslationProp('$t:removeFile'),
 })
 
 const emit = defineEmits(['remove'])

--- a/packages/ui/src/components/va-file-upload/VaFileUploadListItem/VaFileUploadListItem.vue
+++ b/packages/ui/src/components/va-file-upload/VaFileUploadListItem/VaFileUploadListItem.vue
@@ -38,7 +38,7 @@
 <script lang="ts">
 import { ref, PropType } from 'vue'
 
-import { useBem, useFocus, useStrictInject, useTranslation } from '../../../composables'
+import { useBem, useFocus, useStrictInject, useTranslation, useTranslationProp } from '../../../composables'
 import { VaFileUploadKey, ConvertedFile } from '../types'
 
 import { VaButton } from '../../va-button'
@@ -59,7 +59,7 @@ const props = defineProps({
   file: { type: Object as PropType<ConvertedFile | null>, default: null },
   color: { type: String, default: 'success' },
 
-  ariaRemoveFileLabel: { type: String, default: '$t:removeFile' },
+  ariaRemoveFileLabel: useTranslationProp('$t:removeFile'),
 })
 
 const emit = defineEmits(['remove'])

--- a/packages/ui/src/components/va-file-upload/VaFileUploadSingleItem/VaFileUploadSingleItem.vue
+++ b/packages/ui/src/components/va-file-upload/VaFileUploadSingleItem/VaFileUploadSingleItem.vue
@@ -26,7 +26,7 @@
 
 <script lang="ts">
 import { PropType } from 'vue'
-import { useStrictInject, useTranslation } from '../../../composables'
+import { useStrictInject, useTranslation, useTranslationProp } from '../../../composables'
 
 import { VaButton, VaListItem, VaListItemSection } from '../../index'
 import { VaFileUploadKey, ConvertedFile } from '../types'
@@ -42,7 +42,7 @@ defineOptions({
 
 const props = defineProps({
   file: { type: Object as PropType<ConvertedFile | null>, default: null },
-  ariaRemoveFileLabel: { type: String, default: '$t:removeFile' },
+  ariaRemoveFileLabel: useTranslationProp('$t:removeFile'),
 })
 
 const emit = defineEmits(['remove'])

--- a/packages/ui/src/components/va-input-wrapper/hooks/useInputFieldAria.ts
+++ b/packages/ui/src/components/va-input-wrapper/hooks/useInputFieldAria.ts
@@ -1,9 +1,10 @@
 import { ExtractPropTypes, Ref, computed } from 'vue'
 import { useComponentUuid } from '../../../composables/useComponentUuid'
+import { useTranslationProp } from '../../../composables'
 
 export const useInputFieldAriaProps = {
   label: { type: String, default: '' },
-  inputAriaLabel: { type: String, default: '$t:inputField' },
+  inputAriaLabel: useTranslationProp('$t:inputField'),
   inputAriaLabelledby: { type: String },
   inputAriaDescribedby: { type: String },
 }

--- a/packages/ui/src/components/va-input/VaInput.vue
+++ b/packages/ui/src/components/va-input/VaInput.vue
@@ -59,7 +59,7 @@ import {
   useValidation, useValidationProps, useValidationEmits,
   useEmitProxy,
   useClearable, useClearableProps, useClearableEmits,
-  useTranslation,
+  useTranslation, useTranslationProp,
   useStateful, useStatefulProps, useStatefulEmits, useDeprecatedCondition,
   useFocusable, useFocusableProps, useEvent,
 } from '../../composables'
@@ -115,7 +115,7 @@ const props = defineProps({
   counter: { type: Boolean, default: false },
 
     // style
-  ariaResetLabel: { type: String, default: '$t:reset' },
+  ariaResetLabel: useTranslationProp('$t:reset'),
 
     /** Set value to input when model value is updated */
   strictBindInputValue: { type: Boolean, default: false },

--- a/packages/ui/src/components/va-modal/VaModal.vue
+++ b/packages/ui/src/components/va-modal/VaModal.vue
@@ -140,7 +140,7 @@ import {
   useComponentPresetProp,
   useTrapFocus,
   useModalLevel,
-  useTranslation,
+  useTranslation, useTranslationProp,
   useClickOutside,
   useDocument,
   useTeleported,
@@ -188,8 +188,8 @@ const props = defineProps({
   disableAttachment: { type: Boolean, default: false },
   title: { type: String, default: '' },
   message: { type: String, default: '' },
-  okText: { type: String, default: '$t:ok' },
-  cancelText: { type: String, default: '$t:cancel' },
+  okText: useTranslationProp('$t:ok'),
+  cancelText: useTranslationProp('$t:cancel'),
   hideDefaultActions: { type: Boolean, default: false },
   fullscreen: { type: Boolean, default: false },
   closeButton: { type: Boolean, default: false },
@@ -228,7 +228,7 @@ const props = defineProps({
   beforeClose: { type: Function as PropType<(hide: () => void) => any> },
   beforeOk: { type: Function as PropType<(hide: () => void) => any> },
   beforeCancel: { type: Function as PropType<(hide: () => void) => any> },
-  ariaCloseLabel: { type: String, default: '$t:close' },
+  ariaCloseLabel: useTranslationProp('$t:close'),
 })
 
 useChildComponents(props)

--- a/packages/ui/src/components/va-pagination/VaPagination.vue
+++ b/packages/ui/src/components/va-pagination/VaPagination.vue
@@ -114,7 +114,7 @@ import {
   useColors,
   useStateful, useStatefulProps, useStatefulEmits,
   useArrayRefs,
-  useTranslation, useNumericProp,
+  useTranslation, useTranslationProp, useNumericProp,
 } from '../../composables'
 import { setPaginationRange } from './setPaginationRange'
 
@@ -160,13 +160,13 @@ const props = defineProps({
   buttonProps: { type: Object as PropType<VaButtonProps>, default: () => ({}) },
   buttonsPreset: { type: String, default: 'primary' },
 
-  ariaLabel: { type: String, default: '$t:pagination' },
-  ariaGoToTheFirstPageLabel: { type: String, default: '$t:goToTheFirstPage' },
-  ariaGoToPreviousPageLabel: { type: String, default: '$t:goToPreviousPage' },
-  ariaGoToSpecificPageLabel: { type: String, default: '$t:goToSpecificPage' },
-  ariaGoToSpecificPageInputLabel: { type: String, default: '$t:goToSpecificPageInput' },
-  ariaGoToNextPageLabel: { type: String, default: '$t:goNextPage' },
-  ariaGoToLastPageLabel: { type: String, default: '$t:goLastPage' },
+  ariaLabel: useTranslationProp('$t:pagination'),
+  ariaGoToTheFirstPageLabel: useTranslationProp('$t:goToTheFirstPage'),
+  ariaGoToPreviousPageLabel: useTranslationProp('$t:goToPreviousPage'),
+  ariaGoToSpecificPageLabel: useTranslationProp('$t:goToSpecificPage'),
+  ariaGoToSpecificPageInputLabel: useTranslationProp('$t:goToSpecificPageInput'),
+  ariaGoToNextPageLabel: useTranslationProp('$t:goNextPage'),
+  ariaGoToLastPageLabel: useTranslationProp('$t:goLastPage'),
 })
 
 const emit = defineEmits([...useStatefulEmits])

--- a/packages/ui/src/components/va-progress-bar/VaProgressBar.vue
+++ b/packages/ui/src/components/va-progress-bar/VaProgressBar.vue
@@ -45,7 +45,7 @@ import { useComponentPresetProp } from '../../composables/useComponentPreset'
 import { computed, PropType, StyleValue } from 'vue'
 import clamp from 'lodash/clamp.js'
 
-import { useColors, useTextColor, useTranslation } from '../../composables'
+import { useColors, useTextColor, useTranslation, useTranslationProp } from '../../composables'
 
 defineOptions({
   name: 'VaProgressBar',
@@ -66,7 +66,7 @@ const props = defineProps({
   contentInside: { type: Boolean, default: false },
   showPercent: { type: Boolean, default: false },
   max: { type: [Number, String], default: 100 },
-  ariaLabel: { type: String, default: '$t:progressState' },
+  ariaLabel: useTranslationProp('$t:progressState'),
 })
 
 const { getColor, getHoverColor } = useColors()

--- a/packages/ui/src/components/va-progress-circle/VaProgressCircle.vue
+++ b/packages/ui/src/components/va-progress-circle/VaProgressCircle.vue
@@ -35,7 +35,7 @@
 import { computed } from 'vue'
 import clamp from 'lodash/clamp.js'
 
-import { useComponentPresetProp, useColors, useSize, useSizeProps, useTranslation } from '../../composables'
+import { useComponentPresetProp, useColors, useSize, useSizeProps, useTranslation, useTranslationProp } from '../../composables'
 
 defineOptions({
   name: 'VaProgressCircle',
@@ -48,7 +48,7 @@ const props = defineProps({
   indeterminate: { type: Boolean, default: false },
   thickness: { type: [Number, String], default: 0.06 },
   color: { type: String, default: 'primary' },
-  ariaLabel: { type: String, default: '$t:progressState' },
+  ariaLabel: useTranslationProp('$t:progressState'),
 })
 
 const { getColor } = useColors()

--- a/packages/ui/src/components/va-rating/VaRating.vue
+++ b/packages/ui/src/components/va-rating/VaRating.vue
@@ -50,7 +50,7 @@
 import { computed, PropType } from 'vue'
 
 import { extractComponentProps, filterComponentProps } from '../../utils/component-options'
-import { useFormField, useFormFieldProps, useTranslation } from '../../composables'
+import { useFormField, useFormFieldProps, useTranslation, useTranslationProp } from '../../composables'
 import { useRating, useRatingProps } from './hooks/useRating'
 import { useVaRatingColors, useVaRatingColorsProps } from './hooks/useVaRatingColors'
 
@@ -81,8 +81,8 @@ const props = defineProps({
   max: { type: [Number, String], default: 5 },
   texts: { type: Array as PropType<string[]>, default: () => [] },
 
-  ariaLabel: { type: String, default: '$t:currentRating' },
-  ariaItemLabel: { type: String, default: '$t:voteRating' },
+  ariaLabel: useTranslationProp('$t:currentRating'),
+  ariaItemLabel: useTranslationProp('$t:voteRating'),
 })
 
 const emit = defineEmits(['update:modelValue'])

--- a/packages/ui/src/components/va-select/VaSelect.vue
+++ b/packages/ui/src/components/va-select/VaSelect.vue
@@ -139,7 +139,7 @@ import {
   useMaxSelections, useMaxSelectionsProps,
   useClearableProps, useClearable, useClearableEmits,
   useFocusDeep,
-  useTranslation,
+  useTranslation, useTranslationProp,
   useBem,
   useThrottleProps,
   useDropdownable, useDropdownableEmits, useDropdownableProps, useSyncProp,
@@ -217,7 +217,7 @@ const props = defineProps({
   searchable: { type: Boolean, default: false },
   width: { type: String, default: '100%' },
   maxHeight: { type: String, default: '256px' },
-  noOptionsText: { type: String, default: '$t:noOptions' },
+  noOptionsText: useTranslationProp('$t:noOptions'),
   hideSelected: { type: Boolean, default: false },
   tabindex: { type: [String, Number], default: 0 },
   virtualScroller: { type: Boolean, default: false },
@@ -228,11 +228,11 @@ const props = defineProps({
 
     // Input style
   placeholder: { type: String, default: '' },
-  searchPlaceholderText: { type: String, default: '$t:search' },
+  searchPlaceholderText: useTranslationProp('$t:search'),
 
-  ariaLabel: { type: String, default: '$t:select' },
-  ariaSearchLabel: { type: String, default: '$t:optionsFilter' },
-  ariaClearLabel: { type: String, default: '$t:reset' },
+  ariaLabel: useTranslationProp('$t:select'),
+  ariaSearchLabel: useTranslationProp('$t:optionsFilter'),
+  ariaClearLabel: useTranslationProp('$t:reset'),
 
   search: { type: String, default: undefined },
 })

--- a/packages/ui/src/components/va-skeleton/VaSkeleton.vue
+++ b/packages/ui/src/components/va-skeleton/VaSkeleton.vue
@@ -15,7 +15,7 @@
 
 <script lang="ts" setup>
 import { onMounted, ref, computed, PropType, onBeforeUnmount, useAttrs, ComputedRef } from 'vue'
-import { useBem, useColors, useNumericProp, useTranslation } from '../../composables'
+import { useBem, useColors, useNumericProp, useTranslation, useTranslationProp } from '../../composables'
 
 defineOptions({
   name: 'VaSkeleton',
@@ -36,7 +36,7 @@ const props = defineProps({
   lastLineWidth: { type: [String], default: '75%' },
 
   variant: { type: String as PropType<'text' | 'circle' | 'rounded' | 'squared'>, default: 'squared' },
-  ariaLabel: { type: String, default: '$t:loading' },
+  ariaLabel: useTranslationProp('$t:loading'),
 })
 
 const doShow = ref(false)

--- a/packages/ui/src/components/va-slider/VaSlider.vue
+++ b/packages/ui/src/components/va-slider/VaSlider.vue
@@ -179,6 +179,7 @@ import {
   useStateful,
   useStatefulProps,
   useTranslation,
+  useTranslationProp,
   useNumericProp,
 } from '../../composables'
 import { validateSlider } from './validateSlider'
@@ -212,7 +213,7 @@ const props = defineProps({
   iconAppend: { type: String, default: '' },
   vertical: { type: Boolean, default: false },
   showTrack: { type: Boolean, default: true },
-  ariaLabel: { type: String, default: '$t:sliderValue' },
+  ariaLabel: useTranslationProp('$t:sliderValue'),
 })
 
 const emit = defineEmits(['drag-start', 'drag-end', 'change', 'update:modelValue'])

--- a/packages/ui/src/components/va-split/VaSplit.vue
+++ b/packages/ui/src/components/va-split/VaSplit.vue
@@ -49,7 +49,7 @@ import {
   useComponentPresetProp,
   useStateful, useStatefulEmits, useStatefulProps,
   useResizeObserver,
-  useTranslation,
+  useTranslation, useTranslationProp,
 } from '../../composables'
 import { useSplitDragger, useSplitDraggerProps } from './useSplitDragger'
 
@@ -84,7 +84,7 @@ const props = defineProps({
   },
   snappingRange: { type: [Number, String] as PropType<number | string>, default: 4 },
 
-  ariaLabel: { type: String, default: '$t:splitPanels' },
+  ariaLabel: useTranslationProp('$t:splitPanels'),
 })
 
 const emit = defineEmits([...useStatefulEmits])

--- a/packages/ui/src/components/va-stepper/VaStepper.vue
+++ b/packages/ui/src/components/va-stepper/VaStepper.vue
@@ -83,7 +83,7 @@
 import VaStepperControls from './VaStepperControls.vue'
 import VaStepperStepButton from './VaStepperStepButton.vue'
 import { computed, PropType, ref, Ref, shallowRef, watch } from 'vue'
-import { useColors, useStateful, useStatefulProps, useTranslation } from '../../composables'
+import { useColors, useStateful, useStatefulProps, useTranslation, useTranslationProp } from '../../composables'
 import type { Step, StepControls } from './types'
 import { isStepHasError } from './step'
 
@@ -106,7 +106,7 @@ const props = defineProps({
   nextDisabled: { type: Boolean, default: false },
   nextDisabledOnError: { type: Boolean, default: false },
   finishButtonHidden: { type: Boolean, default: false },
-  ariaLabel: { type: String, default: '$t:progress' },
+  ariaLabel: useTranslationProp('$t:progress'),
   linear: { type: Boolean, default: false },
   /** Hidden step shown when all steps complete */
   finishStep: { type: Object as PropType<Step> },

--- a/packages/ui/src/components/va-stepper/VaStepperControls.vue
+++ b/packages/ui/src/components/va-stepper/VaStepperControls.vue
@@ -27,7 +27,7 @@
 </template>
 <script lang="ts" setup>
 import { PropType, computed } from 'vue'
-import { useTranslation } from '../../composables/useTranslation'
+import { useTranslation } from '../../composables'
 import { VaButton } from '../va-button'
 import type { Step, StepControls } from './types'
 import { unFunction } from '../../utils/un-function'

--- a/packages/ui/src/components/va-switch/VaSwitch.vue
+++ b/packages/ui/src/components/va-switch/VaSwitch.vue
@@ -88,7 +88,7 @@ import {
   useKeyboardOnlyFocus,
   useSelectable, useSelectableProps, useSelectableEmits,
   useColors, useTextColor,
-  useBem,
+  useBem, useTranslationProp,
 } from '../../composables'
 
 import { VaProgressCircle } from '../va-progress-circle'
@@ -112,7 +112,7 @@ const props = defineProps({
   falseLabel: { type: String, default: null },
   trueInnerLabel: { type: String, default: null },
   falseInnerLabel: { type: String, default: null },
-  ariaLabel: { type: String, default: '$t:switch' },
+  ariaLabel: useTranslationProp('$t:switch'),
   color: { type: String, default: 'primary' },
   offColor: { type: String, default: 'background-element' },
   size: {

--- a/packages/ui/src/components/va-tabs/VaTabs.vue
+++ b/packages/ui/src/components/va-tabs/VaTabs.vue
@@ -83,7 +83,7 @@ import {
   useStateful, useStatefulProps,
   useColors,
   useResizeObserver,
-  useTranslation,
+  useTranslation, useTranslationProp,
 } from '../../composables'
 
 import { TabsViewKey, TabComponent, TabSelected } from './types'
@@ -116,8 +116,8 @@ const props = defineProps({
   color: { type: String, default: 'primary' },
   prevIcon: { type: String, default: 'va-arrow-left' },
   nextIcon: { type: String, default: 'va-arrow-right' },
-  ariaMoveRightLabel: { type: String, default: '$t:movePaginationLeft' },
-  ariaMoveLeftLabel: { type: String, default: '$t:movePaginationRight' },
+  ariaMoveRightLabel: useTranslationProp('$t:movePaginationLeft'),
+  ariaMoveLeftLabel: useTranslationProp('$t:movePaginationRight'),
 })
 
 const emit = defineEmits(['update:modelValue', 'click:next', 'click:prev'])

--- a/packages/ui/src/components/va-time-input/VaTimeInput.vue
+++ b/packages/ui/src/components/va-time-input/VaTimeInput.vue
@@ -82,7 +82,7 @@ import {
   useClearable, useClearableEmits, useClearableProps,
   useFocus, useFocusEmits,
   useStateful, useStatefulEmits, useStatefulProps,
-  useTranslation,
+  useTranslation, useTranslationProp,
   useDropdownable, useDropdownableProps, useDropdownableEmits, useLongPressKey,
 } from '../../composables'
 import { useTimeParser } from './hooks/time-text-parser'
@@ -122,9 +122,9 @@ const props = defineProps({
   leftIcon: { type: Boolean, default: false },
   icon: { type: String, default: 'schedule' },
 
-  ariaLabel: { type: String, default: '$t:selectedTime' },
-  ariaResetLabel: { type: String, default: '$t:resetTime' },
-  ariaToggleDropdownLabel: { type: String, default: '$t:toggleDropdown' },
+  ariaLabel: useTranslationProp('$t:selectedTime'),
+  ariaResetLabel: useTranslationProp('$t:resetTime'),
+  ariaToggleDropdownLabel: useTranslationProp('$t:toggleDropdown'),
 })
 
 const emit = defineEmits([

--- a/packages/ui/src/components/va-toast/VaToast.vue
+++ b/packages/ui/src/components/va-toast/VaToast.vue
@@ -44,7 +44,7 @@
 <script lang="ts">
 import { PropType, ref, computed, onMounted, shallowRef, defineComponent, ComputedRef } from 'vue'
 
-import { useComponentPresetProp, useColors, useTimer, useTextColor, useTranslation, useNumericProp } from '../../composables'
+import { useComponentPresetProp, useColors, useTimer, useTextColor, useTranslation, useTranslationProp, useNumericProp } from '../../composables'
 
 import { ToastPosition } from './types'
 
@@ -89,7 +89,7 @@ const props = defineProps({
     validator: (value: string) => ['top-right', 'top-left', 'bottom-right', 'bottom-left'].includes(value),
   },
   render: { type: Function },
-  ariaCloseLabel: { type: String, default: '$t:close' },
+  ariaCloseLabel: useTranslationProp('$t:close'),
   role: { type: String as PropType<StringWithAutocomplete<'alert' | 'alertdialog' | 'status'>>, default: undefined },
   inline: { type: Boolean, default: false },
 })

--- a/packages/ui/src/composables/useTranslation.ts
+++ b/packages/ui/src/composables/useTranslation.ts
@@ -1,9 +1,23 @@
-import { computed } from 'vue'
+import { computed, PropType } from 'vue'
 import { useGlobalConfig } from '../composables'
-import { I18nConfig } from '../services/i18n'
+import { I18NKey, I18NKnownKey } from '../services/i18n'
 import { warn } from '../utils/console'
+import { StringWithAutocomplete } from '../utils/types/prop-type'
 
 type Stringable = number | string | boolean | undefined
+
+export type TranslationKey = `$t:${I18NKnownKey}`;
+
+// Also allows arbitrary keys
+export type TranslationProp = StringWithAutocomplete<TranslationKey>
+
+const isTranslationKey = (value: string): value is TranslationKey => value.startsWith('$t:')
+
+export const useTranslationProp = (defaultValue: TranslationProp) => {
+  return { type: String as PropType<TranslationProp>, default: defaultValue }
+}
+
+const f: TranslationProp | undefined = '$t:back'
 
 const applyI18nTemplate = (key: string, values?: Record<string, Stringable>) => {
   if (!values) { return key }
@@ -21,17 +35,17 @@ export const useTranslation = () => {
 
   return {
     /** Translate prop. Translate only if key has `$t:` prefix */
-    tp: <Key extends string | undefined>(key: Key, values?: Record<string, Stringable>): string => {
+    tp<Key extends TranslationProp | undefined> (key: Key, values?: Record<string, Stringable>): string {
       if (!key) { return '' }
 
-      if (key.startsWith('$t:')) {
-        key = (config.value[key.slice(3) as keyof I18nConfig] || key) as NonNullable<Key>
+      if (isTranslationKey(key)) {
+        key = (config.value[key.slice(3)] || key) as NonNullable<Key>
       }
 
       return (applyI18nTemplate(key, values) || key)
     },
-    t (key: string, values?: Record<string, Stringable>) {
-      const translated = config.value[key as keyof I18nConfig]
+    t<Key extends I18NKey> (key: Key, values?: Record<string, Stringable>) {
+      const translated = config.value[key]
       if (!translated) {
         warn(`${key} not found in VuesticUI i18n config`)
         return key

--- a/packages/ui/src/main.ts
+++ b/packages/ui/src/main.ts
@@ -28,3 +28,4 @@ export type { GlobalConfig, GlobalConfigUpdater, PartialGlobalConfig } from './s
 export type { ComponentConfig } from './services/component-config'
 export type { IconConfig, IconConfiguration } from './services/icon/types'
 export type { ColorConfig } from './services/color/types'
+export type { I18NKey, I18nConfig, CustomI18NKeys } from './services/i18n'

--- a/packages/ui/src/services/i18n/types.ts
+++ b/packages/ui/src/services/i18n/types.ts
@@ -1,3 +1,27 @@
 import type { getI18nConfigDefaults } from './config/default'
+import { StringWithAutocomplete } from '../../utils/types/prop-type'
 
-export type I18nConfig = ReturnType<typeof getI18nConfigDefaults>
+/**
+ * This is a placeholder meant to be implemented via TypeScript's Module
+ * Augmentation feature to allow key type inference
+ *
+ * @example
+ * ```ts
+ * declare module 'vuestic-ui' {
+ *   interface CustomI18NKeys {
+ *     newKey: string
+ *   }
+ * }
+ * ```
+ *
+ * @see https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
+ */
+export interface CustomI18NKeys {}
+
+export type I18NDefaultKey = keyof ReturnType<typeof getI18nConfigDefaults>
+
+export type I18nConfig = Record<I18NDefaultKey, string> & CustomI18NKeys & Record<string, string>
+
+export type I18NKnownKey = I18NDefaultKey | keyof CustomI18NKeys;
+
+export type I18NKey = StringWithAutocomplete<I18NKnownKey>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

closes #4243

## Description
Allowed custom strings and improved type checking and autocompletion in ide for keys

<img width="912" alt="image" src="https://github.com/epicmaxco/vuestic-ui/assets/32033964/18f38d66-c694-4ebf-bca6-d2f8aa7f782a">

Also added ability to have autocompletion know about user-added keys through module augmentation

<img width="778" alt="image" src="https://github.com/epicmaxco/vuestic-ui/assets/32033964/e7d387a2-2dd2-451d-bede-9df82bac09e6">

<img width="839" alt="image" src="https://github.com/epicmaxco/vuestic-ui/assets/32033964/0818c187-41a7-4557-b0c8-140edf3e5b4d">


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
