### PR TITLE
fix(#4394): correct button dropdown teleport when split is used

### DIFF
--- a/packages/ui/src/components/va-button-dropdown/VaButtonDropdown.vue
+++ b/packages/ui/src/components/va-button-dropdown/VaButtonDropdown.vue
@@ -44,7 +44,6 @@
         v-bind="vaDropdownProps"
         v-model="valueComputed"
         :disabled="$props.disabled || $props.disableDropdown"
-        :teleport="$el"
       >
         <template #anchor>
           <va-button


### PR DESCRIPTION
closes #4394 