### PR TITLE
Added feature to have a quick date that inputs the defined date or a …

### DIFF
--- a/packages/docs/page-config/navigationRoutes.ts
+++ b/packages/docs/page-config/navigationRoutes.ts
@@ -288,7 +288,7 @@ export const navigationRoutes: NavigationRoute[] = [
         name: "date-input",
         displayName: "Date Input",
         meta: {
-          badge : navigationBadge.updated('1.8.0'),
+          badge : navigationBadge.updated('1.9.11'),
         }
       },
       {

--- a/packages/docs/page-config/ui-elements/date-input/api-description.ts
+++ b/packages/docs/page-config/ui-elements/date-input/api-description.ts
@@ -62,7 +62,8 @@ export default defineApiDescription({
     offset: "Dropdown content will be moved by main and cross axis according to current `placement`",
     placement: "Sets the placement of the dropdown content. [More about placements](/ui-elements/dropdown#placement-and-offset)",
     rangeDelimiter: "The delimiter used when turning model value to string",
-    trigger: "Action that will triggered when open and close dropdown."
+    trigger: "Action that will triggered when open and close dropdown.",
+    quickDate: 'When supplied will automatically input the defined date. The default key detected is `t`. The property value must be either `{ date: new Date() } , { date: \'01/01/2024\' key: \'s\' } or just exist with no value. When supplying a custom value, you must supply a `date` but `key` is optional.',
   },
   events: {
     clear: "Emitted if select value has been cleared",

--- a/packages/ui/src/components/va-date-input/VaDateInput.demo.vue
+++ b/packages/ui/src/components/va-date-input/VaDateInput.demo.vue
@@ -202,6 +202,18 @@
       <va-date-input v-model="range" close-on-change label="Range" />
       <va-date-input v-model="value" manual-input close-on-change label="Manual input" />
     </VbCard>
+
+    <VbCard title="Quick date using default date and key">
+  <va-date-input v-model="quickDateDefault" manual-input label="Start date on 't' press (Enters todays date)" quick-date />
+  </VbCard>
+
+  <VbCard title="Start date on 's' press">
+  <va-date-input v-model="quickDate" manual-input label="Start date on 's' press (Enters todays date)" :quick-date="{ date: new Date(), key: 's' }" />
+  </VbCard>
+
+  <VbCard title="Start date on 't' press with string date for property">
+  <va-date-input v-model="strQuickDate" manual-input label="Start date on 't' press (Enters 01/01/2022)"  :quick-date="{ date: '01/01/2022' }" />
+  </VbCard>
   </VbDemo>
 </template>
 
@@ -226,6 +238,9 @@ export default {
   data () {
     return {
       value: getStaticDate(),
+      quickDateDefault: undefined as any,
+      quickDate: undefined as any,
+      strQuickDate: undefined as any,
       range: { start: getStaticDate(), end: nextWeek },
       dates: [getStaticDate(), nextWeek],
       dayView: { type: 'day', month: 3, year: 2013 } as DatePickerView,

--- a/packages/ui/src/components/va-date-input/VaDateInput.vue
+++ b/packages/ui/src/components/va-date-input/VaDateInput.vue
@@ -17,6 +17,7 @@
           v-on="inputListeners"
           :model-value="valueText"
           @change="onInputTextChanged"
+          @keydown="onKeyDown"
         >
           <template
             v-for="name in filterSlots"
@@ -151,6 +152,8 @@ const props = defineProps({
   ariaToggleDropdownLabel: useTranslationProp('$t:toggleDropdown'),
   ariaResetLabel: useTranslationProp('$t:resetDate'),
   ariaSelectedDateLabel: useTranslationProp('$t:selectedDate'),
+
+  quickDate: { type: Object as PropType<{date: Date | string; key?: string}| boolean>, default: () => {}, required: false },
 })
 
 const emit = defineEmits([
@@ -267,6 +270,25 @@ const onInputTextChanged = ({ target }: Event) => {
 
   if (isValid.value) {
     valueComputed.value = parsedValue
+  }
+}
+
+const onKeyDown = (event: KeyboardEvent) => {
+  const defaultKey = 't'
+  const quickDate = (props.quickDate as any)?.key ?? 't'
+  const shouldInput = !!((event.key.toLocaleLowerCase() === quickDate || event.key.toLocaleLowerCase() === defaultKey))
+
+  if (event.key.match(/^[a-zA-Z]+$/)) {
+    event.preventDefault()
+    valueComputed.value = props.clearValue
+  }
+
+  if (shouldInput) {
+    if (typeof props.quickDate === 'string') {
+      valueComputed.value = parseDateInputValue(new Date().toString())
+    } else {
+      valueComputed.value = typeof ((props.quickDate as any).date) === 'string' ? parseDateInputValue((props.quickDate as any).date as string) : parseDateInputValue((props.quickDate as any).date.toString())
+    }
   }
 }
 


### PR DESCRIPTION
## Description
This allow a quick date property. When used, it allows for a on key letter input. By default this allows you to quickly select today simply by adding the property and then hitting the 't' key. You can pass it any date or date string and even change what key you want to trigger the change.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
