### PR TITLE
feat(VaToast #4373): add bottom-center, top-center position options

### DIFF
--- a/packages/docs/page-config/ui-elements/toast/examples/Position.vue
+++ b/packages/docs/page-config/ui-elements/toast/examples/Position.vue
@@ -7,6 +7,12 @@
   </VaButton>
   <VaButton
     class="mr-2 mb-2"
+    @click="$vaToast.init({ message: 'Top-center', position: 'top-center' })"
+  >
+    top-center
+  </VaButton>
+  <VaButton
+    class="mr-2 mb-2"
     @click="$vaToast.init({ message: 'Top-left', position: 'top-left' })"
   >
     top-left
@@ -18,6 +24,14 @@
     "
   >
     bottom-right
+  </VaButton>
+  <VaButton
+    class="mr-2 mb-2"
+    @click="
+      $vaToast.init({ message: 'Bottom-center', position: 'bottom-center' })
+    "
+  >
+    bottom-center
   </VaButton>
   <VaButton
     class="mr-2 mb-2"

--- a/packages/docs/page-config/ui-elements/toast/index.ts
+++ b/packages/docs/page-config/ui-elements/toast/index.ts
@@ -79,7 +79,7 @@ export default definePageConfig({
     }),
     block.example("Position", {
       title: "Position",
-      description: "Use `position` property to set the custom position of the toast. Available are `top-right`, `top-left`, `bottom-right`, `bottom-left`."
+      description: "Use `position` property to set the custom position of the toast. Available are `top-right`, `top-center`, `top-left`, `bottom-right`,  `bottom-center`, `bottom-left`."
     }),
     block.example("Close", {
       title: "Close",

--- a/packages/ui/.stylelintrc.js
+++ b/packages/ui/.stylelintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     'value-list-max-empty-lines': 1,
     'function-calc-no-unspaced-operator': null,
     'value-keyword-case': null,
+    'length-zero-no-unit': null,
     'selector-pseudo-class-no-unknown': [
       true,
       {

--- a/packages/ui/src/components/va-toast/VaToast.stories.ts
+++ b/packages/ui/src/components/va-toast/VaToast.stories.ts
@@ -32,7 +32,35 @@ export const Color: StoryFn = () => ({
 `,
 })
 
-export const PositionTopenter: StoryFn = () => ({
+export const PositionBottomLeft: StoryFn = () => ({
+  components: { VaToast: VaToast },
+
+  setup () {
+    const { notify } = useToast()
+
+    return {
+      notify,
+    }
+  },
+
+  template: '<button @click="notify({ message: \'Test\', position: \'bottom-left\' })">Show</button>',
+})
+
+export const PositionTopLeft: StoryFn = () => ({
+  components: { VaToast: VaToast },
+
+  setup () {
+    const { notify } = useToast()
+
+    return {
+      notify,
+    }
+  },
+
+  template: '<button @click="notify({ message: \'Test\', position: \'top-left\' })">Show</button>',
+})
+
+export const PositionTopCenter: StoryFn = () => ({
   components: { VaToast: VaToast },
 
   setup () {

--- a/packages/ui/src/components/va-toast/VaToast.vue
+++ b/packages/ui/src/components/va-toast/VaToast.vue
@@ -86,7 +86,7 @@ const props = defineProps({
   position: {
     type: String as PropType<ToastPosition>,
     default: 'top-right',
-    validator: (value: string) => ['top-right', 'top-left', 'bottom-right', 'bottom-left'].includes(value),
+    validator: (value: string) => ['top-right', 'top-center', 'top-left', 'bottom-right', 'bottom-center', 'bottom-left'].includes(value),
   },
   render: { type: Function },
   ariaCloseLabel: useTranslationProp('$t:close'),
@@ -123,7 +123,7 @@ const toastClasses = computed(() => [
 
 const toastStyles = computed(() => ({
   [positionY.value]: `${offsetYComputed.value}px`,
-  [positionX.value]: `${offsetXComputed.value}px`,
+  [positionX.value]: `calc(${props.position.includes('center') ? '50%' : '0px'} + ${offsetXComputed.value}px)`,
   backgroundColor: getColor(props.color),
   color: textColorComputed.value,
 }))
@@ -257,6 +257,11 @@ onMounted(() => {
     &:hover {
       opacity: 1;
     }
+  }
+
+  &.center {
+    left: 50%;
+    transform: translateX(-50%);
   }
 }
 

--- a/packages/ui/src/components/va-toast/VaToast.vue
+++ b/packages/ui/src/components/va-toast/VaToast.vue
@@ -47,6 +47,7 @@ import { PropType, ref, computed, onMounted, shallowRef, defineComponent, Comput
 import { useComponentPresetProp, useColors, useTimer, useTextColor, useTranslation, useTranslationProp, useNumericProp } from '../../composables'
 
 import { ToastPosition } from './types'
+import { useToastService } from './hooks/useToastService'
 
 import { StringWithAutocomplete } from '../../utils/types/prop-type'
 </script>
@@ -107,20 +108,22 @@ const durationComputed = useNumericProp('duration') as ComputedRef<number>
 
 const visible = ref(false)
 
+const yOffset = useToastService(props)
+
 const getPositionStyle = () => {
   const vertical = props.position.includes('top') ? 'top' : 'bottom'
   const horizontal = props.position.includes('center') ? 'center' : props.position.includes('right') ? 'right' : 'left'
 
   if (horizontal === 'center') {
     return {
-      [vertical]: `${offsetYComputed.value}px`,
+      [vertical]: `${offsetYComputed.value + yOffset.value}px`,
       left: '50%',
       transform: 'translateX(-50%)',
     }
   }
 
   return {
-    [vertical]: `${offsetYComputed.value}px`,
+    [vertical]: `${offsetYComputed.value + yOffset.value}px`,
     [horizontal]: `${offsetXComputed.value}px`,
   }
 }
@@ -214,14 +217,6 @@ onMounted(() => {
 
   &--multiline {
     min-height: 70px;
-  }
-
-  &--right {
-    right: 16px;
-  }
-
-  &--left {
-    left: 16px;
   }
 
   &__group {

--- a/packages/ui/src/components/va-toast/VaToast.vue
+++ b/packages/ui/src/components/va-toast/VaToast.vue
@@ -219,11 +219,6 @@ onMounted(() => {
     min-height: 70px;
   }
 
-  &__group {
-    margin-left: var(--va-toast-group-margin-left);
-    margin-right: var(--va-toast-group-margin-right);
-  }
-
   &__title {
     font-weight: var(--va-toast-title-font-weight);
     font-size: var(--va-toast-title-font-size);

--- a/packages/ui/src/components/va-toast/VaToast.vue
+++ b/packages/ui/src/components/va-toast/VaToast.vue
@@ -257,11 +257,6 @@ onMounted(() => {
       opacity: 1;
     }
   }
-
-  &.center {
-    left: 50%;
-    transform: translateX(-50%);
-  }
 }
 
 .va-toast-fade-enter {

--- a/packages/ui/src/components/va-toast/_variables.scss
+++ b/packages/ui/src/components/va-toast/_variables.scss
@@ -2,7 +2,7 @@
 :host {
   --va-toast-display: flex;
   --va-toast-width: 330px;
-  --va-toast-padding: 14px 26px 14px 13px;
+  --va-toast-padding: 14px 1.25rem 14px 1.25rem;
   --va-toast-border-radius: 8px;
   --va-toast-border-color: transparent;
   --va-toast-border: 1px solid var(--va-toast-border-color);
@@ -10,10 +10,6 @@
   --va-toast-box-shadow: 0 2px 12px 0 var(--va-shadow);
   --va-toast-transition: opacity 0.3s, transform 0.3s, left 0.3s, right 0.3s, top 0.4s, bottom 0.3s;
   --va-toast-z-index: calc(var(--va-z-index-teleport-overlay) + 100);
-
-  /* Group */
-  --va-toast-group-margin-left: 13px;
-  --va-toast-group-margin-right: 8px;
 
   /* Title */
   --va-toast-title-font-weight: bold;

--- a/packages/ui/src/components/va-toast/hooks/useToastService.ts
+++ b/packages/ui/src/components/va-toast/hooks/useToastService.ts
@@ -1,0 +1,56 @@
+import { computed, getCurrentInstance, onBeforeUnmount, onMounted, Ref, ref, VNode } from 'vue'
+import { ToastOptions } from '../types'
+
+const GAP = 5
+
+// Expect as client-side used only
+const toastInstances = ref([]) as Ref<VNode[]>
+
+type OptionKeys = keyof ToastOptions;
+
+const getNodeProps = (vNode: VNode): Record<OptionKeys, any> => {
+  return (vNode.component?.props as Record<OptionKeys, any>) || {}
+}
+
+const getTranslateValue = (item: VNode) => {
+  if (item.el) {
+    return (item.el.offsetHeight + GAP)
+  }
+  return 0
+}
+
+export const useToastService = (props: {
+  position: NonNullable<ToastOptions['position']>,
+}) => {
+  const currentInstance = getCurrentInstance()!
+
+  const yOffset = computed(() => {
+    const currentIndex = toastInstances.value.findIndex((instance) => instance === currentInstance.vnode)
+
+    if (currentIndex === -1) { return 0 }
+
+    return toastInstances.value.slice(currentIndex + 1).reduce((acc, instance) => {
+      const {
+        position: itemPosition,
+      } = getNodeProps(instance)
+
+      const { position } = props
+
+      if (position === itemPosition) {
+        return getTranslateValue(instance) + acc
+      }
+
+      return acc
+    }, 0)
+  })
+
+  onMounted(() => {
+    toastInstances.value.unshift(currentInstance.vnode)
+  })
+
+  onBeforeUnmount(() => {
+    toastInstances.value = toastInstances.value.filter((item) => item !== currentInstance.vnode)
+  })
+
+  return yOffset
+}

--- a/packages/ui/src/components/va-toast/hooks/useToastService.ts
+++ b/packages/ui/src/components/va-toast/hooks/useToastService.ts
@@ -52,5 +52,10 @@ export const useToastService = (props: {
     toastInstances.value = toastInstances.value.filter((item) => item !== currentInstance.vnode)
   })
 
-  return yOffset
+  return {
+    yOffset,
+    updateYOffset: () => {
+      toastInstances.value = toastInstances.value.filter((item) => item !== currentInstance.vnode)
+    },
+  }
 }

--- a/packages/ui/src/components/va-toast/toast.ts
+++ b/packages/ui/src/components/va-toast/toast.ts
@@ -81,7 +81,7 @@ const mount = (component: any, {
     }
   }
 
-  vNode = createVNode(component, { ...props, onClose, ...(props?.position?.includes('center') && { class: 'center' }) }, children)
+  vNode = createVNode(component, { ...props, onClose }, children)
 
   if (appContext) {
     vNode.appContext = appContext

--- a/packages/ui/src/components/va-toast/toast.ts
+++ b/packages/ui/src/components/va-toast/toast.ts
@@ -8,7 +8,6 @@ import { withConfigTransport } from '../../services/config-transport'
 
 export const VaToast = withConfigTransport(_VaToast)
 
-const GAP = 5
 let seed = 1
 
 declare global {
@@ -22,19 +21,6 @@ getGlobal().vaToastInstances = []
 type OptionKeys = keyof ToastOptions;
 
 export type VaToastId = string
-
-const getTranslateValue = (item: VNode, position: string) => {
-  if (item.el) {
-    const direction = position.includes('bottom') ? -1 : 1
-    return (item.el.offsetHeight + GAP) * direction
-  }
-  return 0
-}
-
-const getNewTranslateValue = (transformY: string, redundantHeight: number, position: string) => {
-  const direction = position.includes('bottom') ? -1 : 1
-  return parseInt(transformY, 10) - (redundantHeight + GAP) * direction
-}
 
 const getNodeProps = (vNode: VNode): Record<OptionKeys, any> => {
   return (vNode.component?.props as Record<OptionKeys, any>) || {}
@@ -52,31 +38,13 @@ const closeNotification = (targetInstance: VNode | null, destroyElementFn: () =>
 
   if (targetInstanceIndex < 0) { return }
 
-  const nodeProps = getNodeProps(targetInstance)
-
-  const {
-    offsetX: targetOffsetX,
-    offsetY: targetOffsetY,
-    position: targetPosition,
-  } = nodeProps
-  const redundantHeight: number | null = targetInstance.el?.offsetHeight
-
   destroyElementFn()
 
   getGlobal().vaToastInstances = getGlobal().vaToastInstances.reduce((acc: any[], instance, index) => {
     if (instance === targetInstance) {
       return acc
     }
-    if (instance.component) {
-      const { offsetX, offsetY, position } = getNodeProps(instance)
-      const isNextInstance = index > targetInstanceIndex && targetOffsetX === offsetX && targetOffsetY === offsetY && targetPosition === position
-      if (isNextInstance && instance.el && redundantHeight) {
-        const [_, transformY] = instance.el.style.transform.match(/[\d-]+(?=px|%)/g)
-        const transformYNew = getNewTranslateValue(transformY, redundantHeight, position)
-        const transformX = position.includes('center') ? '-50%' : '0'
-        instance.el.style.transform = `translate(${transformX}, ${transformYNew}px)`
-      }
-    }
+
     return [...acc, instance]
   }, [])
 
@@ -164,25 +132,8 @@ export const createToastInstance = (customProps: ToastOptions | string, appConte
 
   if (el && vNode.el && nodeProps) {
     document.body.appendChild(el.childNodes[0])
-    const { offsetX, offsetY, position } = nodeProps
 
-    vNode.el.style.display = 'flex'
     vNode.el.id = 'notification_' + seed
-
-    let transformY = 0
-    getGlobal().vaToastInstances.filter(item => {
-      const {
-        offsetX: itemOffsetX,
-        offsetY: itemOffsetY,
-        position: itemPosition,
-      } = getNodeProps(item)
-
-      return itemOffsetX === offsetX && itemOffsetY === offsetY && position === itemPosition
-    }).forEach((item) => {
-      transformY += getTranslateValue(item, position)
-    })
-    const transformX = position.includes('center') ? '-50%' : '0'
-    vNode.el.style.transform = `translate(${transformX}, ${transformY}px)`
 
     seed += 1
 

--- a/packages/ui/src/components/va-toast/toast.ts
+++ b/packages/ui/src/components/va-toast/toast.ts
@@ -71,9 +71,10 @@ const closeNotification = (targetInstance: VNode | null, destroyElementFn: () =>
       const { offsetX, offsetY, position } = getNodeProps(instance)
       const isNextInstance = index > targetInstanceIndex && targetOffsetX === offsetX && targetOffsetY === offsetY && targetPosition === position
       if (isNextInstance && instance.el && redundantHeight) {
-        const [_, transformY] = instance.el.style.transform.match(/[\d-]+(?=px)/g)
+        const [_, transformY] = instance.el.style.transform.match(/[\d-]+(?=px|%)/g)
         const transformYNew = getNewTranslateValue(transformY, redundantHeight, position)
-        instance.el.style.transform = `translate(0, ${transformYNew}px)`
+        const transformX = position.includes('center') ? '-50%' : '0'
+        instance.el.style.transform = `translate(${transformX}, ${transformYNew}px)`
       }
     }
     return [...acc, instance]
@@ -112,7 +113,7 @@ const mount = (component: any, {
     }
   }
 
-  vNode = createVNode(component, { ...props, onClose }, children)
+  vNode = createVNode(component, { ...props, onClose, ...(props?.position?.includes('center') && { class: 'center' }) }, children)
 
   if (appContext) {
     vNode.appContext = appContext
@@ -180,7 +181,8 @@ export const createToastInstance = (customProps: ToastOptions | string, appConte
     }).forEach((item) => {
       transformY += getTranslateValue(item, position)
     })
-    vNode.el.style.transform = `translate(0, ${transformY}px)`
+    const transformX = position.includes('center') ? '-50%' : '0'
+    vNode.el.style.transform = `translate(${transformX}, ${transformY}px)`
 
     seed += 1
 

--- a/packages/ui/src/components/va-toast/types.ts
+++ b/packages/ui/src/components/va-toast/types.ts
@@ -2,8 +2,10 @@ import { VNode } from 'vue'
 
 export type ToastPosition =
   'top-right'
+  | 'top-center'
   | 'top-left'
   | 'bottom-right'
+  | 'bottom-center'
   | 'bottom-left'
 
 export interface ToastOptions {

--- a/packages/ui/src/components/va-toast/types.ts
+++ b/packages/ui/src/components/va-toast/types.ts
@@ -7,8 +7,6 @@ export type ToastPosition =
   | 'bottom-right'
   | 'bottom-center'
   | 'bottom-left'
-  | 'top-center'
-  | 'bottom-center'
 
 export interface ToastOptions {
   /** Title */


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->
Add bottom-center, top-center position options to VaToast
<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail -->
Two new position options have been added to Vatoast: 'top-center' and 'bottom-center'.

closes https://github.com/epicmaxco/vuestic-ui/issues/4373

'top-center': Displays the toast at the top center of the screen.
'bottom-center': Displays the toast at the bottom center of the screen.
The Y-axis shift overlay and fade-out animation when the toast appears have been taken into account.

In order to handle the relationship of the animation starting point, it was necessary to add the 'center' class to the toast for these two options.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
