### PR TITLE
Change Button docs to say `text-color` instead of `description-color`

### DIFF
--- a/packages/docs/page-config/ui-elements/button/index.ts
+++ b/packages/docs/page-config/ui-elements/button/index.ts
@@ -27,7 +27,7 @@ export default definePageConfig({
     }),
     block.example("WithTextColor", {
       title: "Text colors",
-      description: "The `description-color` prop is used to change the color of the button description."
+      description: "The `text-color` prop is used to change the color of the button description."
     }),
     block.example("WithSize", {
       title: "Sizes",


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description

The Button docs currently say `description-color` is used to change the text color. But that doesn't work, and the example instead uses the (seemingly correct) `text-color` prop.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
