### PR TITLE
fix: correct even in useFocusableControl

### DIFF
--- a/packages/ui/src/components/va-input/VaInput.vue
+++ b/packages/ui/src/components/va-input/VaInput.vue
@@ -69,13 +69,12 @@ import type { AnyStringPropType } from '../../utils/types/prop-type'
 import { VaInputWrapper } from '../va-input-wrapper'
 import { VaIcon } from '../va-icon'
 import { combineFunctions } from '../../utils/combine-functions'
-import { omit } from '../../utils/omit'
 import { pick } from '../../utils/pick'
 
 const VaInputWrapperProps = extractComponentProps(VaInputWrapper)
 
 const { createEmits: createInputEmits, createListeners: createInputListeners } = useEmitProxy(
-  ['change', 'keyup', 'keypress', 'keydown', 'focus', 'blur', 'input'],
+  ['change', 'keyup', 'keypress', 'keydown', 'input'],
 )
 
 const { createEmits: createFieldEmits, createListeners: createFieldListeners } = useEmitProxy([
@@ -178,7 +177,7 @@ const inputListeners = createInputListeners(emit)
 
 const inputEvents = {
   ...inputListeners,
-  onBlur: combineFunctions(onBlur, inputListeners.onBlur),
+  onBlur,
 }
 
 const setInputValue = (newValue: string) => {

--- a/packages/ui/src/composables/fabrics/useFocusableControl.ts
+++ b/packages/ui/src/composables/fabrics/useFocusableControl.ts
@@ -15,9 +15,16 @@ export const useFocusableControl = (
     autofocus: boolean,
     disabled?: boolean,
   },
-  emit: (event: (typeof useFocusableControlEmits)[number]) => void,
+  emit: (event: (typeof useFocusableControlEmits)[number], e: FocusEvent) => void,
 ) => {
-  const isFocused = useElementFocused(el)
+  const isFocused = useElementFocused(el, {
+    onBlur (e) {
+      emit('blur', e)
+    },
+    onFocus (e) {
+      emit('focus', e)
+    },
+  })
 
   const focus = () => {
     if (props.disabled) { return }
@@ -34,14 +41,6 @@ export const useFocusableControl = (
   onMounted(() => {
     if (props.autofocus) {
       focus()
-    }
-  })
-
-  watch(isFocused, (value) => {
-    if (value) {
-      emit('focus')
-    } else {
-      emit('blur')
     }
   })
 

--- a/packages/ui/src/composables/std/browser/useElementFocused.ts
+++ b/packages/ui/src/composables/std/browser/useElementFocused.ts
@@ -4,15 +4,23 @@ import { focusElement, blurElement } from '../../../utils/focus'
 import { unwrapEl } from '../../../utils/unwrapEl'
 import { TemplateRef } from '../../../utils/types/template-ref'
 
-export const useElementFocused = (el: Ref<TemplateRef>) => {
+export const useElementFocused = (
+  el: Ref<TemplateRef>,
+  options: {
+    onFocus?: (e: FocusEvent) => void,
+    onBlur?: (e: FocusEvent) => void
+  } = {},
+) => {
   const isFocused = ref(false)
 
-  useEvent('focus', () => {
+  useEvent('focus', (e) => {
     isFocused.value = true
+    options.onFocus?.(e)
   }, el)
 
-  useEvent('blur', () => {
+  useEvent('blur', (e) => {
     isFocused.value = false
+    options.onBlur?.(e)
   }, el)
 
   return computed({


### PR DESCRIPTION
Fix double focus event.

https://develop.ui.vuestic.dev/play#eNqNlm9P2zAQxr+KlTcFiTZCvOtKxUAgdRPbNDbeLJMIqZsYHNuK7cBU+t13vvxtCEnpm/Tud+fHru8hW++zUrPcUm/uLXSUMWWIpsaqZSAIYamSmSFbktEN2ZFNJlMyAXgSCJeOpNCGpDom5444mkyOi4Tvk+ssk1kDSXEjI6sBPKL8mJwvMS45nXEZQ+iETEpkcvypXXbJbTZc5YiyCNa9s1FEtW63uOI0HOmBSGflK86i57EyQLAsMFXZSihrhssQ6a6WhCKmI8sh0ycTfkQq1geILcCPW6yEoKNntU/3NVvBtwO6OKyv/EdGD9xPSQ40OXRHbbzT7iv9t5YvIxsqofelKoP7OFqL1Ptiq0YrrercwN9qHRqKAzhUbBvs4wa3oCqM6aD+VqMK7214K9eUHyhrTj/U1bQ5XFzRblzdfcjt4BCW7dIaxl4Lv7BOME33WRiaKg4cmugiOSURD7U+D7w8nCangbfcbtE2d7uFn5wW1H2ItuCeCcmnuAJUABZ4EAyM+8wzy6lr9OcoR4H5jFMRm4QsyRl5eyMPN5ZvGOfEJNSpXzPDpHj4iz3g72LjPBYalG5bxx/BRTHs7LRekVwwJwoThbyKj5xjYhy9sxWHWSrj8NTE0buKBD7uV0xDNJSmsDCYXmjK3Ix2URzcDs/gBBrOuU0HgKnbX7Z0gX6su3DbMuqK58IHkCo9oZ3DOa+S+KWdtapKWVXH21cY09056CWry95bUSW7lc297pZhsINjqxbYJ2ZvuS7blYGXKnzkFP+Zw1ws/NYoBcI78YpXkmkaqtmTlgJeW7YODsoEtJoTjLgYvKpow6KpZS4ceIkxSs99f01zyqWaWeZefRwyg5Bf4dIaPw2ZgBUKZbtA7GBto+EGbVjcWTmSqWKcZt+Vm7V9BSHn8uULxkxm6UkVjxIaPffEn/RrIRXulqZZDkde50yYxRQm0KWv777RV3iuk/DLgTUMJn9S8DLrNBbYpRVrkN3iUO0KD5KJ+Je+fjVU6GpTTiieBvJ4ulcDW2/kns3O6lPc/QfLL4TF