### PR TITLE
chore: improve select option render time

### DIFF
--- a/packages/ui/src/components/va-select/components/VaSelectOption/VaSelectOption.vue
+++ b/packages/ui/src/components/va-select/components/VaSelectOption/VaSelectOption.vue
@@ -23,7 +23,7 @@
       {{ optionTextSplitted.end }}
     </slot>
     <va-icon
-      v-show="isSelected"
+      v-if="isSelected"
       class="va-select-option__selected-icon"
       size="small"
       name="va-check"


### PR DESCRIPTION
## Description
Opening `<VaSelect>` with hundreds of items (tested 250) takes seconds to open when you click it.

## Testing
For testing I used this code
<details>

```vue
<script setup lang="ts">
import { ref } from 'vue';
import VSelect from 'vue-select';
import 'vue-select/dist/vue-select.css';

const model = ref(null);
const model2 = ref(null);
const model3 = ref(null);
const testData = [...Array(250)].map((_, i) => `Item ${i}`);
</script>

<template>
    <VaSelect
        v-model="model"
        label="test native"
        :options="testData"
        clearable
        searchable
        :highlight-matched-text="false"
    />

    <hr class="my-4">

    <VaSelect
        v-model="model2"
        label="test custom"
        :options="testData"
        clearable
        searchable
        :highlight-matched-text="false"
    >
        <template #option="slotData">
            <div
                role="option"
                class="va-select-option"
                @click.prevent="slotData.selectOption(slotData.option)"
            >
                {{ slotData.option }}
                <va-icon
                    v-if="model2 === slotData.option"
                    class="va-select-option__selected-icon"
                    size="small"
                    name="va-check"
                />
            </div>
        </template>
    </VaSelect>

    <hr class="my-4">

    <VSelect
        v-model="model3"
        label="test vue-select"
        :options="testData"
    />
</template>
```
</details>

As you can see there are 3 selects all rendering same 250 items.
First one renders native VaSelect.
Second render VaSelect with overrided #option slot to render option with simple component.
Third is compare with vue-select component.

Here is timeline from vue devtools for opening all of this selects:
![image](https://github.com/user-attachments/assets/85b2092c-ab74-43bc-a686-196fae067708)
Times:
1. opening first, yellow in screenshot = 1556ms
1. opening second, blue in screenshot = 157ms
1. opening vue-select, red in screenshot = 0.2ms

From this testing it looks like component `<VueSelectOption>` takes much time to render.

From my first quick look, selected icon is rendering always (hidden) so I tried only skip rendering selected icon when not needed and rendering it goes down to 798ms (-48.2%).

This change is in this pull request.
This is better but it is still a lot of time to open select. For me 250 items is not a lot of items to render and vue-select can open it under 1ms.
So this is only 1st step, but it needs better refactor for rendering selects options. For example prerender options, so it do not need to building all options on opening. Or optimize VueSelectOption to have better render time (closer to 157ms from second second test option) but I am afraid it will not be good with more options.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
