### PR TITLE
fix(VaCard): Ability to customize `outlined border` colour

### DIFF
--- a/packages/ui/src/components/va-card/_variables.scss
+++ b/packages/ui/src/components/va-card/_variables.scss
@@ -10,7 +10,7 @@
   --va-card-padding: 1.25rem;
 
   /* Outlined */
-  --va-card-outlined-border: 3px solid var(--va-background-element);
+  --va-card-outlined-border: 3px solid var(--va-background-border);
   --va-card-outlined-box-shadow: none;
 
   /* Stripe */

--- a/packages/ui/src/styles/global/css-variables.scss
+++ b/packages/ui/src/styles/global/css-variables.scss
@@ -7,7 +7,7 @@
 
   /* Primary block-type items styles */
   --va-block-border-radius: 0.375rem;
-  --va-block-border: thin solid rgba(52, 56, 85, 0.25);
+  --va-block-border: thin solid var(--va-background-element);
   --va-block-box-shadow: 0 2px 3px 0 rgba(52, 56, 85, 0.25);
 
   /* Primary control-type items styles */


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

closes https://github.com/epicmaxco/vuestic-ui/issues/4308

## Description
<!-- Describe your changes in detail -->

1. In Va Card Component
CSS Variable used for Card Outlined Border has been updated from `va-background-element` to `va-background-border`
2.  Apply color schemes variable to define `--va-block-color`


## Markup:
<!-- Paste your markup here. -->
<details>

```TS
// Sample Colors Configuration
createVuesticEssential({
  config: {
    colors: {
      presets: {
        dark: {
          backgroundBorder: "ffffff",
        },
      },
    },
  },
});
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
