### PR TITLE
fix(input): add null to modelValue prop type declaration

### DIFF
--- a/packages/ui/src/components/va-input/VaInput.vue
+++ b/packages/ui/src/components/va-input/VaInput.vue
@@ -47,7 +47,7 @@
 </template>
 
 <script lang="ts">
-import { computed, InputHTMLAttributes, nextTick, shallowRef, toRefs, useAttrs, useSlots, watch } from 'vue'
+import { computed, InputHTMLAttributes, shallowRef, toRefs, useAttrs, useSlots, watch, PropType } from 'vue'
 import omit from 'lodash/omit.js'
 import pick from 'lodash/pick.js'
 
@@ -107,7 +107,7 @@ const props = defineProps({
     // input
   placeholder: { type: String, default: '' },
   tabindex: { type: [String, Number], default: 0 },
-  modelValue: { type: [Number, String], default: '' },
+  modelValue: { type: [Number, String, null] as PropType<number | string | null>, default: '' },
   type: { type: String as AnyStringPropType<'text' | 'password'>, default: 'text' },
   inputClass: { type: String, default: '' },
   pattern: { type: String },

--- a/packages/ui/src/components/va-input/hooks/useCleave.ts
+++ b/packages/ui/src/components/va-input/hooks/useCleave.ts
@@ -29,7 +29,7 @@ export const useCleaveProps = {
 export const useCleave = (
   element: Ref<HTMLInputElement | undefined>,
   props: ExtractPropTypes<typeof useCleaveProps>,
-  syncValue: WritableComputedRef<string | number>,
+  syncValue: WritableComputedRef<string | number | null>,
 ) => {
   const cleave = ref<Cleave>()
 
@@ -78,7 +78,7 @@ export const useCleave = (
       }
     }
 
-    return syncValue.value
+    return syncValue.value || ''
   })
 
   const onInput = (event: Event) => {

--- a/packages/ui/src/components/va-input/hooks/useCleave.ts
+++ b/packages/ui/src/components/va-input/hooks/useCleave.ts
@@ -78,7 +78,7 @@ export const useCleave = (
       }
     }
 
-    return syncValue.value || ''
+    return syncValue.value ?? ''
   })
 
   const onInput = (event: Event) => {


### PR DESCRIPTION
Closes #3859

## Description
Allows to pass null as value to `VaInput` `modelValue` with no TS errors.
PR also includes small tweak of `useCleave` composable

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
