### PR TITLE
fix: augment `vue` rather than `@vue/runtime-core`

### DIFF
--- a/packages/ui/src/components/va-dropdown/plugin/index.ts
+++ b/packages/ui/src/components/va-dropdown/plugin/index.ts
@@ -21,7 +21,7 @@ export const VaDropdownPlugin = defineVuesticPlugin(() => ({
   },
 }))
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     $vaDropdown: typeof vaDropdownPlugin
 

--- a/packages/ui/src/components/va-modal/plugin/index.ts
+++ b/packages/ui/src/components/va-modal/plugin/index.ts
@@ -44,7 +44,7 @@ export const VaModalPlugin = defineVuesticPlugin(() => ({
   },
 }))
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     $vaModal: ReturnType<typeof createVaModalPlugin>
   }

--- a/packages/ui/src/components/va-toast/plugin/index.ts
+++ b/packages/ui/src/components/va-toast/plugin/index.ts
@@ -24,7 +24,7 @@ export const VaToastPlugin = defineVuesticPlugin(() => ({
   },
 }))
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     $vaToast: ReturnType<typeof createVaToastPlugin>
   }

--- a/packages/ui/src/services/breakpoint/plugin/index.ts
+++ b/packages/ui/src/services/breakpoint/plugin/index.ts
@@ -11,7 +11,7 @@ export const BreakpointConfigPlugin = defineVuesticPlugin(() => ({
   },
 }))
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     $vaBreakpoint: ReturnType<typeof createBreakpointConfigPlugin>
   }

--- a/packages/ui/src/services/color/plugin/index.ts
+++ b/packages/ui/src/services/color/plugin/index.ts
@@ -9,7 +9,7 @@ export const ColorConfigPlugin = defineVuesticPlugin((config?: PartialGlobalConf
   },
 }))
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     $vaColorConfig: ReturnType<typeof createColorConfigPlugin>
   }

--- a/packages/ui/src/services/colors-classes/plugin/index.ts
+++ b/packages/ui/src/services/colors-classes/plugin/index.ts
@@ -71,7 +71,7 @@ export const ColorsClassesPlugin = defineVuesticPlugin(() => ({
   },
 }))
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     $vaColorsClasses: ReturnType<typeof createColorHelpersPlugin>
   }

--- a/packages/ui/src/services/global-config/plugin/index.ts
+++ b/packages/ui/src/services/global-config/plugin/index.ts
@@ -21,7 +21,7 @@ export const GlobalConfigPlugin = defineVuesticPlugin((config: PartialGlobalConf
   },
 }))
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     $vaConfig: ReturnType<typeof createGlobalConfig>
   }

--- a/packages/ui/src/services/vue-plugin/create-vuestic/create-vuestic.ts
+++ b/packages/ui/src/services/vue-plugin/create-vuestic/create-vuestic.ts
@@ -7,7 +7,7 @@ import { setCurrentApp } from '../../current-app'
 import { ColorsClassesPlugin } from '../../colors-classes'
 
 // Declare all components globally
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
   export interface GlobalComponents extends VuesticComponents {}
 }

--- a/packages/ui/src/services/vue-plugin/types/components.ts
+++ b/packages/ui/src/services/vue-plugin/types/components.ts
@@ -16,7 +16,7 @@ export type VuesticComponentName = keyof VuesticComponentsMap
  * @example
  * This will register all vuestic components globally:
  * ```
- * declare module '@vue/runtime-core' {
+ * declare module 'vue' {
  *   export interface GlobalComponents extends VuesticComponents {}
  * }
  * ```
@@ -24,7 +24,7 @@ export type VuesticComponentName = keyof VuesticComponentsMap
  * @example
  * If you using tree-shaking and want to register only specific components:
  * ```
- * declare module '@vue/runtime-core' {
+ * declare module 'vue' {
  *   export interface GlobalComponents extends VuesticComponents<'VaButton' | 'VaInput'> {}
  * }
  * ```

--- a/packages/ui/src/services/vue-plugin/utils/global-properties.ts
+++ b/packages/ui/src/services/vue-plugin/utils/global-properties.ts
@@ -7,7 +7,7 @@ export const extractGlobalProperties = (app: App | AppContext) => app.config.glo
  * Type safe set vue global property
  * Declare type before use this method.
  * ```
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     $vaThing: ThingType
   }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail -->

In line with https://github.com/vuejs/router/pull/2295 and https://github.com/nuxt/nuxt/pull/28542, this moves to augment `vue` rather than `@vue/runtime` core.

This is now officially recommended [in the docs](https://vuejs.org/api/utility-types.html#componentcustomproperties) and it _must_ be done by all libraries or it will break types for _other_ libraries.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
