### PR TITLE
fix(VaFormField): fix not working errorCount prop

### DIFF
--- a/packages/ui/src/components/va-form-field/VaFormField.vue
+++ b/packages/ui/src/components/va-form-field/VaFormField.vue
@@ -3,6 +3,7 @@
     :model-value="messagesComputed"
     :has-error="!isValid"
     :color="messagesColor"
+    :limit="errorLimit"
   >
     <template v-for="name in ['message', 'messages']" :key="name" v-slot:[name]="slotScope">
       <slot :name="name" v-bind="slotScope" />
@@ -84,6 +85,8 @@ const messagesColor = computed(() => {
 
   return ''
 })
+
+const errorLimit = computed(() => props.error ? Number(props.errorCount) : 99)
 
 const innerValue = ref(valueComputed.value)
 


### PR DESCRIPTION
## Description
Property `errorCount` is not working in `<VaFormField>`. It always shows only 1 error message.

## Markup:
<details>

```vue
<VaFormField
    dirty
    error
    :error-count="2"
    :error-messages="['error 1', 'error 2']"
>
    example field
</VaFormField>
```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
