### PR TITLE
fix(avatar): object fit to properly handle non-squared images

### DIFF
--- a/packages/ui/src/components/va-avatar/VaAvatar.vue
+++ b/packages/ui/src/components/va-avatar/VaAvatar.vue
@@ -142,6 +142,7 @@ defineExpose({
 
   img,
   svg {
+    object-fit: var(--va-avatar-object-fit);
     border-radius: inherit;
     display: inline-flex;
     height: inherit;

--- a/packages/ui/src/components/va-avatar/_variables.scss
+++ b/packages/ui/src/components/va-avatar/_variables.scss
@@ -9,4 +9,5 @@
   --va-avatar-position: relative;
   --va-avatar-line-height: normal;
   --va-avatar-border-radius: 50%;
+  --va-avatar-object-fit: cover;
 }


### PR DESCRIPTION
Closes #4232

## Description
Fixes `VaAvatar` image stretching by customizable css variable for `object-fit`

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
