### PR TITLE
feat(input): add native autocomplete attribute support

### DIFF
--- a/packages/ui/src/components/va-input/VaInput.vue
+++ b/packages/ui/src/components/va-input/VaInput.vue
@@ -110,6 +110,7 @@ const props = defineProps({
   pattern: { type: String },
   inputmode: { type: String, default: 'text' },
   counter: { type: Boolean, default: false },
+  autocomplete: { type: String },
 
     // style
   ariaResetLabel: useTranslationProp('$t:reset'),
@@ -227,7 +228,7 @@ const computedChildAttributes = computed(() => (({
 
 const computedInputAttributes = computed(() => (({
   ...computedChildAttributes.value,
-  ...pick(props, ['type', 'disabled', 'readonly', 'placeholder', 'pattern', 'inputmode', 'name']),
+  ...pick(props, ['type', 'disabled', 'readonly', 'placeholder', 'pattern', 'inputmode', 'name', 'autocomplete']),
   ...pick(attrs, ['minlength', 'minlength']),
 }) as InputHTMLAttributes))
 


### PR DESCRIPTION
## Description
Add support for native `<input autocomplete=...>` attribute. [Docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete).
This attribute is very necessary to handle autofilling forms (like login/register/address/...)

## Markup:
<!-- Paste your markup here. -->
<details>

```vue
<VaInput
    v-model="form.username"
    :label="t('username')"
    required
    autofocus
    autocomplete="username"
/>

<VaInput
    v-model="form.password"
    type="password"
    :label="t('password')"
    required
    autocomplete="current-password"
/>
```
</details>

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
