### PR TITLE
feat: attempt at unified stateful test

### DIFF
--- a/packages/ui/.storybook/composable-templates/useStateful-template.ts
+++ b/packages/ui/.storybook/composable-templates/useStateful-template.ts
@@ -1,0 +1,47 @@
+import { DefineComponent } from 'vue'
+import { getStoryId } from '../interaction-utils/storySelector'
+import { expect } from '@storybook/jest'
+import { StoryFn } from '@storybook/vue3'
+
+export const UseStatefulTemplate = (
+  component: Record<string, DefineComponent>,
+  input: (el: HTMLElement) => void = el => el.click(),
+  defaultValue = false
+): StoryFn => {
+  const story = () => ({
+    setup () {
+      return {
+        component,
+        defaultValue,
+      }
+    },
+    template: `
+    <p>[true]</p>
+    <component
+      data-testid="true"
+      :is="component"
+      :stateful="defaultValue === true ? undefined : true"
+    />
+
+    <p>[false]</p>
+    <component
+      data-testid="false"
+      :is="component"
+      :stateful="defaultValue === false ? undefined : false"
+    />
+  `,
+  })
+  story.play = async () => {
+    /**
+     * To test stateful we need to test 2 things:
+     * * On user input for stateful="true" - there should be change
+     * * On user input for stateful="false" - there should be no change
+     */
+    input(getStoryId('true'))
+    input(getStoryId('false'))
+
+    // We rely on visual tests here
+    expect(true).toBe(true)
+  }
+  return story
+}

--- a/packages/ui/src/components/va-checkbox/VaCheckbox.stories.ts
+++ b/packages/ui/src/components/va-checkbox/VaCheckbox.stories.ts
@@ -1,6 +1,9 @@
 import { VaCheckbox } from './'
 import { VaButton } from '../va-button'
 import { defineStory } from '../../../.storybook/types'
+import {
+  UseStatefulTemplate,
+} from '../../../.storybook/composable-templates/useStateful-template'
 
 export default {
   title: 'VaCheckbox',
@@ -16,15 +19,10 @@ export const Default = () => ({
   `,
 })
 
-export const Stateful = () => ({
-  components: { VaCheckbox },
-  template: `
-    [true]
-    <VaCheckbox stateful/>
-    [false]
-    <VaCheckbox :stateful="false"/>
-  `,
-})
+export const Stateful = UseStatefulTemplate(
+  VaCheckbox,
+  (el) => (el.children[0] as HTMLInputElement).click(), // Clicking on checkbox container doesn't change value. see #4187
+)
 
 export const Color = () => ({
   components: { VaCheckbox },

--- a/packages/ui/src/components/va-switch/VaSwitch.demo.vue
+++ b/packages/ui/src/components/va-switch/VaSwitch.demo.vue
@@ -207,12 +207,6 @@
         indeterminate-value="middle"
       />
     </VbCard>
-    <VbCard title="Stateless switch without v-model">
-      <va-switch />
-    </VbCard>
-    <VbCard title="Stateful">
-      <va-switch stateful />
-    </VbCard>
   </VbDemo>
 </template>
 

--- a/packages/ui/src/components/va-switch/VaSwitch.stories.ts
+++ b/packages/ui/src/components/va-switch/VaSwitch.stories.ts
@@ -3,6 +3,10 @@ import { defineComponent } from 'vue'
 import VaSwitchDemo from './VaSwitch.demo.vue'
 import VaSwitch from './VaSwitch.vue'
 import { defineStory } from '../../../.storybook/types'
+import { expect } from '@storybook/jest'
+import {
+  UseStatefulTemplate,
+} from '../../../.storybook/composable-templates/useStateful-template'
 
 export default {
   title: 'VaSwitch',
@@ -13,6 +17,11 @@ export const Default = () => defineComponent({
   components: { VaSwitch: VaSwitchDemo },
   template: '<VaSwitch/>',
 })
+
+export const Stateful = UseStatefulTemplate(
+  VaSwitch,
+  el => (el.children[0].children[0].children[0] as HTMLInputElement).click(), // Clicking on checkbox container doesn't change value. see #4187
+)
 
 export const ChangeEvent = defineStory({
   story: () => ({


### PR DESCRIPTION
I attempted to somewhat unify a feature test. I took stateful as a simplest case. We may want to merge it its incomplete state or attempt to apply to other components, making this PR more useful.

I would like this test to be sort of like `statefulWorksFor(VaComponent, testDetails)`.

I only managed to make it work with 2 components, and even that wasn't perfect (click on root element didn't work).

For VaCounter the problematic part was that it didn't even support `data-testid` on root element. (I detailed in #4262)

<img width="409" alt="image" src="https://github.com/epicmaxco/vuestic-ui/assets/5394573/f328ae99-e99e-420c-bcd6-1351d4937291">
