### PR TITLE
Feat/va slider invert track

### DIFF
--- a/packages/docs/page-config/ui-elements/slider/examples/InvertedTrack.vue
+++ b/packages/docs/page-config/ui-elements/slider/examples/InvertedTrack.vue
@@ -1,0 +1,35 @@
+<template>
+  <div>
+    <VaSlider
+      v-model="value"
+      class="mr-8"
+      track-label-visible
+      invert-track
+      :track-label="'bigger than ' + value"
+    />
+
+  </div>
+    <div
+    class="flex flex-wrap justify-center h-48"
+  >
+
+    <VaSlider
+      v-model="value"
+      class="mr-8"
+      vertical
+      track-label-visible
+      invert-track
+      :track-label="'bigger than ' + value"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      value: 25
+    };
+  },
+};
+</script>

--- a/packages/docs/page-config/ui-elements/slider/index.ts
+++ b/packages/docs/page-config/ui-elements/slider/index.ts
@@ -1,5 +1,5 @@
-import apiOptions from "./api-options";
 import apiDescription from './api-description';
+import apiOptions from "./api-options";
 
 export default definePageConfig({
   blocks: [
@@ -61,6 +61,10 @@ export default definePageConfig({
     block.example("Vertical", {
       title: "Vertical",
       description: "Vertical state of slider."
+    }),
+    block.example("InvertedTrack", {
+      title: "Inverted",
+      description: "Inverted track fill."
     }),
 
     block.subtitle('Accessibility'),

--- a/packages/ui/src/components/va-slider/VaSlider.stories.ts
+++ b/packages/ui/src/components/va-slider/VaSlider.stories.ts
@@ -1,9 +1,9 @@
-import { getStoryId, getStoryIdAll, getStorySelector, getStorySelectorAll } from '../../../.storybook/interaction-utils/storySelector'
-import { userEvent } from '../../../.storybook/interaction-utils/userEvent'
+import { sleep } from '@/utils/sleep'
+import { expect } from '@storybook/jest'
 import { fireEvent } from '@storybook/testing-library'
 import { StoryFn } from '@storybook/vue3'
-import { expect } from '@storybook/jest'
-import { sleep } from '@/utils/sleep'
+import { getStoryId, getStoryIdAll, getStorySelector, getStorySelectorAll } from '../../../.storybook/interaction-utils/storySelector'
+import { userEvent } from '../../../.storybook/interaction-utils/userEvent'
 import { VaSlider } from './'
 
 function getSlider () {
@@ -678,3 +678,26 @@ Vertical.play = async ({ step }) => {
     expect(slider[2]).toHaveAttribute('aria-valuetext', '100')
   })
 }
+
+export const invertTrack: StoryFn = () => ({
+  components: { VaSlider },
+  data: () => ({ value: 25 }),
+  template: `
+    [default inverted]
+    <div>
+      <VaSlider v-model="value" track-label-visible invert-track :track-label="'bigger than ' + value" />
+    </div>
+    [vertical inverted]
+    <div style="height: 192px">
+      <VaSlider v-model="value" vertical track-label-visible invert-track :track-label="'bigger than ' + value" />
+    </div>
+     [default regular]
+     <div>
+      <VaSlider v-model="value" track-label-visible :track-label="'smaller than ' + value"/>
+    </div>
+    [vertical regular]
+    <div style="height: 192px">
+      <VaSlider v-model="value" vertical track-label-visible :track-label="'smaller than ' + value"/>
+    </div>
+  `,
+})

--- a/packages/ui/src/components/va-slider/VaSlider.vue
+++ b/packages/ui/src/components/va-slider/VaSlider.vue
@@ -229,6 +229,7 @@ const props = defineProps({
   iconAppend: { type: String, default: '' },
   vertical: { type: Boolean, default: false },
   showTrack: { type: Boolean, default: true },
+  invertTrack: { type: Boolean, default: false },
   ariaLabel: useTranslationProp('$t:sliderValue'),
   ariaLabelDot: useTranslationProp('$t:sliderDot'),
   ariaLabelMaxDot: useTranslationProp('$t:sliderMaxDot'),
@@ -267,6 +268,7 @@ const orders = computed(() => {
 
 const pinPositionStyle = computed(() => props.vertical ? 'bottom' : 'left')
 const trackSizeStyle = computed(() => props.vertical ? 'height' : 'width')
+const trackPositionStyle = computed(() => props.vertical ? props.invertTrack ? 'top' : 'bottom' : props.invertTrack ? 'right' : 'left')
 
 const moreToLess = computed(() => Array.isArray(val.value) && (val.value[1] - stepComputed.value) < val.value[0])
 
@@ -307,9 +309,11 @@ const processedStyles = computed(() => {
     } as CSSProperties
   } else {
     const val0 = calculatePercentage(val.value)
+    const trackSizeStyleValue = props.invertTrack ? 100 - val0 : val0
 
     return {
-      [trackSizeStyle.value]: `${val0 > 100 ? 100 : val0}%`,
+      [trackSizeStyle.value]: `${trackSizeStyleValue > 100 ? 100 : trackSizeStyleValue < 0 ? 0 : trackSizeStyleValue}%`,
+      [trackPositionStyle.value]: 0,
       backgroundColor: getColor(props.color),
       visibility: props.showTrack ? 'visible' : 'hidden',
     } as CSSProperties


### PR DESCRIPTION

Added props in VaSlider for having an inverted track colouring.

## Description
This change is useful for handling cases where the slider represents something from the value selected onward, like "greater than", while the classic slider track colouring handles cases like "less than".
It works in both vertical and normal sliders just by adding "invert-track" 
I've added a storybook and updated the docs, appending an example.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
