### PR TITLE
fix(docs): Fix missing modal size auto

### DIFF
--- a/packages/docs/page-config/ui-elements/confirm/api-description.ts
+++ b/packages/docs/page-config/ui-elements/confirm/api-description.ts
@@ -6,7 +6,7 @@ export default defineApiDescription({
     message: "Content of modal body",
     attachElement: "A valid selector of element, where modal will be rendered",
     disableAttachment: "Ignore `attach-element` prop and render component as it's parent child",
-    size: "Set the size of the modal's width. `\"small\"`, `\"medium\"` (default) or `\"large\"`",
+    size: "Set the size of the modal's width. `\"auto\"`, `\"small\"`, `\"medium\"` (default) or `\"large\"`",
     okText: "Text string to place in the default footer **Ok** button",
     cancelText: "Text string to place in the default footer **Cancel** button",
     hideDefaultActions: "Use `hide-default-actions: true` to hide **Cancel** and **Ok** buttons",

--- a/packages/docs/page-config/ui-elements/modal/api-description.ts
+++ b/packages/docs/page-config/ui-elements/modal/api-description.ts
@@ -6,7 +6,7 @@ export default defineApiDescription({
     message: "Content of modal body",
     attachElement: "A valid selector of element, where modal will be rendered",
     disableAttachment: "Ignore `attach-element` prop and render component as it's parent child",
-    size: "Set the size of the modal's width. `\"small\"`, `\"medium\"` (default) or `\"large\"`",
+    size: "Set the size of the modal's width. `\"auto\"`, `\"small\"`, `\"medium\"` (default) or `\"large\"`",
     okText: "Text string to place in the default footer **Ok** button",
     cancelText: "Text string to place in the default footer **Cancel** button",
     hideDefaultActions: "Use `hide-default-actions: true` to hide **Cancel** and **Ok** buttons",

--- a/packages/docs/page-config/ui-elements/modal/examples/ModalSizing.vue
+++ b/packages/docs/page-config/ui-elements/modal/examples/ModalSizing.vue
@@ -3,7 +3,7 @@
     class="mr-6 my-1"
     @click="showModalSizeAuto = !showModalSizeAuto"
   >
-    Show modal size small
+    Show modal size auto
   </VaButton>
 
   <VaButton

--- a/packages/docs/page-config/ui-elements/modal/index.ts
+++ b/packages/docs/page-config/ui-elements/modal/index.ts
@@ -69,7 +69,7 @@ export default definePageConfig({
     }),
     block.example("ModalSizing", {
       title: "Modal sizing",
-      description: "Modals have three optional sizes, available via the prop `size`. These sizes kick in at certain breakpoints to avoid horizontal scrollbars on narrower viewports. Valid optional sizes are `small`, `medium` (default), and `large`."
+      description: "Modals have three optional sizes, available via the prop `size`. These sizes kick in at certain breakpoints to avoid horizontal scrollbars on narrower viewports. Valid optional sizes are `auto`, `small`, `medium` (default), and `large`."
     }),
 
     block.example("NestedModals", {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-ui/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
I notice the size `auto` is available for `modal`and `confirm` components (based on the default value of `sizesConfig`). But it's not documented. So I added it to the size list. Also I fix the size in a modal's example, where it was `small`, but it should be `auto`

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
